### PR TITLE
Add base_ntp role for time synchronization management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,22 @@
 Release history for `ansible-roles`.
 Documents notable changes across repository structure, roles, examples, and documentation.
 
+## [v0.11.0]
+### Added
+- `roles/base_ntp/`: New role for configuring time synchronization through `systemd-timesyncd` during the base phase.
+- `roles/base_ntp/defaults/main.yml`: Added `base_ntp_packages`, `base_ntp_service_name`, `base_ntp_servers`, and `base_ntp_fallback_servers` defaults.
+- `roles/base_ntp/tasks/`: Added assert, install, config, and validate phase task files for Debian-family NTP management, including managed timesyncd configuration and service-state validation.
+- `roles/base_ntp/handlers/main.yml`: Added a handler that restarts the managed NTP service after configuration changes.
+- `roles/base_ntp/templates/timesyncd.conf.j2`: Added a template for the managed `/etc/systemd/timesyncd.conf` file.
+- `roles/base_ntp/README.md`: Added role documentation for NTP configuration and direct usage.
+- `examples/inventory/group_vars/all/base_ntp.yml`: Added example NTP variables for the Debian-family example lab.
+
+### Changed
+- `roles/base/meta/main.yml`: Added `base_ntp` as a dependency of the `base` role with `base` and `base_ntp` tags.
+- `roles/base/README.md`: Updated base role documentation to reflect the `base_ntp` dependency and inputs.
+- `README.md`: Added `base_ntp` to the available roles list and aligned the `base` role description.
+- `examples/README.md` and `docs/01-examples.md`: Updated the example documentation to include the new `base_ntp.yml` role-scoped variables file.
+
 ## [v0.10.0]
 ### Added
 - `roles/base_locale/handlers/main.yml`: Added a locale regeneration handler for managed `/etc/locale.gen` changes.

--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@ ansible-roles/
 
 ## Available Roles
 - `bootstrap`: Creates and validates the automation account used after the bootstrap phase.
-- `base`: Aggregates recurring base-phase configuration for Debian-family hosts through dependency roles such as `base_packages` and `base_timezone`.
+- `base`: Aggregates recurring base-phase configuration for Debian-family hosts through dependency roles such as `base_packages`, `base_ntp`, and `base_timezone`.
 - `base_locale`: Ensures requested locales exist and configures the system default locale on Debian-family hosts during the base phase.
+- `base_ntp`: Configures system time synchronization through `systemd-timesyncd` on Debian-family hosts during the base phase.
 - `base_timezone`: Enforces the system timezone on Debian-family hosts during the base phase.
 - `monitoring`: Aggregates monitoring-related configuration through dependency roles such as `monitoring_authorized_key`.
 - `monitoring_authorized_key`: Installs an SSH authorized key for monitoring-style inter-host access.

--- a/docs/01-examples.md
+++ b/docs/01-examples.md
@@ -51,7 +51,7 @@ ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/base.yml
 
 - The lab content is intentionally simple and meant as an example baseline.
 - The example inventory and variables assume Debian-family hosts and the repository's APT-based role behavior.
-- `group_vars/all/` is split by role prefix so example variables stay readable as the base stack grows.
+- `group_vars/all/` is split by role prefix so example variables such as `base_packages.yml`, `base_locale.yml`, `base_ntp.yml`, and `base_timezone.yml` stay readable as the base stack grows.
 - `hosts.ini` keeps default `ansible_user=ansible` in `[all:vars]`, while `[bootstrap:vars]` holds initial login values used only during bootstrap.
 - `playbooks/bootstrap.yml` prompts once for the bootstrap password and reuses it for both SSH login and sudo.
 - Extend the inventory, vars, and playbooks to fit your own infrastructure and test scope.

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,7 +10,7 @@ The inventory variables and role inputs assume the repository's Debian-family de
 ## Structure
 - `ansible.cfg`: Test-specific Ansible configuration.
 - `inventory/hosts.ini`: Test inventory.
-- `inventory/group_vars/all/`: Shared variables for test hosts, split into per-role files such as `bootstrap.yml`, `base_packages.yml`, `base_locale.yml`, and `base_timezone.yml`.
+- `inventory/group_vars/all/`: Shared variables for test hosts, split into per-role files such as `bootstrap.yml`, `base_packages.yml`, `base_locale.yml`, `base_ntp.yml`, and `base_timezone.yml`.
 - `playbooks/bootstrap.yml`: Bootstrap phase playbook that connects with the initial admin account and applies the standalone `bootstrap` role.
 - `playbooks/base.yml`: Base phase playbook that connects as the automation account and applies the `base` role.
 - `playbooks/site.yml`: Base-phase entry playbook that imports `base.yml`.

--- a/examples/inventory/group_vars/all/base_ntp.yml
+++ b/examples/inventory/group_vars/all/base_ntp.yml
@@ -1,0 +1,21 @@
+---
+# examples/inventory/group_vars/all/base_ntp.yml
+# Shared NTP variables for the example lab.
+# Defines the NTP package, service, and server lists enforced during the base phase.
+
+# Package list installed with APT to provide the NTP client on the host.
+base_ntp_packages:
+  - systemd-timesyncd  # systemd NTP client used by the base_ntp role on Debian-family hosts
+
+# Service name enabled and validated during the base phase.
+base_ntp_service_name: systemd-timesyncd
+
+# Primary NTP servers written to /etc/systemd/timesyncd.conf.
+base_ntp_servers:
+  - time.cloudflare.com  # low-latency public NTP service
+  - time.google.com      # simple public NTP service for example hosts
+
+# Optional fallback NTP servers used if the primary servers are unavailable.
+base_ntp_fallback_servers:
+  - 0.pool.ntp.org
+  - 1.pool.ntp.org

--- a/roles/base/README.md
+++ b/roles/base/README.md
@@ -6,7 +6,7 @@ Explains how the aggregate base role delegates recurring Debian-family host conf
 ## Features
 - Runs the recurring base configuration on every `base` execution
 - Keeps orchestration in `roles/base/meta/main.yml`
-- Includes `base_packages`, `base_locale`, and `base_timezone` through role dependencies
+- Includes `base_packages`, `base_locale`, `base_ntp`, and `base_timezone` through role dependencies
 
 ## Usage
 Use `base` on Debian-family hosts after the bootstrap phase has already created the automation account:
@@ -19,7 +19,7 @@ Use `base` on Debian-family hosts after the bootstrap phase has already created 
 ```
 
 Bootstrap is handled separately by the standalone `bootstrap` role/playbook.
-Role-specific inputs for `base` currently come from `base_packages_*`, `base_locale_*`, and `base_timezone_*`.
+Role-specific inputs for `base` currently come from `base_packages_*`, `base_locale_*`, `base_ntp_*`, and `base_timezone_*`.
 
 ## License
 MIT

--- a/roles/base/meta/main.yml
+++ b/roles/base/meta/main.yml
@@ -8,11 +8,12 @@ dependencies:
     tags: [base, base_packages]
   - role: base_locale
     tags: [base, base_locale]
+  - role: base_ntp
+    tags: [base, base_ntp]
   - role: base_timezone
     tags: [base, base_timezone]
 
 # Future base dependencies:
-# - role: base_ntp
 # - role: base_hostname
 # - role: base_sudo
 # - role: base_sshd

--- a/roles/base_ntp/README.md
+++ b/roles/base_ntp/README.md
@@ -1,0 +1,53 @@
+# roles/base_ntp/README.md
+
+Reference for the `base_ntp` role.
+Explains how the role configures system time synchronization on Debian-family hosts during the base phase.
+
+## Features
+- Installs the NTP client package with APT before time synchronization configuration
+- Validates the requested NTP package, service, and server list inputs
+- Fully manages `/etc/systemd/timesyncd.conf` through a template
+- Ensures the NTP service is enabled and running
+- Verifies the managed configuration file and service state after changes
+
+## Variables
+
+| Variable | Default | Required | Description |
+|----------|---------|----------|-------------|
+| `base_ntp_packages` | `['systemd-timesyncd']` | no | Package list installed with APT to provide the NTP client |
+| `base_ntp_service_name` | `systemd-timesyncd` | no | Service name enabled, restarted, and validated by the role |
+| `base_ntp_servers` | `['0.pool.ntp.org', '1.pool.ntp.org', '2.pool.ntp.org', '3.pool.ntp.org']` | no | NTP servers written to the managed `NTP=` line |
+| `base_ntp_fallback_servers` | `[]` | no | Optional fallback NTP servers written to `FallbackNTP=` |
+
+## Usage
+
+The `base` role includes `base_ntp` through meta dependencies.
+
+Direct usage:
+
+```yaml
+- hosts: all
+  become: true
+  roles:
+    - base_ntp
+```
+
+Example variables:
+
+```yaml
+base_ntp_servers:
+  - time.cloudflare.com
+  - time.google.com
+base_ntp_fallback_servers:
+  - 0.pool.ntp.org
+  - 1.pool.ntp.org
+```
+
+## Dependencies
+None
+
+## License
+MIT
+
+## Author
+Tatbyte

--- a/roles/base_ntp/defaults/main.yml
+++ b/roles/base_ntp/defaults/main.yml
@@ -1,0 +1,14 @@
+---
+# roles/base_ntp/defaults/main.yml
+# Default variables for the `base_ntp` role.
+# Defines the NTP package, service, and server lists enforced during the base phase.
+
+base_ntp_packages:
+  - systemd-timesyncd
+base_ntp_service_name: systemd-timesyncd
+base_ntp_servers:
+  - 0.pool.ntp.org
+  - 1.pool.ntp.org
+  - 2.pool.ntp.org
+  - 3.pool.ntp.org
+base_ntp_fallback_servers: []

--- a/roles/base_ntp/handlers/main.yml
+++ b/roles/base_ntp/handlers/main.yml
@@ -1,0 +1,9 @@
+---
+# roles/base_ntp/handlers/main.yml
+# Handlers for the `base_ntp` role.
+# Restarts the NTP service when the managed timesyncd configuration changes.
+
+- name: Restart NTP service
+  ansible.builtin.service:
+    name: "{{ base_ntp_service_name }}"
+    state: restarted

--- a/roles/base_ntp/tasks/assert.yml
+++ b/roles/base_ntp/tasks/assert.yml
@@ -1,0 +1,28 @@
+---
+# roles/base_ntp/tasks/assert.yml
+# Assert phase tasks for the `base_ntp` role.
+# Validates the requested NTP package, service, and server list inputs before installation and configuration run.
+
+- name: "Assert | Validate base_ntp variable structure"
+  ansible.builtin.assert:
+    that:
+      - base_ntp_packages is sequence
+      - base_ntp_packages is not string
+      - base_ntp_service_name is string
+      - base_ntp_service_name | trim | length > 0
+      - base_ntp_servers is sequence
+      - base_ntp_servers is not string
+      - base_ntp_fallback_servers is sequence
+      - base_ntp_fallback_servers is not string
+      - (base_ntp_packages | map('string') | list | length) == (base_ntp_packages | length)
+      - (base_ntp_servers | map('string') | list | length) == (base_ntp_servers | length)
+      - (base_ntp_fallback_servers | map('string') | list | length) == (base_ntp_fallback_servers | length)
+      - (base_ntp_packages | map('trim') | reject('equalto', '') | list | length) == (base_ntp_packages | length)
+      - (base_ntp_servers | map('trim') | reject('equalto', '') | list | length) == (base_ntp_servers | length)
+      - (base_ntp_fallback_servers | map('trim') | reject('equalto', '') | list | length) == (base_ntp_fallback_servers | length)
+      - (base_ntp_servers | length) > 0
+    fail_msg: >-
+      base_ntp_packages must be a list of package names, base_ntp_service_name
+      must be a non-empty service name, and base_ntp_servers plus
+      base_ntp_fallback_servers must be lists of non-empty NTP host names
+    quiet: true

--- a/roles/base_ntp/tasks/config.yml
+++ b/roles/base_ntp/tasks/config.yml
@@ -1,0 +1,22 @@
+---
+# roles/base_ntp/tasks/config.yml
+# Config phase tasks for the `base_ntp` role.
+# Manages the systemd-timesyncd configuration file and ensures the NTP service is enabled and running.
+
+- name: "Config | Render timesyncd configuration"
+  ansible.builtin.template:
+    src: timesyncd.conf.j2
+    dest: /etc/systemd/timesyncd.conf
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart NTP service
+
+- name: "Config | Ensure NTP service is enabled and running"
+  ansible.builtin.service:
+    name: "{{ base_ntp_service_name }}"
+    enabled: true
+    state: started
+
+- name: "Config | Flush NTP handler"
+  ansible.builtin.meta: flush_handlers

--- a/roles/base_ntp/tasks/install.yml
+++ b/roles/base_ntp/tasks/install.yml
@@ -1,0 +1,12 @@
+---
+# roles/base_ntp/tasks/install.yml
+# Install phase tasks for the `base_ntp` role.
+# Ensures the NTP client package is present with APT before time synchronization configuration.
+
+- name: "Install | Ensure NTP packages are present"
+  ansible.builtin.apt:
+    name: "{{ base_ntp_packages }}"
+    state: present
+    update_cache: true
+    cache_valid_time: 3600
+  when: base_ntp_packages | length > 0

--- a/roles/base_ntp/tasks/main.yml
+++ b/roles/base_ntp/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+# roles/base_ntp/tasks/main.yml
+# Task entrypoint for the `base_ntp` role.
+# Imports the assert, install, config, and validate phase files in order.
+
+- name: Assert
+  ansible.builtin.import_tasks: assert.yml
+  tags: [assert, base_ntp_assert]
+
+- name: Install
+  ansible.builtin.import_tasks: install.yml
+  tags: [install, base_ntp_install]
+
+- name: Config
+  ansible.builtin.import_tasks: config.yml
+  tags: [config, base_ntp_config]
+
+- name: Validate
+  ansible.builtin.import_tasks: validate.yml
+  tags: [validate, base_ntp_validate]

--- a/roles/base_ntp/tasks/validate.yml
+++ b/roles/base_ntp/tasks/validate.yml
@@ -1,0 +1,30 @@
+---
+# roles/base_ntp/tasks/validate.yml
+# Validate phase tasks for the `base_ntp` role.
+# Verifies the managed timesyncd configuration file and the enabled, running service state.
+
+- name: "Validate | Read timesyncd configuration"
+  ansible.builtin.slurp:
+    path: /etc/systemd/timesyncd.conf
+  register: base_ntp_config_file
+
+- name: "Validate | Gather service facts"
+  ansible.builtin.service_facts:
+
+- name: "Validate | Assert NTP state"
+  vars:
+    base_ntp_expected_config: "{{ lookup('template', 'timesyncd.conf.j2') }}"
+    base_ntp_service_unit: >-
+      {{
+        base_ntp_service_name
+        if base_ntp_service_name.endswith('.service')
+        else (base_ntp_service_name ~ '.service')
+      }}
+  ansible.builtin.assert:
+    that:
+      - (base_ntp_config_file.content | b64decode) == base_ntp_expected_config
+      - base_ntp_service_unit in ansible_facts.services
+      - ansible_facts.services[base_ntp_service_unit].status == 'enabled'
+      - ansible_facts.services[base_ntp_service_unit].state == 'running'
+    fail_msg: "Configured NTP state does not match the requested base_ntp values"
+    quiet: true

--- a/roles/base_ntp/templates/timesyncd.conf.j2
+++ b/roles/base_ntp/templates/timesyncd.conf.j2
@@ -1,0 +1,13 @@
+{# roles/base_ntp/templates/timesyncd.conf.j2 #}
+{# Template for the managed `/etc/systemd/timesyncd.conf` file in the `base_ntp` role. #}
+{# Renders the Debian-family NTP server configuration for systemd-timesyncd. #}
+{{
+  (
+    ['[Time]', 'NTP=' ~ (base_ntp_servers | join(' '))]
+    + (
+      ['FallbackNTP=' ~ (base_ntp_fallback_servers | join(' '))]
+      if base_ntp_fallback_servers | length > 0
+      else []
+    )
+  ) | join('\n')
+}}


### PR DESCRIPTION
- Introduced `base_ntp` role to configure time synchronization using systemd-timesyncd.
- Added default variables, tasks for installation, configuration, and validation.
- Updated documentation and examples to include the new role and its variables.
- Established dependencies in the base role and updated related documentation.