### PR TITLE
Add base_hostname role for system hostname management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,27 @@
 Release history for `ansible-roles`.
 Documents notable changes across repository structure, roles, examples, and documentation.
 
+## [v0.12.0]
+### Added
+- `roles/base_hostname/`: New role for enforcing the system hostname during the base phase.
+- `roles/base_hostname/defaults/main.yml`: Added `base_hostname_name` defaults for hostname management.
+- `roles/base_hostname/tasks/`: Added assert, config, and validate phase task files for Debian-family hostname management.
+- `roles/base_hostname/README.md`: Added role documentation for hostname management and direct usage.
+- `examples/inventory/group_vars/all/base_hostname.yml`: Added example hostname variables for the Debian-family example lab.
+
+### Changed
+- `roles/base/meta/main.yml`: Added `base_hostname` as a dependency of the `base` role with `base` and `base_hostname` tags.
+- `roles/base/README.md`: Updated base role documentation to reflect the `base_hostname` dependency and inputs.
+- `README.md`: Added `base_hostname` to the available roles list and aligned the `base` role description.
+- `examples/README.md` and `docs/01-examples.md`: Updated the example documentation to include the new `base_hostname.yml` role-scoped variables file.
+
+### Fixed
+- `roles/base_hostname/tasks/assert.yml`: Tightened hostname validation to require real DNS-style hostname labels instead of only rejecting whitespace and edge punctuation.
+- `roles/base_hostname/tasks/validate.yml`: Validates the managed `/etc/hostname` value separately from the current short hostname so FQDN inputs such as `lab.example.internal` align with hosts that report `lab`.
+
+### Documentation
+- `roles/base_hostname/README.md` and `examples/inventory/group_vars/all/base_hostname.yml`: Clarified that the role writes the full hostname or FQDN to `/etc/hostname` while validating the current short hostname against the first label.
+
 ## [v0.11.0]
 ### Added
 - `roles/base_ntp/`: New role for configuring time synchronization through `systemd-timesyncd` during the base phase.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ ansible-roles/
 
 ## Available Roles
 - `bootstrap`: Creates and validates the automation account used after the bootstrap phase.
-- `base`: Aggregates recurring base-phase configuration for Debian-family hosts through dependency roles such as `base_packages`, `base_ntp`, and `base_timezone`.
+- `base`: Aggregates recurring base-phase configuration for Debian-family hosts through dependency roles such as `base_packages`, `base_hostname`, `base_ntp`, and `base_timezone`.
+- `base_hostname`: Enforces the system hostname on Debian-family hosts during the base phase.
 - `base_locale`: Ensures requested locales exist and configures the system default locale on Debian-family hosts during the base phase.
 - `base_ntp`: Configures system time synchronization through `systemd-timesyncd` on Debian-family hosts during the base phase.
 - `base_timezone`: Enforces the system timezone on Debian-family hosts during the base phase.

--- a/docs/01-examples.md
+++ b/docs/01-examples.md
@@ -51,7 +51,7 @@ ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/base.yml
 
 - The lab content is intentionally simple and meant as an example baseline.
 - The example inventory and variables assume Debian-family hosts and the repository's APT-based role behavior.
-- `group_vars/all/` is split by role prefix so example variables such as `base_packages.yml`, `base_locale.yml`, `base_ntp.yml`, and `base_timezone.yml` stay readable as the base stack grows.
+- `group_vars/all/` is split by role prefix so example variables such as `base_packages.yml`, `base_hostname.yml`, `base_locale.yml`, `base_ntp.yml`, and `base_timezone.yml` stay readable as the base stack grows.
 - `hosts.ini` keeps default `ansible_user=ansible` in `[all:vars]`, while `[bootstrap:vars]` holds initial login values used only during bootstrap.
 - `playbooks/bootstrap.yml` prompts once for the bootstrap password and reuses it for both SSH login and sudo.
 - Extend the inventory, vars, and playbooks to fit your own infrastructure and test scope.

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,7 +10,7 @@ The inventory variables and role inputs assume the repository's Debian-family de
 ## Structure
 - `ansible.cfg`: Test-specific Ansible configuration.
 - `inventory/hosts.ini`: Test inventory.
-- `inventory/group_vars/all/`: Shared variables for test hosts, split into per-role files such as `bootstrap.yml`, `base_packages.yml`, `base_locale.yml`, `base_ntp.yml`, and `base_timezone.yml`.
+- `inventory/group_vars/all/`: Shared variables for test hosts, split into per-role files such as `bootstrap.yml`, `base_packages.yml`, `base_hostname.yml`, `base_locale.yml`, `base_ntp.yml`, and `base_timezone.yml`.
 - `playbooks/bootstrap.yml`: Bootstrap phase playbook that connects with the initial admin account and applies the standalone `bootstrap` role.
 - `playbooks/base.yml`: Base phase playbook that connects as the automation account and applies the `base` role.
 - `playbooks/site.yml`: Base-phase entry playbook that imports `base.yml`.

--- a/examples/inventory/group_vars/all/base_hostname.yml
+++ b/examples/inventory/group_vars/all/base_hostname.yml
@@ -1,0 +1,9 @@
+---
+# examples/inventory/group_vars/all/base_hostname.yml
+# Shared hostname variables for the example lab.
+# Defines the hostname enforced during the base phase.
+
+# Hostname enforced during the base phase.
+# Use the final host name or FQDN you want written to /etc/hostname.
+# The current short hostname is expected to match the first label.
+base_hostname_name: lab.example.internal  # full hostname written to /etc/hostname for the example host

--- a/roles/base/README.md
+++ b/roles/base/README.md
@@ -6,7 +6,7 @@ Explains how the aggregate base role delegates recurring Debian-family host conf
 ## Features
 - Runs the recurring base configuration on every `base` execution
 - Keeps orchestration in `roles/base/meta/main.yml`
-- Includes `base_packages`, `base_locale`, `base_ntp`, and `base_timezone` through role dependencies
+- Includes `base_packages`, `base_hostname`, `base_locale`, `base_ntp`, and `base_timezone` through role dependencies
 
 ## Usage
 Use `base` on Debian-family hosts after the bootstrap phase has already created the automation account:
@@ -19,7 +19,7 @@ Use `base` on Debian-family hosts after the bootstrap phase has already created 
 ```
 
 Bootstrap is handled separately by the standalone `bootstrap` role/playbook.
-Role-specific inputs for `base` currently come from `base_packages_*`, `base_locale_*`, `base_ntp_*`, and `base_timezone_*`.
+Role-specific inputs for `base` currently come from `base_packages_*`, `base_hostname_*`, `base_locale_*`, `base_ntp_*`, and `base_timezone_*`.
 
 ## License
 MIT

--- a/roles/base/meta/main.yml
+++ b/roles/base/meta/main.yml
@@ -6,6 +6,8 @@
 dependencies:
   - role: base_packages
     tags: [base, base_packages]
+  - role: base_hostname
+    tags: [base, base_hostname]
   - role: base_locale
     tags: [base, base_locale]
   - role: base_ntp
@@ -14,7 +16,6 @@ dependencies:
     tags: [base, base_timezone]
 
 # Future base dependencies:
-# - role: base_hostname
 # - role: base_sudo
 # - role: base_sshd
 # - role: base_firewall

--- a/roles/base_hostname/README.md
+++ b/roles/base_hostname/README.md
@@ -1,0 +1,46 @@
+# roles/base_hostname/README.md
+
+Reference for the `base_hostname` role.
+Explains how the role enforces the system hostname on Debian-family hosts during the base phase.
+
+## Features
+- Validates the requested hostname value before changes are applied
+- Sets the current system hostname through the hostname module
+- Writes `/etc/hostname` with the requested hostname or FQDN
+- Verifies the managed file contents and the current short hostname after changes
+
+## Variables
+
+| Variable | Default | Required | Description |
+|----------|---------|----------|-------------|
+| `base_hostname_name` | `localhost` | no | Hostname or FQDN written to `/etc/hostname`; validation expects the current short hostname to match the first label |
+
+## Usage
+
+The `base` role includes `base_hostname` through meta dependencies.
+
+Direct usage:
+
+```yaml
+- hosts: all
+  become: true
+  roles:
+    - base_hostname
+```
+
+Example variable:
+
+```yaml
+base_hostname_name: lab.example.internal
+```
+
+When `base_hostname_name` is an FQDN such as `lab.example.internal`, this role manages that full value in `/etc/hostname` and validates the current short hostname as `lab`.
+
+## Dependencies
+None
+
+## License
+MIT
+
+## Author
+Tatbyte

--- a/roles/base_hostname/defaults/main.yml
+++ b/roles/base_hostname/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+# roles/base_hostname/defaults/main.yml
+# Default variables for the `base_hostname` role.
+# Defines the hostname enforced during the base phase.
+
+base_hostname_name: localhost

--- a/roles/base_hostname/tasks/assert.yml
+++ b/roles/base_hostname/tasks/assert.yml
@@ -1,0 +1,26 @@
+---
+# roles/base_hostname/tasks/assert.yml
+# Assert phase tasks for the `base_hostname` role.
+# Validates the requested hostname value before configuration runs.
+
+- name: "Assert | Validate hostname input"
+  ansible.builtin.assert:
+    that:
+      - base_hostname_name is string
+      - base_hostname_name | trim | length > 0
+      - base_hostname_name | length <= 253
+      - base_hostname_name == (base_hostname_name | trim)
+      - base_hostname_name is not match('.*\\s+.*')
+      - (base_hostname_name.split('.') | map('length') | min) > 0
+      - (base_hostname_name.split('.') | map('length') | max) <= 63
+      - >-
+        (
+          base_hostname_name.split('.')
+          | reject('match', '^[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?$')
+          | list
+          | length
+        ) == 0
+    fail_msg: >-
+      base_hostname_name must be a valid hostname or FQDN with DNS-style labels,
+      without whitespace, empty labels, or labels longer than 63 characters
+    quiet: true

--- a/roles/base_hostname/tasks/config.yml
+++ b/roles/base_hostname/tasks/config.yml
@@ -1,0 +1,16 @@
+---
+# roles/base_hostname/tasks/config.yml
+# Config phase tasks for the `base_hostname` role.
+# Sets the system hostname and writes the managed `/etc/hostname` file.
+
+- name: "Config | Set system hostname"
+  ansible.builtin.hostname:
+    name: "{{ base_hostname_name }}"
+
+- name: "Config | Write /etc/hostname"
+  ansible.builtin.copy:
+    content: "{{ base_hostname_name }}\n"
+    dest: /etc/hostname
+    owner: root
+    group: root
+    mode: "0644"

--- a/roles/base_hostname/tasks/main.yml
+++ b/roles/base_hostname/tasks/main.yml
@@ -1,0 +1,16 @@
+---
+# roles/base_hostname/tasks/main.yml
+# Task entrypoint for the `base_hostname` role.
+# Imports the assert, config, and validate phase files in order.
+
+- name: Assert
+  ansible.builtin.import_tasks: assert.yml
+  tags: [assert, base_hostname_assert]
+
+- name: Config
+  ansible.builtin.import_tasks: config.yml
+  tags: [config, base_hostname_config]
+
+- name: Validate
+  ansible.builtin.import_tasks: validate.yml
+  tags: [validate, base_hostname_validate]

--- a/roles/base_hostname/tasks/validate.yml
+++ b/roles/base_hostname/tasks/validate.yml
@@ -1,0 +1,24 @@
+---
+# roles/base_hostname/tasks/validate.yml
+# Validate phase tasks for the `base_hostname` role.
+# Verifies the current short hostname and the managed `/etc/hostname` contents.
+
+- name: "Validate | Read /etc/hostname"
+  ansible.builtin.slurp:
+    path: /etc/hostname
+  register: base_hostname_file
+
+- name: "Validate | Read current short hostname"
+  ansible.builtin.command: hostname --short
+  register: base_hostname_current_short
+  changed_when: false
+
+- name: "Validate | Assert hostname state"
+  vars:
+    base_hostname_short_name: "{{ base_hostname_name.split('.', 1) | first }}"
+  ansible.builtin.assert:
+    that:
+      - (base_hostname_file.content | b64decode | trim) == base_hostname_name
+      - (base_hostname_current_short.stdout | trim) == base_hostname_short_name
+    fail_msg: "Configured hostname state does not match {{ base_hostname_name }}"
+    quiet: true


### PR DESCRIPTION
- Introduced `base_hostname` role to enforce system hostname during the base phase on Debian-family hosts.
- Added default variables, tasks for assert, config, and validate phases.
- Updated documentation and examples to include the new role and its usage.