### PR TITLE
Add base_sshd role for managing SSH daemon baseline during base phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,35 @@
 Release history for `ansible-roles`.
 Documents notable changes across repository structure, roles, examples, and documentation.
 
+## [v0.14.0]
+### Added
+- `roles/base_sshd/`: New role for enforcing an SSH daemon baseline during the base phase.
+- `roles/base_sshd/defaults/main.yml`: Added `base_sshd_packages`, `base_sshd_service_name`, `base_sshd_port`, `base_sshd_permit_root_login`, `base_sshd_password_authentication`, `base_sshd_pubkey_authentication`, and `base_sshd_allow_users` defaults.
+- `roles/base_sshd/tasks/`: Added assert, install, config, and validate phase task files for Debian-family SSH daemon management.
+- `roles/base_sshd/handlers/main.yml`: Added a handler that restarts the managed SSH service after drop-in changes.
+- `roles/base_sshd/templates/sshd_base.conf.j2`: Added a template for the managed `/etc/ssh/sshd_config.d/90-base-sshd.conf` drop-in.
+- `roles/base_sshd/README.md`: Added role documentation for SSH daemon management and direct usage.
+- `examples/inventory/group_vars/all/base_sshd.yml`: Added example SSH daemon variables for the Debian-family example lab.
+- `examples/playbooks/test_base_sshd.yml`: Added an example integration test playbook that temporarily creates extra SSH daemon fragments to exercise merged `AllowUsers` and `Match User` behavior around `base_sshd`.
+
+### Changed
+- `roles/base/meta/main.yml`: Added `base_sshd` as a dependency of the `base` role with `base` and `base_sshd` tags.
+- `roles/base/README.md`: Updated base role documentation to reflect the `base_sshd` dependency, inputs, and active dependency order.
+- `README.md`: Added `base_sshd` to the available roles list and aligned the `base` role description.
+- `examples/README.md`, `docs/01-examples.md`, and `README.md`: Updated the example documentation to include the new `base_sshd.yml` role-scoped variables file and the optional `base_sshd` integration test playbook.
+- `docs/02-role-workflow.md`: Updated the documented aggregate base-role order so `base_sshd` is part of the active sequence and removed it from the future placeholder order.
+
+### Fixed
+- `roles/base_sshd/tasks/validate.yml`, `roles/base_sshd/README.md`, and `examples/inventory/group_vars/all/base_sshd.yml`: Validation and documentation now treat `AllowUsers` as effective SSH daemon state instead of implying that an empty `base_sshd_allow_users` list clears constraints defined elsewhere.
+- `roles/base_sshd/tasks/validate.yml`: Normalized `sshd -T` `AllowUsers` parsing so validation compares the full effective user list instead of only the first reported entry.
+- `roles/base_sshd/tasks/validate.yml`: Relaxed `AllowUsers` validation so the role confirms its required users are present after OpenSSH merges config sources instead of requiring this drop-in to own the complete effective list.
+- `roles/base_sshd/tasks/validate.yml`: Runs `sshd -T` with a representative `-C` connection context and ignores duplicated `allowusers` tokens in merged output so validation behaves better on hosts with `Match` rules or accumulated `AllowUsers` entries.
+- `roles/base_sshd/tasks/validate.yml`: Validates `AllowUsers` per required user context with `sshd -T -C` and checks the reported values without discarding the literal `allowusers` string as a special-case token.
+- `roles/base_sshd/tasks/validate.yml` and `examples/playbooks/test_base_sshd.yml`: Use an IP-only fallback for `sshd -T -C addr=` so validation does not depend on `ansible_host` being an address.
+- `examples/playbooks/test_base_sshd.yml`: Applies `base_sshd` before writing temporary SSH fixture fragments so the integration test still works when `/etc/ssh/sshd_config.d/` does not exist yet.
+- `roles/base_sshd/tasks/validate.yml`: Validates baseline SSH daemon settings with `sshd -T` without a connection-specific context so external `Match` rules do not cause false failures in the role's general setting checks.
+- `examples/playbooks/test_base_sshd.yml`, `examples/README.md`, and `docs/01-examples.md`: Expanded the `base_sshd` integration coverage to exercise a temporary `Match Address` fixture in addition to merged `AllowUsers` and `Match User`.
+
 ## [v0.13.0]
 ### Added
 - `roles/base_sudo/`: New role for enforcing recurring sudo policy during the base phase.

--- a/README.md
+++ b/README.md
@@ -29,11 +29,12 @@ ansible-roles/
 
 ## Available Roles
 - `bootstrap`: Creates and validates the automation account used after the bootstrap phase.
-- `base`: Aggregates recurring base-phase configuration for Debian-family hosts through dependency roles such as `base_packages`, `base_locale`, `base_hostname`, `base_ntp`, `base_sudo`, and `base_timezone`.
+- `base`: Aggregates recurring base-phase configuration for Debian-family hosts through dependency roles such as `base_packages`, `base_locale`, `base_hostname`, `base_ntp`, `base_sudo`, `base_sshd`, and `base_timezone`.
 - `base_hostname`: Enforces the system hostname on Debian-family hosts during the base phase.
 - `base_locale`: Ensures requested locales exist and configures the system default locale on Debian-family hosts during the base phase.
 - `base_ntp`: Configures system time synchronization through `systemd-timesyncd` on Debian-family hosts during the base phase.
 - `base_sudo`: Enforces recurring sudo-group membership and a managed passwordless sudo policy on Debian-family hosts during the base phase.
+- `base_sshd`: Enforces a managed SSH daemon baseline through a dedicated `sshd_config.d` drop-in on Debian-family hosts during the base phase.
 - `base_timezone`: Enforces the system timezone on Debian-family hosts during the base phase.
 - `monitoring`: Aggregates monitoring-related configuration through dependency roles such as `monitoring_authorized_key`.
 - `monitoring_authorized_key`: Installs an SSH authorized key for monitoring-style inter-host access.
@@ -85,6 +86,12 @@ Then run the base phase:
 
 ```sh
 ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/site.yml
+```
+
+Optional `base_sshd` integration check:
+
+```sh
+ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/test_base_sshd.yml --tags base_sshd
 ```
 
 Or from the `examples/` directory:

--- a/docs/01-examples.md
+++ b/docs/01-examples.md
@@ -23,6 +23,7 @@ The example content assumes Debian-family targets such as Debian and Ubuntu.
 - `examples/playbooks/bootstrap.yml`: Bootstrap phase playbook that uses initial host credentials and applies the standalone `bootstrap` role.
 - `examples/playbooks/base.yml`: Base phase playbook for post-bootstrap role execution.
 - `examples/playbooks/site.yml`: Base-phase entry playbook that imports `base.yml`.
+- `examples/playbooks/test_base_sshd.yml`: Optional integration test playbook for exercising merged `sshd_config.d` fragments plus `Match User` and `Match Address` behavior around the `base_sshd` role.
 
 ## How to Use the Example
 
@@ -47,11 +48,18 @@ Equivalent direct base-phase command:
 ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/base.yml
 ```
 
+Optional `base_sshd` integration check:
+
+```bash
+ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/test_base_sshd.yml --tags base_sshd
+```
+
 ## Notes
 
 - The lab content is intentionally simple and meant as an example baseline.
 - The example inventory and variables assume Debian-family hosts and the repository's APT-based role behavior.
-- `group_vars/all/` is split by role prefix so example variables such as `base_packages.yml`, `base_hostname.yml`, `base_locale.yml`, `base_ntp.yml`, `base_sudo.yml`, and `base_timezone.yml` stay readable as the base stack grows.
+- `group_vars/all/` is split by role prefix so example variables such as `base_packages.yml`, `base_hostname.yml`, `base_locale.yml`, `base_ntp.yml`, `base_sudo.yml`, `base_sshd.yml`, and `base_timezone.yml` stay readable as the base stack grows.
 - `hosts.ini` keeps default `ansible_user=ansible` in `[all:vars]`, while `[bootstrap:vars]` holds initial login values used only during bootstrap.
 - `playbooks/bootstrap.yml` prompts once for the bootstrap password and reuses it for both SSH login and sudo.
+- `playbooks/test_base_sshd.yml` removes its temporary SSH fixture files in an `always` block after the integration run, so the example host is returned to the normal post-test state.
 - Extend the inventory, vars, and playbooks to fit your own infrastructure and test scope.

--- a/docs/02-role-workflow.md
+++ b/docs/02-role-workflow.md
@@ -77,16 +77,16 @@ Current order:
 4. `base_ntp`
 5. `base_hostname`
 6. `base_sudo`
+7. `base_sshd`
 
-Use this sequence to keep foundational packages and environment settings first, then time synchronization, then final host identity and sudo policy.
+Use this sequence to keep foundational packages and environment settings first, then time synchronization, then final host identity, sudo policy, and SSH daemon policy.
 
 Planned future additions should follow after the current foundational roles:
 
-1. `base_sshd`
-2. `base_firewall`
-3. `base_logging`
-4. `base_updates`
-5. `base_apparmor`
+1. `base_firewall`
+2. `base_logging`
+3. `base_updates`
+4. `base_apparmor`
 
 ## Tag Usage
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,10 +10,11 @@ The inventory variables and role inputs assume the repository's Debian-family de
 ## Structure
 - `ansible.cfg`: Test-specific Ansible configuration.
 - `inventory/hosts.ini`: Test inventory.
-- `inventory/group_vars/all/`: Shared variables for test hosts, split into per-role files such as `bootstrap.yml`, `base_packages.yml`, `base_hostname.yml`, `base_locale.yml`, `base_ntp.yml`, `base_sudo.yml`, and `base_timezone.yml`.
+- `inventory/group_vars/all/`: Shared variables for test hosts, split into per-role files such as `bootstrap.yml`, `base_packages.yml`, `base_hostname.yml`, `base_locale.yml`, `base_ntp.yml`, `base_sudo.yml`, `base_sshd.yml`, and `base_timezone.yml`.
 - `playbooks/bootstrap.yml`: Bootstrap phase playbook that connects with the initial admin account and applies the standalone `bootstrap` role.
 - `playbooks/base.yml`: Base phase playbook that connects as the automation account and applies the `base` role.
 - `playbooks/site.yml`: Base-phase entry playbook that imports `base.yml`.
+- `playbooks/test_base_sshd.yml`: Integration test playbook that temporarily adds extra SSH daemon fragments, runs `base_sshd`, verifies merged `AllowUsers` plus `Match User` and `Match Address` behavior, and removes the temporary fixtures.
 
 ## Usage
 Run bootstrap from repository root:
@@ -40,6 +41,14 @@ Equivalent direct base-phase command:
 ```sh
 ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/base.yml
 ```
+
+Optional `base_sshd` integration check:
+
+```sh
+ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/test_base_sshd.yml --tags base_sshd
+```
+
+The SSH integration test playbook cleans up its temporary `/etc/ssh/sshd_config.d/` fixture files in an `always` block, so you do not need to remove them manually after the run.
 
 ## Bootstrap Credentials
 The example inventory stores only the bootstrap login user:

--- a/examples/inventory/group_vars/all/base_sshd.yml
+++ b/examples/inventory/group_vars/all/base_sshd.yml
@@ -1,0 +1,30 @@
+---
+# examples/inventory/group_vars/all/base_sshd.yml
+# Shared SSH daemon variables for the example lab.
+# Defines the SSH daemon package, service, and managed policy enforced during the base phase.
+
+# Package list installed with APT to provide the SSH daemon on the host.
+base_sshd_packages:
+  - openssh-server    # OpenSSH server package for Debian-family hosts
+
+# SSH service name enabled and validated by the role.
+base_sshd_service_name: ssh
+
+# TCP port enforced in the managed SSH daemon drop-in.
+base_sshd_port: 22
+
+# Root-login policy written to PermitRootLogin.
+base_sshd_permit_root_login: "no"
+
+# Keep password authentication enabled in the example lab unless you are ready
+# to rely only on authorized keys for every allowed login path.
+base_sshd_password_authentication: true
+
+# Keep public-key authentication enabled for the automation account.
+base_sshd_pubkey_authentication: true
+
+# Optional login allow-list for the example lab. The role validates that these
+# users are present in the effective AllowUsers result after SSH config merge.
+base_sshd_allow_users:
+  - ansible
+  - admin

--- a/examples/playbooks/test_base_sshd.yml
+++ b/examples/playbooks/test_base_sshd.yml
@@ -1,0 +1,121 @@
+---
+# examples/playbooks/test_base_sshd.yml
+# Integration test playbook for the `base_sshd` role in the example lab.
+# Exercises merged `sshd_config.d` fragments plus `Match User` and `Match Address` behavior, then removes the temporary fixture files.
+
+- name: Exercise base_sshd integration scenarios
+  hosts: all
+  become: true
+  vars:
+    base_sshd_test_host: "{{ inventory_hostname }}"
+    base_sshd_test_addr: >-
+      {{
+        ansible_default_ipv4.address
+        | default(ansible_all_ipv4_addresses | default([]) | first, true)
+        | default('127.0.0.1', true)
+      }}
+  tasks:
+    - name: Test base_sshd integration behavior
+      tags: [base_sshd]
+      block:
+        - name: "Test | Apply base_sshd role for baseline state"
+          ansible.builtin.include_role:
+            name: base_sshd
+
+        - name: "Fixture | Add extra AllowUsers fragment"
+          ansible.builtin.copy:
+            dest: /etc/ssh/sshd_config.d/10-test-extra-allowusers.conf
+            content: |
+              AllowUsers admin
+            owner: root
+            group: root
+            mode: "0644"
+
+        - name: "Fixture | Add Match User fragment"
+          ansible.builtin.copy:
+            dest: /etc/ssh/sshd_config.d/20-test-match-user.conf
+            content: |
+              Match User backup
+                  PasswordAuthentication no
+            owner: root
+            group: root
+            mode: "0644"
+
+        - name: "Fixture | Add Match Address fragment"
+          ansible.builtin.copy:
+            dest: /etc/ssh/sshd_config.d/30-test-match-address.conf
+            content: |
+              Match Address {{ base_sshd_test_addr }}
+                  PubkeyAuthentication no
+            owner: root
+            group: root
+            mode: "0644"
+
+        - name: "Fixture | Validate SSH daemon syntax"
+          ansible.builtin.command: sshd -t -f /etc/ssh/sshd_config
+          changed_when: false
+
+        - name: "Fixture | Restart SSH service"
+          ansible.builtin.service:
+            name: "{{ base_sshd_service_name }}"
+            state: restarted
+
+        - name: "Test | Apply base_sshd role"
+          ansible.builtin.include_role:
+            name: base_sshd
+
+        - name: "Test | Read effective SSH daemon settings for backup"
+          ansible.builtin.command: >-
+            sshd -T -f /etc/ssh/sshd_config
+            -C user=backup,host={{ base_sshd_test_host }},addr={{ base_sshd_test_addr }}
+          register: base_sshd_test_backup_effective_config
+          changed_when: false
+
+        - name: "Test | Assert Match User behavior remains effective"
+          ansible.builtin.assert:
+            that:
+              - "'passwordauthentication no' in base_sshd_test_backup_effective_config.stdout_lines"
+            fail_msg: >-
+              The temporary Match User fixture is not effective for the backup
+              user after base_sshd convergence
+            quiet: true
+
+        - name: "Test | Read effective SSH daemon settings for address match"
+          ansible.builtin.command: >-
+            sshd -T -f /etc/ssh/sshd_config
+            -C user=ansible,host={{ base_sshd_test_host }},addr={{ base_sshd_test_addr }}
+          register: base_sshd_test_address_effective_config
+          changed_when: false
+
+        - name: "Test | Assert Match Address behavior remains effective"
+          ansible.builtin.assert:
+            that:
+              - "'pubkeyauthentication no' in base_sshd_test_address_effective_config.stdout_lines"
+            fail_msg: >-
+              The temporary Match Address fixture is not effective for the test
+              address after base_sshd convergence
+            quiet: true
+      always:
+        - name: "Cleanup | Remove AllowUsers test fragment"
+          ansible.builtin.file:
+            path: /etc/ssh/sshd_config.d/10-test-extra-allowusers.conf
+            state: absent
+
+        - name: "Cleanup | Remove Match User test fragment"
+          ansible.builtin.file:
+            path: /etc/ssh/sshd_config.d/20-test-match-user.conf
+            state: absent
+
+        - name: "Cleanup | Remove Match Address test fragment"
+          ansible.builtin.file:
+            path: /etc/ssh/sshd_config.d/30-test-match-address.conf
+            state: absent
+
+        - name: "Cleanup | Validate SSH daemon syntax"
+          ansible.builtin.command: sshd -t -f /etc/ssh/sshd_config
+          changed_when: false
+
+        - name: "Cleanup | Restart SSH service"
+          ansible.builtin.service:
+            name: "{{ base_sshd_service_name }}"
+            state: restarted

--- a/roles/base/README.md
+++ b/roles/base/README.md
@@ -6,7 +6,7 @@ Explains how the aggregate base role delegates recurring Debian-family host conf
 ## Features
 - Runs the recurring base configuration on every `base` execution
 - Keeps orchestration in `roles/base/meta/main.yml`
-- Includes `base_packages`, `base_locale`, `base_timezone`, `base_ntp`, `base_hostname`, and `base_sudo` through role dependencies
+- Includes `base_packages`, `base_locale`, `base_timezone`, `base_ntp`, `base_hostname`, `base_sudo`, and `base_sshd` through role dependencies
 
 ## Usage
 Use `base` on Debian-family hosts after the bootstrap phase has already created the automation account:
@@ -19,7 +19,7 @@ Use `base` on Debian-family hosts after the bootstrap phase has already created 
 ```
 
 Bootstrap is handled separately by the standalone `bootstrap` role/playbook.
-Role-specific inputs for `base` currently come from `base_packages_*`, `base_hostname_*`, `base_locale_*`, `base_ntp_*`, `base_sudo_*`, and `base_timezone_*`.
+Role-specific inputs for `base` currently come from `base_packages_*`, `base_hostname_*`, `base_locale_*`, `base_ntp_*`, `base_sudo_*`, `base_sshd_*`, and `base_timezone_*`.
 
 Current dependency order in `base` is:
 
@@ -29,16 +29,16 @@ Current dependency order in `base` is:
 4. `base_ntp`
 5. `base_hostname`
 6. `base_sudo`
+7. `base_sshd`
 
-This keeps foundational packages and system environment first, then time synchronization, then final host identity and sudo policy.
+This keeps foundational packages and system environment first, then time synchronization, then final host identity, sudo policy, and SSH daemon policy.
 
 Planned future dependency order after the current roles is:
 
-1. `base_sshd`
-2. `base_firewall`
-3. `base_logging`
-4. `base_updates`
-5. `base_apparmor`
+1. `base_firewall`
+2. `base_logging`
+3. `base_updates`
+4. `base_apparmor`
 
 ## License
 MIT

--- a/roles/base/meta/main.yml
+++ b/roles/base/meta/main.yml
@@ -16,9 +16,10 @@ dependencies:
     tags: [base, base_hostname]
   - role: base_sudo
     tags: [base, base_sudo]
+  - role: base_sshd
+    tags: [base, base_sshd]
 
 # Future base dependencies:
-# - role: base_sshd
 # - role: base_firewall
 # - role: base_logging
 # - role: base_updates

--- a/roles/base_sshd/README.md
+++ b/roles/base_sshd/README.md
@@ -1,0 +1,62 @@
+# roles/base_sshd/README.md
+
+Reference for the `base_sshd` role.
+Explains how the role manages a Debian-family SSH daemon baseline during the base phase.
+
+## Features
+- Installs the OpenSSH server package with APT before SSH daemon configuration
+- Validates the requested SSH package, service, port, login-policy, and user-list inputs
+- Manages `/etc/ssh/sshd_config.d/90-base-sshd.conf` as a dedicated base-phase drop-in
+- Validates SSH daemon syntax before the managed service is restarted
+- Ensures the SSH service is enabled and running
+- Verifies the managed drop-in contents and key effective SSH daemon settings after changes
+- Validates general SSH daemon settings against baseline `sshd -T` output and checks `AllowUsers` in per-user `sshd -T -C` contexts
+
+## Variables
+
+| Variable | Default | Required | Description |
+|----------|---------|----------|-------------|
+| `base_sshd_packages` | `['openssh-server']` | no | Package list installed with APT to provide the SSH daemon |
+| `base_sshd_service_name` | `ssh` | no | Service name enabled, restarted, and validated by the role |
+| `base_sshd_port` | `22` | no | TCP port enforced in the managed SSH daemon drop-in |
+| `base_sshd_permit_root_login` | `no` | no | Root-login policy written to `PermitRootLogin`; allowed values are `yes`, `no`, `prohibit-password`, and `forced-commands-only` |
+| `base_sshd_password_authentication` | `true` | no | Whether password authentication stays enabled in the managed SSH daemon drop-in |
+| `base_sshd_pubkey_authentication` | `true` | no | Whether public-key authentication stays enabled in the managed SSH daemon drop-in |
+| `base_sshd_allow_users` | `[]` | no | Optional login allow-list written to `AllowUsers`; when set, validation requires those users to be present in the effective `AllowUsers` result |
+
+## Usage
+
+The `base` role includes `base_sshd` through meta dependencies.
+
+Direct usage:
+
+```yaml
+- hosts: all
+  become: true
+  roles:
+    - base_sshd
+```
+
+Example variables:
+
+```yaml
+base_sshd_permit_root_login: "no"
+base_sshd_password_authentication: false
+base_sshd_pubkey_authentication: true
+base_sshd_allow_users:
+  - ansible
+```
+
+This role manages a dedicated drop-in under `/etc/ssh/sshd_config.d/` so Debian-family package defaults and other local drop-ins can stay separate from the base-phase policy.
+If `base_sshd_allow_users` is empty, this role does not add an `AllowUsers` line of its own; any existing `AllowUsers` setting from other SSH daemon config files remains outside this role's management.
+If `base_sshd_allow_users` is set, the role validates that those users are allowed after OpenSSH merges all config sources, but it does not require this role to be the only source of `AllowUsers` entries.
+General validation for settings such as `Port`, `PermitRootLogin`, `PasswordAuthentication`, and `PubkeyAuthentication` uses baseline `sshd -T` output rather than trying to validate every external `Match` rule interaction on the host.
+
+## Dependencies
+None
+
+## License
+MIT
+
+## Author
+Tatbyte

--- a/roles/base_sshd/defaults/main.yml
+++ b/roles/base_sshd/defaults/main.yml
@@ -1,0 +1,13 @@
+---
+# roles/base_sshd/defaults/main.yml
+# Default variables for the `base_sshd` role.
+# Defines the SSH daemon package, service, and managed policy values enforced during the base phase.
+
+base_sshd_packages:
+  - openssh-server
+base_sshd_service_name: ssh
+base_sshd_port: 22
+base_sshd_permit_root_login: "no"
+base_sshd_password_authentication: true
+base_sshd_pubkey_authentication: true
+base_sshd_allow_users: []

--- a/roles/base_sshd/handlers/main.yml
+++ b/roles/base_sshd/handlers/main.yml
@@ -1,0 +1,9 @@
+---
+# roles/base_sshd/handlers/main.yml
+# Handlers for the `base_sshd` role.
+# Restarts the SSH daemon when the managed base-phase drop-in changes.
+
+- name: Restart SSH service
+  ansible.builtin.service:
+    name: "{{ base_sshd_service_name }}"
+    state: restarted

--- a/roles/base_sshd/tasks/assert.yml
+++ b/roles/base_sshd/tasks/assert.yml
@@ -1,0 +1,41 @@
+---
+# roles/base_sshd/tasks/assert.yml
+# Assert phase tasks for the `base_sshd` role.
+# Validates the requested SSH daemon package, service, and managed policy inputs before installation and configuration run.
+
+- name: "Assert | Validate base_sshd variable structure"
+  ansible.builtin.assert:
+    that:
+      - base_sshd_packages is sequence
+      - base_sshd_packages is not string
+      - base_sshd_service_name is string
+      - base_sshd_service_name | trim | length > 0
+      - base_sshd_port is integer
+      - base_sshd_port >= 1
+      - base_sshd_port <= 65535
+      - base_sshd_permit_root_login is string
+      - base_sshd_permit_root_login in ['yes', 'no', 'prohibit-password', 'forced-commands-only']
+      - base_sshd_password_authentication is boolean
+      - base_sshd_pubkey_authentication is boolean
+      - base_sshd_allow_users is sequence
+      - base_sshd_allow_users is not string
+      - (base_sshd_packages | map('string') | list | length) == (base_sshd_packages | length)
+      - (base_sshd_allow_users | map('string') | list | length) == (base_sshd_allow_users | length)
+      - (base_sshd_packages | map('trim') | reject('equalto', '') | list | length) == (base_sshd_packages | length)
+      - (base_sshd_allow_users | map('trim') | reject('equalto', '') | list | length) == (base_sshd_allow_users | length)
+      - >-
+        (
+          base_sshd_allow_users
+          | reject('equalto', '')
+          | reject('match', '.*\\s+.*')
+          | list
+          | length
+        ) == (base_sshd_allow_users | length)
+    fail_msg: >-
+      base_sshd_packages must be a list of package names, base_sshd_service_name
+      must be a non-empty service name, base_sshd_port must be between 1 and
+      65535, base_sshd_permit_root_login must use a supported OpenSSH value,
+      base_sshd_password_authentication and base_sshd_pubkey_authentication
+      must be booleans, and base_sshd_allow_users must be a list of non-empty
+      user names without whitespace
+    quiet: true

--- a/roles/base_sshd/tasks/config.yml
+++ b/roles/base_sshd/tasks/config.yml
@@ -1,0 +1,34 @@
+---
+# roles/base_sshd/tasks/config.yml
+# Config phase tasks for the `base_sshd` role.
+# Manages the base-phase SSH daemon drop-in, validates syntax, and ensures the SSH service is enabled and running.
+
+- name: "Config | Ensure sshd drop-in directory exists"
+  ansible.builtin.file:
+    path: /etc/ssh/sshd_config.d
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: "Config | Render SSH daemon drop-in"
+  ansible.builtin.template:
+    src: sshd_base.conf.j2
+    dest: /etc/ssh/sshd_config.d/90-base-sshd.conf
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart SSH service
+
+- name: "Config | Validate SSH daemon syntax"
+  ansible.builtin.command: sshd -t -f /etc/ssh/sshd_config
+  changed_when: false
+
+- name: "Config | Ensure SSH service is enabled and running"
+  ansible.builtin.service:
+    name: "{{ base_sshd_service_name }}"
+    enabled: true
+    state: started
+
+- name: "Config | Flush SSH handler"
+  ansible.builtin.meta: flush_handlers

--- a/roles/base_sshd/tasks/install.yml
+++ b/roles/base_sshd/tasks/install.yml
@@ -1,0 +1,12 @@
+---
+# roles/base_sshd/tasks/install.yml
+# Install phase tasks for the `base_sshd` role.
+# Ensures the OpenSSH server package is present with APT before SSH daemon configuration.
+
+- name: "Install | Ensure SSH daemon packages are present"
+  ansible.builtin.apt:
+    name: "{{ base_sshd_packages }}"
+    state: present
+    update_cache: true
+    cache_valid_time: 3600
+  when: base_sshd_packages | length > 0

--- a/roles/base_sshd/tasks/main.yml
+++ b/roles/base_sshd/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+# roles/base_sshd/tasks/main.yml
+# Task entrypoint for the `base_sshd` role.
+# Imports the assert, install, config, and validate phase files in order.
+
+- name: Assert
+  ansible.builtin.import_tasks: assert.yml
+  tags: [assert, base_sshd_assert]
+
+- name: Install
+  ansible.builtin.import_tasks: install.yml
+  tags: [install, base_sshd_install]
+
+- name: Config
+  ansible.builtin.import_tasks: config.yml
+  tags: [config, base_sshd_config]
+
+- name: Validate
+  ansible.builtin.import_tasks: validate.yml
+  tags: [validate, base_sshd_validate]

--- a/roles/base_sshd/tasks/validate.yml
+++ b/roles/base_sshd/tasks/validate.yml
@@ -1,0 +1,92 @@
+---
+# roles/base_sshd/tasks/validate.yml
+# Validate phase tasks for the `base_sshd` role.
+# Verifies the managed SSH daemon drop-in, effective OpenSSH settings, and the enabled, running service state.
+
+- name: "Validate | Read SSH daemon drop-in"
+  ansible.builtin.slurp:
+    path: /etc/ssh/sshd_config.d/90-base-sshd.conf
+  register: base_sshd_config_file
+
+- name: "Validate | Gather service facts"
+  ansible.builtin.service_facts:
+
+- name: "Validate | Read baseline SSH daemon settings"
+  ansible.builtin.command: sshd -T -f /etc/ssh/sshd_config
+  register: base_sshd_effective_config
+  changed_when: false
+
+- name: "Validate | Read effective SSH daemon settings for required users"
+  vars:
+    base_sshd_validate_host: "{{ inventory_hostname }}"
+    base_sshd_validate_addr: >-
+      {{
+        ansible_default_ipv4.address
+        | default(ansible_all_ipv4_addresses | default([]) | first, true)
+        | default('127.0.0.1', true)
+      }}
+  ansible.builtin.command: >-
+    sshd -T -f /etc/ssh/sshd_config
+    -C user={{ item }},host={{ base_sshd_validate_host }},addr={{ base_sshd_validate_addr }}
+  loop: "{{ base_sshd_allow_users }}"
+  loop_control:
+    label: "{{ item }}"
+  register: base_sshd_allow_users_checks
+  changed_when: false
+  when: base_sshd_allow_users | length > 0
+
+- name: "Validate | Assert SSH daemon state"
+  vars:
+    base_sshd_expected_config: "{{ lookup('template', 'sshd_base.conf.j2') }}"
+    base_sshd_service_unit: >-
+      {{
+        base_sshd_service_name
+        if base_sshd_service_name.endswith('.service')
+        else (base_sshd_service_name ~ '.service')
+      }}
+    base_sshd_expected_password_authentication: >-
+      {{ 'yes' if base_sshd_password_authentication else 'no' }}
+    base_sshd_expected_pubkey_authentication: >-
+      {{ 'yes' if base_sshd_pubkey_authentication else 'no' }}
+  ansible.builtin.assert:
+    that:
+      - (base_sshd_config_file.content | b64decode) == base_sshd_expected_config
+      - base_sshd_service_unit in ansible_facts.services
+      - ansible_facts.services[base_sshd_service_unit].status == 'enabled'
+      - ansible_facts.services[base_sshd_service_unit].state == 'running'
+      - ('port ' ~ (base_sshd_port | string)) in base_sshd_effective_config.stdout_lines
+      - ('permitrootlogin ' ~ base_sshd_permit_root_login) in base_sshd_effective_config.stdout_lines
+      - ('passwordauthentication ' ~ base_sshd_expected_password_authentication) in base_sshd_effective_config.stdout_lines
+      - ('pubkeyauthentication ' ~ base_sshd_expected_pubkey_authentication) in base_sshd_effective_config.stdout_lines
+    fail_msg: >-
+      Configured SSH daemon state does not match the requested base_sshd
+      values
+    quiet: true
+
+- name: "Validate | Assert required users are allowed"
+  vars:
+    base_sshd_allowusers_values: >-
+      {{
+        item.stdout_lines
+        | select('match', '^allowusers ')
+        | map('regex_replace', '^allowusers\\s+', '')
+        | list
+      }}
+  ansible.builtin.assert:
+    that:
+      - base_sshd_allowusers_values | length > 0
+      - >-
+        (
+          base_sshd_allowusers_values
+          | select('search', '(^|\\s)' ~ (item.item | regex_escape) ~ '(\\s|$)')
+          | list
+          | length
+        ) > 0
+    fail_msg: >-
+      Effective AllowUsers for {{ item.item }} does not include the required
+      user. Effective AllowUsers={{ base_sshd_allowusers_values | join(', ') | default('(none)', true) }}
+    quiet: true
+  loop: "{{ base_sshd_allow_users_checks.results | default([]) }}"
+  loop_control:
+    label: "{{ item.item }}"
+  when: base_sshd_allow_users | length > 0

--- a/roles/base_sshd/templates/sshd_base.conf.j2
+++ b/roles/base_sshd/templates/sshd_base.conf.j2
@@ -1,0 +1,10 @@
+{# roles/base_sshd/templates/sshd_base.conf.j2 #}
+{# Template for the managed `/etc/ssh/sshd_config.d/90-base-sshd.conf` file in the `base_sshd` role. #}
+{# Renders the Debian-family SSH daemon baseline managed during the base phase. #}
+Port {{ base_sshd_port }}
+PermitRootLogin {{ base_sshd_permit_root_login }}
+PasswordAuthentication {{ 'yes' if base_sshd_password_authentication else 'no' }}
+PubkeyAuthentication {{ 'yes' if base_sshd_pubkey_authentication else 'no' }}
+{% if base_sshd_allow_users | length > 0 %}
+AllowUsers {{ base_sshd_allow_users | join(' ') }}
+{% endif %}


### PR DESCRIPTION
Introduce the `base_sshd` role to manage the SSH daemon configuration and ensure the OpenSSH server is installed and properly configured during the base phase. This role includes handlers, tasks for installation, configuration, and validation, as well as default variables for SSH settings.