### PR TITLE
Enhance common role task flow: add quiet wrapper, summary/debug controls, and update documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ All notable changes to this project will be documented in this file.
   - Added safety hooks (`check-case-conflict`, `detect-private-key`).
   - Simplified ansible-lint trigger to YAML files only.
 - Updated root `README.md` pre-commit section and quick start instructions for accuracy.
+- `_common/tasks/task_flow.yml`:
+  - Added optional `_task_flow_debug` and `_task_flow_summary` outputs.
+  - Clean role-disable handling (skip role; no end_host/role errors).
+  - Added quiet summary/phase breadcrumbs per `task_flow_summary_mode`.
+- `_common/tasks/main.yml`: NEW quiet wrapper that emits a single success/fail line and delegates to task_flow; fixed include path to shared task_flow and suppresses success message on failures.
+- `_common/defaults/main.yml`: NEW defaults for summary/debug and `_role_enabled`.
+- `_common/vars/task_flow.yml`: Guard profile now runs `assert` + `validate`.
+- `base_bootstrap/tasks/main.yml`: Uses the quiet wrapper and passes `_role_enabled` via vars (no `when`).
 
 ### Removed
 - Removed root `ansible.cfg` (not required for this roles-only repository).

--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ This repository uses [pre-commit](https://pre-commit.com/) to enforce code quali
 
 ## Development
 - See `_common/README.md` for the shared task flow pattern.
+- `_common/README.md` also documents summary/debug output controls and the recommended
+  custom callback pattern for quiet role-level output in consuming repositories.
+- For a focused output/summary reference, see `docs/10-common-task-flow-output.md`.
 - Each role contains its own README with usage and variable documentation.
 - Test roles using the provided playbooks in your consuming project.
 

--- a/_common/README.md
+++ b/_common/README.md
@@ -2,20 +2,24 @@
 
 Shared “framework” files used by all roles.
 
-This folder provides a **task flow orchestrator** that standardizes how roles run their tasks in ordered phases (assert → install → config → validate), with:
+This folder provides a **task flow orchestrator + quiet wrapper** that standardizes how roles run ordered phases (assert → install → config → validate), with:
 
-- **Profiles** (categories) like `full`, `config`, `guard` (+ dev variants)
+- **Profiles** (full/config/guard + dev variants)
 - Per-role **enable/disable** switch
 - Consistent **tagging** for roles and phases
 - Friendly **fail-fast** checks (bad profile, bad phase override, missing phase task file)
+- Optional **debug/summary** output with minimal noise in normal runs
 
 ---
 
 ## Structure
 
     _common/
+    ├── defaults/
+    │   └── main.yml               # summary/debug defaults, wrapper success toggle
     ├── tasks/
-    │   └── task_flow.yml          # orchestrator (profile engine)
+    │   ├── main.yml               # wrapper + fail handling
+    │   └── task_flow.yml          # orchestrator + role/phase summaries
     └── vars/
         └── task_flow.yml          # canonical phase order + profiles
 
@@ -50,7 +54,7 @@ Default profiles:
 
 - `full`       → `[assert, install, config, validate]`
 - `config`     → `[assert, config, validate]`
-- `guard`      → `[assert]`
+- `guard`      → `[assert, validate]`
 - `full_dev`   → `[assert, install, config]` (skip validate while iterating)
 - `config_dev` → `[assert, config]` (skip validate while iterating)
 
@@ -58,17 +62,21 @@ Default profiles:
 
 ## How roles use it
 
-Each role calls the orchestrator from its `tasks/main.yml` and provides:
+Roles should include the **quiet wrapper** `../_common/tasks/main.yml` from their `tasks/main.yml` and provide:
 
-- `_role_tag` (for tagging)
+- `_role_tag` (for tagging/summary label)
 - `_role_enabled` (enable/disable switch)
 - `_task_flow_profile` (one of the profiles)
+- Optional inventory knobs:
+  - `task_flow_summary_mode` (`phase|role|none`)
+  - `task_flow_debug` (`true|false`)
+  - `task_flow_role_success_output` (`true|false`, controls wrapper `_common passed` line)
 
 Example: **full** role
 
     ---
     - name: Execute common task flow
-      ansible.builtin.include_tasks: "{{ role_path }}/../../_common/tasks/task_flow.yml"
+      ansible.builtin.include_tasks: "{{ role_path }}/../_common/tasks/main.yml"
       vars:
         _role_tag: "base_bootstrap"
         _role_enabled: "{{ base_bootstrap_enabled | default(true) | bool }}"
@@ -78,7 +86,7 @@ Example: **config-only** role
 
     ---
     - name: Execute common task flow
-      ansible.builtin.include_tasks: "{{ role_path }}/../../_common/tasks/task_flow.yml"
+      ansible.builtin.include_tasks: "{{ role_path }}/../_common/tasks/main.yml"
       vars:
         _role_tag: "base_sshd"
         _role_enabled: "{{ base_sshd_enabled | default(true) | bool }}"
@@ -88,7 +96,7 @@ Example: **guard** role
 
     ---
     - name: Execute common task flow
-      ansible.builtin.include_tasks: "{{ role_path }}/../../_common/tasks/task_flow.yml"
+      ansible.builtin.include_tasks: "{{ role_path }}/../_common/tasks/main.yml"
       vars:
         _role_tag: "base_preflight"
         _role_enabled: "{{ base_preflight_enabled | default(true) | bool }}"
@@ -130,6 +138,48 @@ Every included phase task file receives tags:
 
 - `<role_tag>` and `<phase>`
 
+Wrapper summary/debug knobs (inventory-level):
+
+- `task_flow_summary_mode`:
+  - `phase`: ✅ per phase
+  - `role`: single ✅ per role (`[OK] <role_tag> :: role passed`)
+  - `none`: no success lines (failures still show)
+- `task_flow_debug`: `true|false` to print selection + phase start breadcrumbs
+- `task_flow_role_success_output`:
+  - `false`: suppress wrapper line `[OK] <role_tag> :: _common passed` (default)
+  - `true`: print wrapper line when `task_flow_summary_mode == role`
+
+### Where summary lines come from
+
+- `task_flow.yml` emits:
+  - phase summary (`[OK] <role_tag> :: <phase> passed`) when `task_flow_summary_mode == phase`
+  - role summary (`[OK] <role_tag> :: role passed`) when `task_flow_summary_mode == role`
+- `main.yml` wrapper can emit:
+  - `[OK] <role_tag> :: _common passed` when `task_flow_role_success_output == true`
+
+This split lets consuming repos keep `_common` internal usage while showing only role-level summaries.
+
+### Recommended quiet output setup (consuming repo)
+
+In the consuming project (`ansible.cfg`):
+
+    [defaults]
+    callback_plugins = ./callback_plugins
+    stdout_callback = role_summary
+
+And in `_common/defaults/main.yml` (or inventory):
+
+    task_flow_summary_mode: "role"
+    task_flow_role_success_output: false
+    task_flow_debug: false
+
+With this setup:
+
+- Roles still run through `_common`
+- Internal `_common` task noise is suppressed by callback output filtering
+- You keep one line per role: `[OK] <role_tag> :: role passed`
+- Failures/unreachable still surface clearly
+
 So you can run:
 
     # Run only this role (enabled roles only)
@@ -152,7 +202,7 @@ For exceptional cases only, you can bypass the profile and provide an explicit p
 
     ---
     - name: Execute common task flow (override phases)
-      ansible.builtin.include_tasks: "{{ role_path }}/../../_common/tasks/task_flow.yml"
+      ansible.builtin.include_tasks: "{{ role_path }}/../_common/tasks/main.yml"
       vars:
         _role_tag: "some_role"
         _role_enabled: "{{ some_role_enabled | default(true) | bool }}"
@@ -186,3 +236,4 @@ The orchestrator validates override phases against the canonical order and fails
 - `install`: apt packages/repos, binaries, base users/groups if needed
 - `config`: templates, sysctl, systemd units, enable/restart handlers
 - `validate`: verify services, ports, config syntax, health checks
+- Set `task_flow_debug: true` temporarily when diagnosing profile/override issues; use `task_flow_summary_mode: phase|role|none` to control success chatter.

--- a/_common/defaults/main.yml
+++ b/_common/defaults/main.yml
@@ -1,0 +1,19 @@
+---
+# Success summary output:
+# phase = print [OK] per phase
+# role  = print [OK] once per role
+# none  = print nothing on success (only failures)
+task_flow_summary_mode: "role"
+
+# Debug/breadcrumb output from task flow:
+# true  = print extra info (profile/effective phases/start markers)
+# false = minimal prints
+task_flow_debug: false
+
+# Role-level success line from _common wrapper:
+# false = suppress "[OK] <role> :: _common passed" for quieter runs
+# true  = print one success line per role when summary_mode == role
+task_flow_role_success_output: false
+
+# Optional role enable behavior (caller may override)
+_role_enabled: true

--- a/_common/tasks/main.yml
+++ b/_common/tasks/main.yml
@@ -1,0 +1,50 @@
+---
+# roles/_common/tasks/main.yml
+#
+# QUIET WRAPPER:
+# Roles should include this file (not task_flow.yml directly) to keep output minimal.
+# - Success: optional single [OK] (controlled by task_flow_summary_mode)
+# - Failure: single [FAIL] then re-fail (Ansible still shows failing task output)
+#
+# Control knobs (typically set in inventory/group_vars):
+# - task_flow_summary_mode: phase|role|none
+# - task_flow_debug: true|false
+
+- name: "_common wrapper: run task flow"
+  vars:
+    _common_label: "{{ _role_tag | default(role_name | default('role')) }}"
+    _summary: "{{ task_flow_summary_mode | default('role') }}"
+    _dbg: "{{ task_flow_debug | default(false) | bool }}"
+    _role_success_output: "{{ task_flow_role_success_output | default(false) | bool }}"
+  block:
+
+    - name: "_common: load defaults"
+      ansible.builtin.include_vars:
+        file: "{{ role_path }}/../_common/defaults/main.yml"
+      tags: always
+
+    - name: "_common: execute task_flow.yml"
+      ansible.builtin.include_tasks: "{{ role_path }}/../_common/tasks/task_flow.yml"
+
+  rescue:
+    - name: "[FAIL] _common failed"
+      ansible.builtin.debug:
+        msg: "[FAIL] {{ _common_label }} :: _common failed (see failing task output above)"
+      changed_when: false
+      register: _common_fail_debug
+
+    - name: "Stop on _common failure"
+      ansible.builtin.fail:
+        msg: "Stopping: {{ _common_label }} failed in _common"
+      register: _common_fail_stop
+
+  always:
+    - name: "[OK] _common passed"
+      ansible.builtin.debug:
+        msg: "[OK] {{ _common_label }} :: _common passed"
+      changed_when: false
+      when:
+        - (_common_fail_debug is not defined) and (_common_fail_stop is not defined)
+        - not _dbg
+        - _summary == "role"
+        - _role_success_output

--- a/_common/tasks/task_flow.yml
+++ b/_common/tasks/task_flow.yml
@@ -1,17 +1,21 @@
 ---
-# _common/tasks/task_flow.yml
-#
-# Inputs:
+# roles/_common/tasks/task_flow.yml
+# Shared task-flow orchestrator for roles that follow the "phases" pattern.
+# Inputs (from caller role/tasks/main.yml):
 #   _role_enabled: optional bool (default true)
 #   _role_tag: optional role tag string (e.g., "base_bootstrap")
-#   _task_flow_profile: required unless _task_flow_phases_override is provided; profile name (full|config|guard|full_dev|config_dev)
-#   _task_flow_phases_override: optional list of phases (escape hatch; avoids profile)
-#
+#   _task_flow_profile: required unless _task_flow_phases_override is provided
+#   _task_flow_phases_override: optional list of phases (escape hatch)
+# Inventory variables (group_vars/host_vars):
+#   task_flow_summary_mode: phase|role|none
+#   task_flow_debug: true|false
 # Behavior:
-# - Canonical order + profiles come from: _common/vars/task_flow.yml
-# - Included phase tasks get tags: [_role_tag, <phase>]
-# - If _role_enabled is false, role ends immediately
-# - Fails fast with a friendly message if tasks/<phase>.yml is missing
+# - Canonical order + profiles come from: roles/_common/vars/task_flow.yml
+# - If role is disabled, this file will skip the role (no host-level end)
+# - Includes phase tasks in canonical order
+# - Applies tags to included tasks: [_role_tag, <phase>]
+# - Optional debug output shows what was selected and phase starts
+# Note: No success line here; wrapper handles single success print.
 
 - name: Load canonical task flow config (order + profiles)
   ansible.builtin.include_vars:
@@ -19,26 +23,46 @@
     name: _tf
   tags: always
 
-- name: Validate _task_flow_profile is provided and supported
+- name: Compute role enabled
+  ansible.builtin.set_fact:
+    _task_flow_role_enabled: "{{ _role_enabled | default(true) | bool }}"
+  tags: always
+
+- name: "Debug: role skipped (disabled)"
+  ansible.builtin.debug:
+    msg: "[SKIP] {{ _role_tag | default(role_name | default('role')) }} skipped (disabled)"
+  changed_when: false
+  when:
+    - not _task_flow_role_enabled
+    - task_flow_debug | default(false) | bool
+  tags: always
+
+- name: "Validate _task_flow_profile is provided and supported"
   ansible.builtin.assert:
     that:
       - _task_flow_profile is defined
       - _task_flow_profile in _tf.task_flow.profiles
+    quiet: true
     fail_msg: >-
       _task_flow_profile must be one of: {{ _tf.task_flow.profiles.keys() | list }}
-  when: _task_flow_phases_override is not defined
+  when:
+    - _task_flow_role_enabled
+    - _task_flow_phases_override is not defined
   tags: always
 
-- name: Validate override phases are supported (escape hatch)
+- name: "Validate override phases are supported (escape hatch)"
   ansible.builtin.assert:
     that:
       - _task_flow_phases_override is sequence
       - (_task_flow_phases_override | length) > 0
       - (_task_flow_phases_override | difference(_tf.task_flow.order) | length) == 0
+    quiet: true
     fail_msg: >-
       Unknown override phase(s): {{ _task_flow_phases_override | difference(_tf.task_flow.order) }}.
       Supported phases: {{ _tf.task_flow.order }}.
-  when: _task_flow_phases_override is defined
+  when:
+    - _task_flow_role_enabled
+    - _task_flow_phases_override is defined
   tags: always
 
 - name: Compute effective phases (profile or override)
@@ -48,6 +72,23 @@
         _task_flow_phases_override
           | default(_tf.task_flow.profiles[_task_flow_profile])
       }}
+  when: _task_flow_role_enabled
+  tags: always
+
+- name: "Debug: show selection inputs + effective phases"
+  ansible.builtin.debug:
+    msg:
+      role_tag: "{{ _role_tag | default(role_name | default('role')) }}"
+      role_enabled: "{{ _task_flow_role_enabled }}"
+      profile: "{{ _task_flow_profile | default('override') }}"
+      override_phases: "{{ _task_flow_phases_override | default([]) }}"
+      effective_phases: "{{ _task_flow_phases_effective | default([]) }}"
+      summary_mode: "{{ task_flow_summary_mode | default('role') }}"
+      debug: "{{ task_flow_debug | default(false) | bool }}"
+  changed_when: false
+  when:
+    - _task_flow_role_enabled
+    - task_flow_debug | default(false) | bool
   tags: always
 
 - name: "Pre-check: ensure required phase task files exist (friendly errors)"
@@ -57,24 +98,66 @@
   register: _task_flow_phase_files
   delegate_to: localhost
   become: false
-  become_user: "{{ ansible_user | default(omit) }}"
+  vars:
+    ansible_become: false
   run_once: true
+  when: _task_flow_role_enabled
   tags: always
 
 - name: Fail if a phase task file is missing
   ansible.builtin.assert:
     that:
       - item.stat.exists
+    quiet: true
     fail_msg: >-
       Missing task file for phase '{{ item.item }}':
       expected {{ role_path }}/tasks/{{ item.item }}.yml
   loop: "{{ _task_flow_phase_files.results }}"
+  loop_control:
+    label: "{{ item.item }}"
+  when: _task_flow_role_enabled
   tags: always
 
-- name: Run selected phases in canonical order
-  ansible.builtin.include_tasks:
-    file: "{{ role_path }}/tasks/{{ item }}.yml"
-    apply:
-      tags: "{{ ([_role_tag] if (_role_tag is defined and (_role_tag | length > 0)) else []) + [item] }}"
-  loop: "{{ _tf.task_flow.order }}"
-  when: item in _task_flow_phases_effective
+- name: Run phases (selected)
+  vars:
+    _role_label: "{{ _role_tag | default(role_name | default('role')) }}"
+    _summary: "{{ task_flow_summary_mode | default('role') }}"
+    _dbg: "{{ task_flow_debug | default(false) | bool }}"
+  when: _task_flow_role_enabled
+  block:
+    - name: "Phase start (debug)"
+      ansible.builtin.debug:
+        msg: "[START] {{ _role_label }} :: {{ item }} start"
+      changed_when: false
+      loop: "{{ _tf.task_flow.order }}"
+      loop_control:
+        label: "{{ item }}"
+      when: _dbg and item in _task_flow_phases_effective
+
+    - name: "Include phase tasks"
+      ansible.builtin.include_tasks:
+        file: "{{ role_path }}/tasks/{{ item }}.yml"
+        apply:
+          tags: >-
+            {{
+              ([_role_tag] if (_role_tag is defined and (_role_tag | length > 0)) else [])
+              + [item]
+            }}
+      loop: "{{ _tf.task_flow.order }}"
+      when: item in _task_flow_phases_effective
+
+    - name: "Phase passed (summary)"
+      ansible.builtin.debug:
+        msg: "[OK] {{ _role_label }} :: {{ item }} passed"
+      changed_when: false
+      loop: "{{ (_summary == 'phase') | ternary(_task_flow_phases_effective, []) }}"
+      loop_control:
+        label: "{{ item }}"
+
+    - name: "Role passed (summary)"
+      ansible.builtin.debug:
+        msg: "[OK] {{ _role_label }} :: role passed"
+      changed_when: false
+      when:
+        - _summary == "role"
+        - not _dbg

--- a/_common/vars/task_flow.yml
+++ b/_common/vars/task_flow.yml
@@ -12,7 +12,7 @@ task_flow:
     # Standard
     full: [assert, install, config, validate]
     config: [assert, config, validate]
-    guard: [assert]
+    guard: [assert, validate]
     # Dev profiles (skip validate while iterating)
     full_dev: [assert, install, config]
     config_dev: [assert, config]

--- a/base_bootstrap/defaults/main.yml
+++ b/base_bootstrap/defaults/main.yml
@@ -1,5 +1,9 @@
 ---
 # Default variables for bootstrap role
+base_bootstrap_enabled: true
+base_bootstrap_task_flow_profile: config
+base_bootstrap_task_flow_summary_mode: role
+base_bootstrap_task_flow_debug: false
 bootstrap_user: admin
 bootstrap_puid: 1000
 bootstrap_pgid: 1000

--- a/base_bootstrap/tasks/assert.yml
+++ b/base_bootstrap/tasks/assert.yml
@@ -6,6 +6,7 @@
     that:
       - bootstrap_user is defined
       - bootstrap_user | length > 0
+    quiet: true
     fail_msg: "Required variables are not defined"
 
 - name: Validate PUID and PGID are valid numbers
@@ -15,6 +16,7 @@
       - bootstrap_pgid is number
       - bootstrap_puid | int >= 1000
       - bootstrap_pgid | int >= 1000
+    quiet: true
     fail_msg: "PUID and PGID must be valid numbers >= 1000"
 
 - name: Validate user_shell is defined
@@ -23,6 +25,7 @@
       - user_shell is defined
       - user_shell | length > 0
       - user_shell.startswith('/')
+    quiet: true
     fail_msg: "user_shell must be defined and be an absolute path"
 
 - name: Validate bootstrap_authorized_key if defined
@@ -30,5 +33,6 @@
     that:
       - bootstrap_authorized_key | length > 0
       - bootstrap_authorized_key.startswith('ssh-')
+    quiet: true
     fail_msg: "bootstrap_authorized_key must be a valid SSH public key"
   when: bootstrap_authorized_key is defined and bootstrap_authorized_key != ''

--- a/base_bootstrap/tasks/main.yml
+++ b/base_bootstrap/tasks/main.yml
@@ -1,9 +1,8 @@
 ---
-# This task file executes the common task flow for the base_bootstrap role.
-# It includes the shared _common/tasks/task_flow.yml with role-specific variables.
-- name: "Execute base_bootstrap task flow"
-  ansible.builtin.include_tasks: "{{ role_path }}/../_common/tasks/task_flow.yml"
-  when: base_bootstrap_enabled | default(true) | bool
+# Entry point for base_bootstrap: run the shared task flow via quiet wrapper.
+- name: Execute base_bootstrap task flow
+  ansible.builtin.include_tasks: "{{ role_path }}/../_common/tasks/main.yml"
   vars:
     _role_tag: "base_bootstrap"
+    _role_enabled: "{{ base_bootstrap_enabled | default(true) | bool }}"
     _task_flow_profile: "config"

--- a/base_bootstrap/tasks/validate.yml
+++ b/base_bootstrap/tasks/validate.yml
@@ -11,12 +11,14 @@
   ansible.builtin.assert:
     that:
       - bootstrap_user in user_check.ansible_facts.getent_passwd
+    quiet: true
     fail_msg: "Admin user does not exist"
 
 - name: Assert admin user shell is correct
   ansible.builtin.assert:
     that:
       - user_check.ansible_facts.getent_passwd[bootstrap_user][5] == user_shell
+    quiet: true
     fail_msg: "Admin user shell does not match expected value"
 
 - name: Verify admin user is in sudo group
@@ -29,4 +31,5 @@
   ansible.builtin.assert:
     that:
       - bootstrap_user in (sudo_group.ansible_facts.getent_group[bootstrap_sudo_group][2] | default('') | string | split(','))
+    quiet: true
     fail_msg: "Admin user is not in the sudo group"

--- a/docs/10-common-task-flow-output.md
+++ b/docs/10-common-task-flow-output.md
@@ -1,0 +1,66 @@
+# _common Task Flow and Output Model
+
+This document explains how `_common` runs role phases and how success/failure
+output is controlled.
+
+## Flow Overview
+
+Roles include `_common/tasks/main.yml`, which calls `_common/tasks/task_flow.yml`.
+
+High-level sequence:
+
+1. load canonical phase configuration from `_common/vars/task_flow.yml`
+2. compute role enabled state
+3. validate profile or override phases
+4. compute effective phase list
+5. pre-check required phase task files
+6. include role phase tasks in canonical order
+7. emit summary lines based on settings
+
+## Control Variables
+
+Defaults are in `_common/defaults/main.yml`.
+
+- `task_flow_summary_mode`
+  - `phase`: print one success line per phase
+  - `role`: print one success line per role
+  - `none`: no success lines
+- `task_flow_debug`
+  - `true`: print debug breadcrumbs
+  - `false`: quiet mode
+- `task_flow_role_success_output`
+  - `false` (default): suppress wrapper `_common passed` line
+  - `true`: allow wrapper success line when summary mode is `role`
+
+## Summary Line Sources
+
+- From `_common/tasks/task_flow.yml`:
+  - `[OK] <role_tag> :: <phase> passed` (`phase` mode)
+  - `[OK] <role_tag> :: role passed` (`role` mode)
+- From `_common/tasks/main.yml` wrapper:
+  - `[OK] <role_tag> :: _common passed` (only when `task_flow_role_success_output: true`)
+
+## Recommended Quiet Pattern (Consuming Repo)
+
+In consuming repo `ansible.cfg`:
+
+```ini
+[defaults]
+callback_plugins = ./callback_plugins
+stdout_callback = role_summary
+```
+
+In inventory or defaults:
+
+```yaml
+task_flow_summary_mode: role
+task_flow_debug: false
+task_flow_role_success_output: false
+```
+
+Result:
+
+- role uses `_common` orchestration
+- internal `_common` noise is filtered by callback output mode
+- one clean success line per role remains
+- failures/unreachable remain visible

--- a/monitoring/authorized_key/tasks/main.yml
+++ b/monitoring/authorized_key/tasks/main.yml
@@ -1,12 +1,10 @@
 ---
-# monitoring/authorized_key — main orchestrator
-# Adds an SSH authorized key for inter-host monitoring/alert/backup/status access
-# Task flow: assert → configure → validate
-
-- name: Execute task flow
-  ansible.builtin.include_tasks: ../../../_common/tasks/task_flow.yml
+- name: Execute authorized_key task flow
+  ansible.builtin.include_tasks: ../../../_common/tasks/main.yml
   vars:
-    _task_flow_phases:
+    _role_tag: "monitoring_authorized_key"
+    _role_enabled: "{{ monitoring_authorized_key_enabled | default(true) | bool }}"
+    _task_flow_phases_override:
       - assert
-      - configure
+      - config
       - validate


### PR DESCRIPTION
- Introduced a quiet wrapper for task flow execution to minimize output.
- Added optional summary and debug output controls in `_common/defaults/main.yml`.
- Updated task flow orchestrator to support new output modes and improved error handling.
- Enhanced documentation for task flow and output model in `docs/10-common-task-flow-output.md`.
- Refined existing roles to utilize the new quiet wrapper and output settings. _common task flow — summary/debug controls + base_* role main.yml
Fixes #7