### PR TITLE
Add base_sudo role for managing passwordless sudo policy during base phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,27 @@
 Release history for `ansible-roles`.
 Documents notable changes across repository structure, roles, examples, and documentation.
 
+## [v0.13.0]
+### Added
+- `roles/base_sudo/`: New role for enforcing recurring sudo policy during the base phase.
+- `roles/base_sudo/defaults/main.yml`: Added `base_sudo_packages`, `base_sudo_user`, and `base_sudo_group` defaults.
+- `roles/base_sudo/tasks/`: Added assert, install, config, and validate phase task files for Debian-family sudo management.
+- `roles/base_sudo/README.md`: Added role documentation for sudo management and direct usage.
+- `examples/inventory/group_vars/all/base_sudo.yml`: Added example sudo variables for the Debian-family example lab.
+
+### Changed
+- `roles/base_sudo/tasks/config.yml` and `roles/base_sudo/tasks/validate.yml`: Simplified the role to always enforce the managed passwordless sudo drop-in so the base phase keeps a stable, homelab-friendly sudo path.
+- `roles/base_sudo/tasks/assert.yml`: Removed the passwordless-toggle and confirmation-variable handling so validation stays focused on package, user, and group inputs.
+- `roles/base_sudo/README.md`, `examples/inventory/group_vars/all/base_sudo.yml`, and `README.md`: Updated the documentation to reflect the always-managed passwordless sudo behavior.
+- `roles/base/meta/main.yml`: Added `base_sudo` as a dependency of the `base` role with `base` and `base_sudo` tags.
+- `roles/base/README.md`: Updated base role documentation to reflect the `base_sudo` dependency, inputs, and active dependency order.
+- `examples/README.md` and `docs/01-examples.md`: Updated the example documentation to include the new `base_sudo.yml` role-scoped variables file.
+- `docs/02-role-workflow.md`: Updated the documented aggregate base-role order so `base_sudo` is part of the active sequence and removed it from the future placeholder order.
+
+### Fixed
+- `roles/base_sudo/tasks/assert.yml` and `roles/base_sudo/tasks/config.yml`: Fail early when `base_sudo_user` does not already exist so the role enforces sudo policy for an existing account instead of silently creating one.
+- `README.md`: Restored `base_locale` to the aggregate `base` role description so the top-level dependency summary matches the implemented role order.
+
 ## [v0.12.0]
 ### Added
 - `roles/base_hostname/`: New role for enforcing the system hostname during the base phase.
@@ -16,6 +37,7 @@ Documents notable changes across repository structure, roles, examples, and docu
 - `roles/base/README.md`: Updated base role documentation to reflect the `base_hostname` dependency and inputs.
 - `README.md`: Added `base_hostname` to the available roles list and aligned the `base` role description.
 - `examples/README.md` and `docs/01-examples.md`: Updated the example documentation to include the new `base_hostname.yml` role-scoped variables file.
+- `roles/base/meta/main.yml`, `roles/base/README.md`, and `docs/02-role-workflow.md`: Documented and aligned the aggregate base-role execution order as packages, locale, timezone, NTP, then hostname, followed by the planned future base roles.
 
 ### Fixed
 - `roles/base_hostname/tasks/assert.yml`: Tightened hostname validation to require real DNS-style hostname labels instead of only rejecting whitespace and edge punctuation.

--- a/README.md
+++ b/README.md
@@ -29,10 +29,11 @@ ansible-roles/
 
 ## Available Roles
 - `bootstrap`: Creates and validates the automation account used after the bootstrap phase.
-- `base`: Aggregates recurring base-phase configuration for Debian-family hosts through dependency roles such as `base_packages`, `base_hostname`, `base_ntp`, and `base_timezone`.
+- `base`: Aggregates recurring base-phase configuration for Debian-family hosts through dependency roles such as `base_packages`, `base_locale`, `base_hostname`, `base_ntp`, `base_sudo`, and `base_timezone`.
 - `base_hostname`: Enforces the system hostname on Debian-family hosts during the base phase.
 - `base_locale`: Ensures requested locales exist and configures the system default locale on Debian-family hosts during the base phase.
 - `base_ntp`: Configures system time synchronization through `systemd-timesyncd` on Debian-family hosts during the base phase.
+- `base_sudo`: Enforces recurring sudo-group membership and a managed passwordless sudo policy on Debian-family hosts during the base phase.
 - `base_timezone`: Enforces the system timezone on Debian-family hosts during the base phase.
 - `monitoring`: Aggregates monitoring-related configuration through dependency roles such as `monitoring_authorized_key`.
 - `monitoring_authorized_key`: Installs an SSH authorized key for monitoring-style inter-host access.

--- a/docs/01-examples.md
+++ b/docs/01-examples.md
@@ -51,7 +51,7 @@ ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/base.yml
 
 - The lab content is intentionally simple and meant as an example baseline.
 - The example inventory and variables assume Debian-family hosts and the repository's APT-based role behavior.
-- `group_vars/all/` is split by role prefix so example variables such as `base_packages.yml`, `base_hostname.yml`, `base_locale.yml`, `base_ntp.yml`, and `base_timezone.yml` stay readable as the base stack grows.
+- `group_vars/all/` is split by role prefix so example variables such as `base_packages.yml`, `base_hostname.yml`, `base_locale.yml`, `base_ntp.yml`, `base_sudo.yml`, and `base_timezone.yml` stay readable as the base stack grows.
 - `hosts.ini` keeps default `ansible_user=ansible` in `[all:vars]`, while `[bootstrap:vars]` holds initial login values used only during bootstrap.
 - `playbooks/bootstrap.yml` prompts once for the bootstrap password and reuses it for both SSH login and sudo.
 - Extend the inventory, vars, and playbooks to fit your own infrastructure and test scope.

--- a/docs/02-role-workflow.md
+++ b/docs/02-role-workflow.md
@@ -65,6 +65,29 @@ If a role manages one narrow piece of state, keep the phase structure but reduce
 
 Use this compact style when it improves readability and reduces task noise without hiding important state changes.
 
+## Aggregate Base Order
+
+The aggregate `base` role in this repository applies its dependency roles in a stable order.
+
+Current order:
+
+1. `base_packages`
+2. `base_locale`
+3. `base_timezone`
+4. `base_ntp`
+5. `base_hostname`
+6. `base_sudo`
+
+Use this sequence to keep foundational packages and environment settings first, then time synchronization, then final host identity and sudo policy.
+
+Planned future additions should follow after the current foundational roles:
+
+1. `base_sshd`
+2. `base_firewall`
+3. `base_logging`
+4. `base_updates`
+5. `base_apparmor`
+
 ## Tag Usage
 
 Run specific phases during development or troubleshooting:

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,7 +10,7 @@ The inventory variables and role inputs assume the repository's Debian-family de
 ## Structure
 - `ansible.cfg`: Test-specific Ansible configuration.
 - `inventory/hosts.ini`: Test inventory.
-- `inventory/group_vars/all/`: Shared variables for test hosts, split into per-role files such as `bootstrap.yml`, `base_packages.yml`, `base_hostname.yml`, `base_locale.yml`, `base_ntp.yml`, and `base_timezone.yml`.
+- `inventory/group_vars/all/`: Shared variables for test hosts, split into per-role files such as `bootstrap.yml`, `base_packages.yml`, `base_hostname.yml`, `base_locale.yml`, `base_ntp.yml`, `base_sudo.yml`, and `base_timezone.yml`.
 - `playbooks/bootstrap.yml`: Bootstrap phase playbook that connects with the initial admin account and applies the standalone `bootstrap` role.
 - `playbooks/base.yml`: Base phase playbook that connects as the automation account and applies the `base` role.
 - `playbooks/site.yml`: Base-phase entry playbook that imports `base.yml`.

--- a/examples/inventory/group_vars/all/base_sudo.yml
+++ b/examples/inventory/group_vars/all/base_sudo.yml
@@ -1,0 +1,14 @@
+---
+# examples/inventory/group_vars/all/base_sudo.yml
+# Shared sudo variables for the example lab.
+# Defines the sudo package, managed user, and sudo group enforced during the base phase.
+
+# Package list installed with APT to provide sudo on the host.
+base_sudo_packages:
+  - sudo             # privilege escalation package used by the base_sudo role
+
+# Automation user that must remain in the sudo-capable group.
+base_sudo_user: ansible
+
+# Sudo-capable group enforced during the base phase.
+base_sudo_group: sudo

--- a/roles/base/README.md
+++ b/roles/base/README.md
@@ -6,7 +6,7 @@ Explains how the aggregate base role delegates recurring Debian-family host conf
 ## Features
 - Runs the recurring base configuration on every `base` execution
 - Keeps orchestration in `roles/base/meta/main.yml`
-- Includes `base_packages`, `base_hostname`, `base_locale`, `base_ntp`, and `base_timezone` through role dependencies
+- Includes `base_packages`, `base_locale`, `base_timezone`, `base_ntp`, `base_hostname`, and `base_sudo` through role dependencies
 
 ## Usage
 Use `base` on Debian-family hosts after the bootstrap phase has already created the automation account:
@@ -19,7 +19,26 @@ Use `base` on Debian-family hosts after the bootstrap phase has already created 
 ```
 
 Bootstrap is handled separately by the standalone `bootstrap` role/playbook.
-Role-specific inputs for `base` currently come from `base_packages_*`, `base_hostname_*`, `base_locale_*`, `base_ntp_*`, and `base_timezone_*`.
+Role-specific inputs for `base` currently come from `base_packages_*`, `base_hostname_*`, `base_locale_*`, `base_ntp_*`, `base_sudo_*`, and `base_timezone_*`.
+
+Current dependency order in `base` is:
+
+1. `base_packages`
+2. `base_locale`
+3. `base_timezone`
+4. `base_ntp`
+5. `base_hostname`
+6. `base_sudo`
+
+This keeps foundational packages and system environment first, then time synchronization, then final host identity and sudo policy.
+
+Planned future dependency order after the current roles is:
+
+1. `base_sshd`
+2. `base_firewall`
+3. `base_logging`
+4. `base_updates`
+5. `base_apparmor`
 
 ## License
 MIT

--- a/roles/base/meta/main.yml
+++ b/roles/base/meta/main.yml
@@ -6,17 +6,18 @@
 dependencies:
   - role: base_packages
     tags: [base, base_packages]
-  - role: base_hostname
-    tags: [base, base_hostname]
   - role: base_locale
     tags: [base, base_locale]
-  - role: base_ntp
-    tags: [base, base_ntp]
   - role: base_timezone
     tags: [base, base_timezone]
+  - role: base_ntp
+    tags: [base, base_ntp]
+  - role: base_hostname
+    tags: [base, base_hostname]
+  - role: base_sudo
+    tags: [base, base_sudo]
 
 # Future base dependencies:
-# - role: base_sudo
 # - role: base_sshd
 # - role: base_firewall
 # - role: base_logging

--- a/roles/base_sudo/README.md
+++ b/roles/base_sudo/README.md
@@ -1,0 +1,51 @@
+# roles/base_sudo/README.md
+
+Reference for the `base_sudo` role.
+Explains how the role enforces recurring sudo policy for the managed automation user on Debian-family hosts during the base phase.
+
+## Features
+- Installs the sudo package with APT before policy configuration
+- Validates the requested sudo package, user, and group inputs
+- Requires the managed user to already exist before sudo policy changes are applied
+- Ensures the managed user is a member of the configured sudo group
+- Manages `/etc/sudoers.d/90-<user>` for passwordless sudo
+- Verifies group membership and managed sudoers drop-in state after changes
+
+## Variables
+
+| Variable | Default | Required | Description |
+|----------|---------|----------|-------------|
+| `base_sudo_packages` | `['sudo']` | no | Package list installed with APT to provide sudo |
+| `base_sudo_user` | `ansible` | no | Existing user that must remain in the configured sudo group |
+| `base_sudo_group` | `sudo` | no | Sudo-capable group enforced by the role |
+
+## Usage
+
+The `base` role includes `base_sudo` through meta dependencies.
+Use it after bootstrap or another account-creation step has already created `base_sudo_user`.
+The role always enforces passwordless sudo for the managed user so Ansible base-phase runs keep working without a separate become password flow.
+
+Direct usage:
+
+```yaml
+- hosts: all
+  become: true
+  roles:
+    - base_sudo
+```
+
+Example variables:
+
+```yaml
+base_sudo_user: ansible
+base_sudo_group: sudo
+```
+
+## Dependencies
+None
+
+## License
+MIT
+
+## Author
+Tatbyte

--- a/roles/base_sudo/defaults/main.yml
+++ b/roles/base_sudo/defaults/main.yml
@@ -1,0 +1,9 @@
+---
+# roles/base_sudo/defaults/main.yml
+# Default variables for the `base_sudo` role.
+# Defines the sudo package, managed user, and sudo group enforced during the base phase.
+
+base_sudo_packages:
+  - sudo
+base_sudo_user: ansible
+base_sudo_group: sudo

--- a/roles/base_sudo/tasks/assert.yml
+++ b/roles/base_sudo/tasks/assert.yml
@@ -1,0 +1,27 @@
+---
+# roles/base_sudo/tasks/assert.yml
+# Assert phase tasks for the `base_sudo` role.
+# Validates the requested sudo package, user, and group inputs before installation and configuration run.
+
+- name: "Assert | Validate base_sudo variable structure"
+  ansible.builtin.assert:
+    that:
+      - base_sudo_packages is sequence
+      - base_sudo_packages is not string
+      - base_sudo_user is string
+      - base_sudo_user | trim | length > 0
+      - base_sudo_group is string
+      - base_sudo_group | trim | length > 0
+      - (base_sudo_packages | map('string') | list | length) == (base_sudo_packages | length)
+      - (base_sudo_packages | map('trim') | reject('equalto', '') | list | length) == (base_sudo_packages | length)
+      - base_sudo_user == (base_sudo_user | trim)
+      - base_sudo_group == (base_sudo_group | trim)
+    fail_msg: >-
+      base_sudo_packages must be a list of package names, and base_sudo_user
+      and base_sudo_group must be non-empty strings
+    quiet: true
+
+- name: "Assert | Require managed user to exist"
+  ansible.builtin.getent:
+    database: passwd
+    key: "{{ base_sudo_user }}"

--- a/roles/base_sudo/tasks/config.yml
+++ b/roles/base_sudo/tasks/config.yml
@@ -1,0 +1,29 @@
+---
+# roles/base_sudo/tasks/config.yml
+# Config phase tasks for the `base_sudo` role.
+# Ensures the managed user stays in the sudo group and always has the managed passwordless sudo drop-in.
+
+- name: "Config | Ensure sudo group exists"
+  ansible.builtin.group:
+    name: "{{ base_sudo_group }}"
+    state: present
+
+- name: "Config | Confirm managed user exists"
+  ansible.builtin.getent:
+    database: passwd
+    key: "{{ base_sudo_user }}"
+
+- name: "Config | Ensure user is in sudo group"
+  ansible.builtin.user:
+    name: "{{ base_sudo_user }}"
+    groups: "{{ base_sudo_group }}"
+    append: true
+
+- name: "Config | Allow passwordless sudo for managed user"
+  ansible.builtin.copy:
+    dest: "/etc/sudoers.d/90-{{ base_sudo_user }}"
+    content: "{{ base_sudo_user }} ALL=(ALL:ALL) NOPASSWD:ALL\n"
+    owner: root
+    group: root
+    mode: "0440"
+    validate: "visudo -cf %s"

--- a/roles/base_sudo/tasks/install.yml
+++ b/roles/base_sudo/tasks/install.yml
@@ -1,0 +1,12 @@
+---
+# roles/base_sudo/tasks/install.yml
+# Install phase tasks for the `base_sudo` role.
+# Ensures the sudo package is present with APT before sudo policy configuration.
+
+- name: "Install | Ensure sudo packages are present"
+  ansible.builtin.apt:
+    name: "{{ base_sudo_packages }}"
+    state: present
+    update_cache: true
+    cache_valid_time: 3600
+  when: base_sudo_packages | length > 0

--- a/roles/base_sudo/tasks/main.yml
+++ b/roles/base_sudo/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+# roles/base_sudo/tasks/main.yml
+# Task entrypoint for the `base_sudo` role.
+# Imports the assert, install, config, and validate phase files in order.
+
+- name: Assert
+  ansible.builtin.import_tasks: assert.yml
+  tags: [assert, base_sudo_assert]
+
+- name: Install
+  ansible.builtin.import_tasks: install.yml
+  tags: [install, base_sudo_install]
+
+- name: Config
+  ansible.builtin.import_tasks: config.yml
+  tags: [config, base_sudo_config]
+
+- name: Validate
+  ansible.builtin.import_tasks: validate.yml
+  tags: [validate, base_sudo_validate]

--- a/roles/base_sudo/tasks/validate.yml
+++ b/roles/base_sudo/tasks/validate.yml
@@ -1,0 +1,43 @@
+---
+# roles/base_sudo/tasks/validate.yml
+# Validate phase tasks for the `base_sudo` role.
+# Verifies the managed user membership in the sudo group and the managed passwordless sudo drop-in state.
+
+- name: "Validate | Collect managed user and sudo group entries"
+  ansible.builtin.getent:
+    database: "{{ item.database }}"
+    key: "{{ item.key }}"
+  loop:
+    - database: passwd
+      key: "{{ base_sudo_user }}"
+    - database: group
+      key: "{{ base_sudo_group }}"
+  loop_control:
+    label: "{{ item.database }}"
+  register: base_sudo_lookup
+
+- name: "Validate | Read passwordless sudo drop-in"
+  ansible.builtin.slurp:
+    path: "/etc/sudoers.d/90-{{ base_sudo_user }}"
+  register: base_sudo_drop_in
+  changed_when: false
+
+- name: "Validate | Assert sudo state"
+  ansible.builtin.assert:
+    that:
+      - base_sudo_user in base_sudo_lookup.results[0].ansible_facts.getent_passwd
+      - base_sudo_group in base_sudo_lookup.results[1].ansible_facts.getent_group
+      - base_sudo_user in (
+          base_sudo_lookup.results[1].ansible_facts.getent_group[base_sudo_group]
+          | last
+          | default('')
+          | string
+          | split(',')
+          | map('trim')
+          | reject('equalto', '')
+          | list
+        )
+      - (base_sudo_drop_in.content | b64decode) ==
+        (base_sudo_user ~ ' ALL=(ALL:ALL) NOPASSWD:ALL\n')
+    fail_msg: "Configured sudo state does not match the requested base_sudo values"
+    quiet: true


### PR DESCRIPTION
- Introduced `base_sudo` role with tasks for installation, configuration, and validation of sudo settings.
- Updated documentation to include `base_sudo` in role descriptions and examples.
- Adjusted aggregate base role order to include `base_sudo`.
- Added example variables for `base_sudo` in the inventory.