### PR TITLE
Add base_firewall role for UFW management during base phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,24 @@
 Release history for `ansible-roles`.
 Documents notable changes across repository structure, roles, examples, and documentation.
 
+## [v0.15.0]
+### Added
+- `roles/base_firewall/`: New role for enforcing a UFW baseline during the base phase.
+- `roles/base_firewall/defaults/main.yml`: Added `base_firewall_packages`, `base_firewall_enabled`, `base_firewall_logging`, `base_firewall_default_incoming_policy`, `base_firewall_default_outgoing_policy`, `base_firewall_state_checksum_path`, and `base_firewall_rules` defaults.
+- `roles/base_firewall/tasks/`: Added assert, install, config, and validate phase task files for Debian-family UFW management.
+- `roles/base_firewall/README.md`: Added role documentation for firewall management and direct usage.
+- `examples/inventory/group_vars/all/base_firewall.yml`: Added example firewall variables for the Debian-family example lab.
+- `roles/base/defaults/main.yml`: Added `base_include_firewall` so the aggregate base role can opt in to firewall management without changing existing hosts by default.
+
+### Changed
+- `roles/base/tasks/main.yml`: Optionally includes `base_firewall` only when `base_include_firewall` is true, so existing aggregate base runs do not start enforcing a firewall unexpectedly.
+- `roles/base/meta/main.yml` and `roles/base/README.md`: Restored the aggregate base dependency order to the existing always-on roles and documented `base_firewall` as an explicit opt-in follow-up role.
+- `roles/base_firewall/tasks/assert.yml`: Added a safety check that refuses to enable a deny-or-reject incoming firewall policy unless the managed rules still allow SSH or Ansible access on the management port.
+- `roles/base_firewall/tasks/config.yml` and `roles/base_firewall/tasks/validate.yml`: Added checksum-based convergent reapply behavior so managed rule or comment changes reset and rebuild the stored UFW state instead of leaving stale rules behind.
+- `README.md`: Added `base_firewall` to the available roles list and clarified that the aggregate `base` role includes it only as an explicit opt-in follow-up.
+- `examples/README.md`, `docs/01-examples.md`, and `examples/inventory/group_vars/all/base_firewall.yml`: Updated the example documentation and variables to include the new firewall role file plus the aggregate opt-in variable.
+- `docs/02-role-workflow.md`: Updated the documented aggregate base-role order so `base_firewall` is described as an optional current follow-up instead of a default dependency.
+
 ## [v0.14.0]
 ### Added
 - `roles/base_sshd/`: New role for enforcing an SSH daemon baseline during the base phase.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ ansible-roles/
 
 ## Available Roles
 - `bootstrap`: Creates and validates the automation account used after the bootstrap phase.
-- `base`: Aggregates recurring base-phase configuration for Debian-family hosts through dependency roles such as `base_packages`, `base_locale`, `base_hostname`, `base_ntp`, `base_sudo`, `base_sshd`, and `base_timezone`.
+- `base`: Aggregates recurring base-phase configuration for Debian-family hosts through dependency roles such as `base_packages`, `base_locale`, `base_hostname`, `base_ntp`, `base_sudo`, `base_sshd`, and `base_timezone`, with optional follow-up inclusion for `base_firewall`.
+- `base_firewall`: Enforces a UFW baseline with managed default policies and requested allow or limit rules on Debian-family hosts during the base phase.
 - `base_hostname`: Enforces the system hostname on Debian-family hosts during the base phase.
 - `base_locale`: Ensures requested locales exist and configures the system default locale on Debian-family hosts during the base phase.
 - `base_ntp`: Configures system time synchronization through `systemd-timesyncd` on Debian-family hosts during the base phase.

--- a/docs/01-examples.md
+++ b/docs/01-examples.md
@@ -58,7 +58,8 @@ ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/test_bas
 
 - The lab content is intentionally simple and meant as an example baseline.
 - The example inventory and variables assume Debian-family hosts and the repository's APT-based role behavior.
-- `group_vars/all/` is split by role prefix so example variables such as `base_packages.yml`, `base_hostname.yml`, `base_locale.yml`, `base_ntp.yml`, `base_sudo.yml`, `base_sshd.yml`, and `base_timezone.yml` stay readable as the base stack grows.
+- `group_vars/all/` is split by role prefix so example variables such as `base_packages.yml`, `base_hostname.yml`, `base_locale.yml`, `base_ntp.yml`, `base_sudo.yml`, `base_sshd.yml`, `base_firewall.yml`, and `base_timezone.yml` stay readable as the base stack grows.
+- `base_firewall.yml` sets `base_include_firewall: true`, which opts the example base run into the optional `base_firewall` role.
 - `hosts.ini` keeps default `ansible_user=ansible` in `[all:vars]`, while `[bootstrap:vars]` holds initial login values used only during bootstrap.
 - `playbooks/bootstrap.yml` prompts once for the bootstrap password and reuses it for both SSH login and sudo.
 - `playbooks/test_base_sshd.yml` removes its temporary SSH fixture files in an `always` block after the integration run, so the example host is returned to the normal post-test state.

--- a/docs/02-role-workflow.md
+++ b/docs/02-role-workflow.md
@@ -81,12 +81,15 @@ Current order:
 
 Use this sequence to keep foundational packages and environment settings first, then time synchronization, then final host identity, sudo policy, and SSH daemon policy.
 
+Optional current follow-up:
+
+1. `base_firewall` when `base_include_firewall: true`
+
 Planned future additions should follow after the current foundational roles:
 
-1. `base_firewall`
-2. `base_logging`
-3. `base_updates`
-4. `base_apparmor`
+1. `base_logging`
+2. `base_updates`
+3. `base_apparmor`
 
 ## Tag Usage
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,7 +10,7 @@ The inventory variables and role inputs assume the repository's Debian-family de
 ## Structure
 - `ansible.cfg`: Test-specific Ansible configuration.
 - `inventory/hosts.ini`: Test inventory.
-- `inventory/group_vars/all/`: Shared variables for test hosts, split into per-role files such as `bootstrap.yml`, `base_packages.yml`, `base_hostname.yml`, `base_locale.yml`, `base_ntp.yml`, `base_sudo.yml`, `base_sshd.yml`, and `base_timezone.yml`.
+- `inventory/group_vars/all/`: Shared variables for test hosts, split into per-role files such as `bootstrap.yml`, `base_packages.yml`, `base_hostname.yml`, `base_locale.yml`, `base_ntp.yml`, `base_sudo.yml`, `base_sshd.yml`, `base_firewall.yml`, and `base_timezone.yml`.
 - `playbooks/bootstrap.yml`: Bootstrap phase playbook that connects with the initial admin account and applies the standalone `bootstrap` role.
 - `playbooks/base.yml`: Base phase playbook that connects as the automation account and applies the `base` role.
 - `playbooks/site.yml`: Base-phase entry playbook that imports `base.yml`.
@@ -49,6 +49,7 @@ ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/test_bas
 ```
 
 The SSH integration test playbook cleans up its temporary `/etc/ssh/sshd_config.d/` fixture files in an `always` block, so you do not need to remove them manually after the run.
+`inventory/group_vars/all/base_firewall.yml` also sets `base_include_firewall: true`, which opts the example base run into the optional `base_firewall` role.
 
 ## Bootstrap Credentials
 The example inventory stores only the bootstrap login user:

--- a/examples/inventory/group_vars/all/base_firewall.yml
+++ b/examples/inventory/group_vars/all/base_firewall.yml
@@ -1,0 +1,48 @@
+---
+# examples/inventory/group_vars/all/base_firewall.yml
+# Shared firewall variables for the example lab.
+# Defines the aggregate-role opt-in, UFW package, enabled state, default policies, and managed rule list enforced during the base phase.
+
+# Opt in to the optional base_firewall role from the aggregate base role.
+base_include_firewall: true
+
+# Package list installed with APT to provide the firewall on the host.
+base_firewall_packages:
+  - ufw               # uncomplicated firewall package used by the base_firewall role
+
+# Keep the firewall enabled during the base phase.
+base_firewall_enabled: true
+
+# Logging level configured through UFW.
+base_firewall_logging: low
+
+# Default inbound policy for traffic arriving at the host.
+base_firewall_default_incoming_policy: deny
+
+# Default outbound policy for traffic leaving the host.
+base_firewall_default_outgoing_policy: allow
+
+# Path used by the role to store the checksum of the requested managed
+# firewall state. Keep the default unless you have a host-specific reason
+# to place this state file somewhere else under /etc.
+base_firewall_state_checksum_path: /etc/ufw/.base_firewall_state.sha256
+
+# Firewall rules that must exist in UFW.
+# When the default incoming policy is deny or reject, keep at least one
+# incoming allow or limit rule for the SSH or Ansible management port.
+# This example follows the SSH port managed by base_sshd and rate-limits
+# new connections.
+base_firewall_rules:
+  - rule: limit
+    direction: in
+    port: "{{ base_sshd_port | string }}"
+    proto: tcp
+    comment: Limit SSH access
+
+  # Optional service example:
+  # - rule: allow
+  #   direction: in
+  #   port: "8080"
+  #   proto: tcp
+  #   from_ip: 192.168.1.0/24
+  #   comment: Allow Traefik dashboard from LAN

--- a/examples/inventory/group_vars/all/base_sshd.yml
+++ b/examples/inventory/group_vars/all/base_sshd.yml
@@ -26,5 +26,6 @@ base_sshd_pubkey_authentication: true
 # Optional login allow-list for the example lab. The role validates that these
 # users are present in the effective AllowUsers result after SSH config merge.
 base_sshd_allow_users:
+  - vagrant      # Used by Vagrant for VM lifecycle (halt/up) and testing automation
   - ansible
   - admin

--- a/roles/base/README.md
+++ b/roles/base/README.md
@@ -5,8 +5,9 @@ Explains how the aggregate base role delegates recurring Debian-family host conf
 
 ## Features
 - Runs the recurring base configuration on every `base` execution
-- Keeps orchestration in `roles/base/meta/main.yml`
+- Keeps the always-on base-role orchestration in `roles/base/meta/main.yml`
 - Includes `base_packages`, `base_locale`, `base_timezone`, `base_ntp`, `base_hostname`, `base_sudo`, and `base_sshd` through role dependencies
+- Can include `base_firewall` as an explicit opt-in follow-up role when `base_include_firewall: true`
 
 ## Usage
 Use `base` on Debian-family hosts after the bootstrap phase has already created the automation account:
@@ -14,12 +15,14 @@ Use `base` on Debian-family hosts after the bootstrap phase has already created 
 ```yaml
 - hosts: all
   become: true
+  vars:
+    base_include_firewall: true
   roles:
     - base
 ```
 
 Bootstrap is handled separately by the standalone `bootstrap` role/playbook.
-Role-specific inputs for `base` currently come from `base_packages_*`, `base_hostname_*`, `base_locale_*`, `base_ntp_*`, `base_sudo_*`, `base_sshd_*`, and `base_timezone_*`.
+Role-specific inputs for `base` currently come from `base_packages_*`, `base_hostname_*`, `base_locale_*`, `base_ntp_*`, `base_sudo_*`, `base_sshd_*`, optional `base_include_firewall` plus `base_firewall_*`, and `base_timezone_*`.
 
 Current dependency order in `base` is:
 
@@ -33,12 +36,15 @@ Current dependency order in `base` is:
 
 This keeps foundational packages and system environment first, then time synchronization, then final host identity, sudo policy, and SSH daemon policy.
 
+Optional follow-up role:
+
+1. `base_firewall` when `base_include_firewall: true`
+
 Planned future dependency order after the current roles is:
 
-1. `base_firewall`
-2. `base_logging`
-3. `base_updates`
-4. `base_apparmor`
+1. `base_logging`
+2. `base_updates`
+3. `base_apparmor`
 
 ## License
 MIT

--- a/roles/base/defaults/main.yml
+++ b/roles/base/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+# roles/base/defaults/main.yml
+# Default variables for the `base` role.
+# Defines optional aggregate-role toggles that extend the base phase without changing existing consumers by default.
+
+base_include_firewall: false

--- a/roles/base/tasks/main.yml
+++ b/roles/base/tasks/main.yml
@@ -1,4 +1,12 @@
 ---
 # roles/base/tasks/main.yml
-# Main task file for the `base` role.
-# Remains intentionally minimal because the role delegates work through meta dependencies.
+# Task entrypoint for the `base` role.
+# Keeps core orchestration in meta dependencies and includes optional follow-up roles when explicitly enabled.
+
+- name: "Base | Include optional firewall role"
+  ansible.builtin.include_role:
+    name: base_firewall
+    apply:
+      tags: [base, base_firewall]
+  when: base_include_firewall | default(false)
+  tags: [base, base_firewall]

--- a/roles/base_firewall/README.md
+++ b/roles/base_firewall/README.md
@@ -1,0 +1,79 @@
+# roles/base_firewall/README.md
+
+Reference for the `base_firewall` role.
+Explains how the role manages a UFW baseline on Debian-family hosts during the base phase.
+
+## Features
+- Installs the UFW package with APT before firewall configuration
+- Validates the requested package, state, logging, default-policy, and rule inputs
+- Refuses to enable a deny-or-reject incoming firewall baseline unless the managed rules still allow SSH or Ansible access on the management port
+- Configures UFW logging plus default incoming and outgoing policies
+- Resets and reapplies the managed UFW ruleset when the requested firewall state changes
+- Enables or disables UFW according to the role input
+- Verifies effective firewall status, the stored state checksum, and the stored added-rule commands after changes
+
+## Variables
+
+| Variable | Default | Required | Description |
+|----------|---------|----------|-------------|
+| `base_firewall_packages` | `['ufw']` | no | Package list installed with APT to provide the firewall |
+| `base_firewall_enabled` | `true` | no | Whether UFW is enabled after the role applies |
+| `base_firewall_logging` | `low` | no | UFW logging level; supported values are `off`, `on`, `low`, `medium`, `high`, and `full` |
+| `base_firewall_default_incoming_policy` | `deny` | no | Default UFW policy for incoming traffic |
+| `base_firewall_default_outgoing_policy` | `allow` | no | Default UFW policy for outgoing traffic |
+| `base_firewall_state_checksum_path` | `/etc/ufw/.base_firewall_state.sha256` | no | Path used to store the checksum of the requested managed firewall state so rule changes can be reapplied convergently |
+| `base_firewall_rules` | SSH rate-limit rule on `base_sshd_port` | no | Ordered list of UFW rules to ensure are present; supported keys are `rule`, `direction`, `port`, `proto`, `from_ip`, `to_ip`, `comment`, and `log` |
+
+## Usage
+
+The `base` role can include `base_firewall` when `base_include_firewall: true`.
+
+Usage through the aggregate `base` role:
+
+```yaml
+- hosts: all
+  become: true
+  vars:
+    base_include_firewall: true
+  roles:
+    - base
+
+- hosts: all
+  become: true
+  roles:
+    - base_firewall
+```
+
+Example variables:
+
+```yaml
+base_include_firewall: true
+base_firewall_default_incoming_policy: deny
+base_firewall_default_outgoing_policy: allow
+base_firewall_rules:
+  - rule: limit
+    direction: in
+    port: "{{ base_sshd_port | default(22) }}"
+    proto: tcp
+    comment: Limit SSH access
+  - rule: allow
+    direction: in
+    port: "443"
+    proto: tcp
+    comment: Allow HTTPS
+```
+
+This role resets and reapplies the managed UFW state when the requested firewall variables change, so removed or changed managed rules do not linger from an older run.
+If you set `base_firewall_default_incoming_policy` to `deny` or `reject`, keep at least one incoming `allow` or `limit` rule for the SSH or Ansible management port in `base_firewall_rules` or the role will fail early.
+Set `comment: ""` on a managed rule when you want the role to clear an older stored UFW comment during the next convergent reapply.
+Keep `base_firewall_rules` ordered for readability and stable `ufw show added` output.
+Rule directions use `in` and `out` so the stored commands match the long-form syntax used by the Ansible UFW module.
+
+## Dependencies
+None
+
+## License
+MIT
+
+## Author
+Tatbyte

--- a/roles/base_firewall/defaults/main.yml
+++ b/roles/base_firewall/defaults/main.yml
@@ -1,0 +1,18 @@
+---
+# roles/base_firewall/defaults/main.yml
+# Default variables for the `base_firewall` role.
+# Defines the UFW package, enabled state, default policies, and managed rule list enforced during the base phase.
+
+base_firewall_packages:
+  - ufw
+base_firewall_enabled: true
+base_firewall_logging: low
+base_firewall_default_incoming_policy: deny
+base_firewall_default_outgoing_policy: allow
+base_firewall_state_checksum_path: /etc/ufw/.base_firewall_state.sha256
+base_firewall_rules:
+  - rule: limit
+    direction: in
+    port: "{{ base_sshd_port | default(22) | string }}"
+    proto: tcp
+    comment: Limit SSH access

--- a/roles/base_firewall/tasks/assert.yml
+++ b/roles/base_firewall/tasks/assert.yml
@@ -1,0 +1,142 @@
+---
+# roles/base_firewall/tasks/assert.yml
+# Assert phase tasks for the `base_firewall` role.
+# Validates the requested UFW package, state, default-policy, and rule inputs before installation and configuration run.
+
+- name: "Assert | Validate base_firewall variable structure"
+  ansible.builtin.assert:
+    that:
+      - base_firewall_packages is sequence
+      - base_firewall_packages is not string
+      - base_firewall_enabled is boolean
+      - base_firewall_logging is string
+      - base_firewall_logging in ['off', 'on', 'low', 'medium', 'high', 'full']
+      - base_firewall_default_incoming_policy is string
+      - base_firewall_default_incoming_policy in ['allow', 'deny', 'reject']
+      - base_firewall_default_outgoing_policy is string
+      - base_firewall_default_outgoing_policy in ['allow', 'deny', 'reject']
+      - base_firewall_state_checksum_path is string
+      - base_firewall_state_checksum_path | trim | length > 0
+      - base_firewall_rules is sequence
+      - base_firewall_rules is not string
+      - (base_firewall_packages | map('string') | list | length) == (base_firewall_packages | length)
+      - (base_firewall_packages | map('trim') | reject('equalto', '') | list | length) == (base_firewall_packages | length)
+    fail_msg: >-
+      base_firewall_packages must be a list of package names,
+      base_firewall_enabled must be a boolean, base_firewall_logging must use
+      a supported UFW logging level, base_firewall_default_incoming_policy and
+      base_firewall_default_outgoing_policy must use supported UFW policy
+      values, base_firewall_state_checksum_path must be a non-empty path, and
+      base_firewall_rules must be a list
+    quiet: true
+
+- name: "Assert | Validate base_firewall rule structure"
+  ansible.builtin.assert:
+    that:
+      - item is mapping
+      - (item.keys() | difference(['rule', 'direction', 'port', 'proto', 'from_ip', 'to_ip', 'comment', 'log']) | length) == 0
+      - item.rule is defined
+      - item.rule is string
+      - item.rule in ['allow', 'deny', 'reject', 'limit']
+      - item.direction is not defined or (item.direction is string and item.direction in ['in', 'out'])
+      - item.port is not defined or ((item.port | string) | trim | length > 0)
+      - item.proto is not defined or (item.proto is string and item.proto in ['any', 'tcp', 'udp', 'ipv6', 'esp', 'ah', 'gre', 'igmp'])
+      - item.from_ip is not defined or (item.from_ip is string and item.from_ip | trim | length > 0 and item.from_ip == (item.from_ip | trim))
+      - item.to_ip is not defined or (item.to_ip is string and item.to_ip | trim | length > 0 and item.to_ip == (item.to_ip | trim))
+      - >-
+        item.comment is not defined or
+        (item.comment is string and ("'" not in item.comment))
+      - item.log is not defined or item.log is boolean
+    fail_msg: >-
+      Each base_firewall_rules item must be a mapping that uses only the
+      supported keys rule, direction, port, proto, from_ip, to_ip, comment,
+      and log. rule must use a supported UFW action, direction must be in or
+      out, address values must be non-empty, comment cannot contain single
+      quotes, and log must be a boolean when set
+    quiet: true
+  loop: "{{ base_firewall_rules }}"
+  loop_control:
+    label: >-
+      {{
+        item.comment
+        | default(item.rule ~ ' ' ~ (item.port | default(item.to_ip | default('any')) | string))
+      }}
+
+- name: "Assert | Require SSH management rule when firewall would block incoming access"
+  vars:
+    base_firewall_management_port: >-
+      {{
+        ansible_port
+        | default(base_sshd_port | default(22), true)
+        | string
+      }}
+    base_firewall_management_rule_count: >-
+      {{
+        (
+          base_firewall_rules
+          | selectattr('rule', 'in', ['allow', 'limit'])
+          | selectattr('direction', 'undefined')
+          | selectattr('port', 'defined')
+          | selectattr('proto', 'undefined')
+          | map(attribute='port')
+          | map('string')
+          | select('equalto', base_firewall_management_port)
+          | list
+          | length
+        )
+        +
+        (
+          base_firewall_rules
+          | selectattr('rule', 'in', ['allow', 'limit'])
+          | selectattr('direction', 'defined')
+          | selectattr('direction', 'equalto', 'in')
+          | selectattr('port', 'defined')
+          | selectattr('proto', 'undefined')
+          | map(attribute='port')
+          | map('string')
+          | select('equalto', base_firewall_management_port)
+          | list
+          | length
+        )
+        +
+        (
+          base_firewall_rules
+          | selectattr('rule', 'in', ['allow', 'limit'])
+          | selectattr('direction', 'undefined')
+          | selectattr('port', 'defined')
+          | selectattr('proto', 'defined')
+          | selectattr('proto', 'in', ['tcp', 'any'])
+          | map(attribute='port')
+          | map('string')
+          | select('equalto', base_firewall_management_port)
+          | list
+          | length
+        )
+        +
+        (
+          base_firewall_rules
+          | selectattr('rule', 'in', ['allow', 'limit'])
+          | selectattr('direction', 'defined')
+          | selectattr('direction', 'equalto', 'in')
+          | selectattr('port', 'defined')
+          | selectattr('proto', 'defined')
+          | selectattr('proto', 'in', ['tcp', 'any'])
+          | map(attribute='port')
+          | map('string')
+          | select('equalto', base_firewall_management_port)
+          | list
+          | length
+        )
+      }}
+  ansible.builtin.assert:
+    that:
+      - (base_firewall_management_rule_count | int) > 0
+    fail_msg: >-
+      base_firewall_rules must include at least one incoming allow or limit
+      rule for the SSH or Ansible management port
+      ({{ base_firewall_management_port }}) before enabling a deny or reject
+      incoming firewall policy
+    quiet: true
+  when:
+    - base_firewall_enabled
+    - base_firewall_default_incoming_policy in ['deny', 'reject']

--- a/roles/base_firewall/tasks/config.yml
+++ b/roles/base_firewall/tasks/config.yml
@@ -1,0 +1,85 @@
+---
+# roles/base_firewall/tasks/config.yml
+# Config phase tasks for the `base_firewall` role.
+# Resets and reapplies the managed UFW state when requested firewall inputs change.
+# Then enforces logging, default policies, rules, and the final enabled state.
+
+- name: "Config | Read stored firewall state checksum"
+  ansible.builtin.slurp:
+    path: "{{ base_firewall_state_checksum_path }}"
+  register: base_firewall_state_checksum_file
+  failed_when: false
+  changed_when: false
+
+- name: "Config | Derive desired firewall state checksum"
+  ansible.builtin.set_fact:
+    base_firewall_desired_state_checksum: >-
+      {{
+        {
+          'enabled': base_firewall_enabled,
+          'logging': base_firewall_logging,
+          'default_incoming_policy': base_firewall_default_incoming_policy,
+          'default_outgoing_policy': base_firewall_default_outgoing_policy,
+          'rules': base_firewall_rules
+        }
+        | to_json
+        | hash('sha256')
+      }}
+    base_firewall_current_state_checksum: >-
+      {{
+        (
+          base_firewall_state_checksum_file.content
+          | default('', true)
+          | b64decode
+          | trim
+        )
+      }}
+
+- name: "Config | Reset firewall before reapplying changed managed state"
+  community.general.ufw:
+    state: reset
+  when: base_firewall_current_state_checksum != base_firewall_desired_state_checksum
+
+- name: "Config | Set firewall logging level"
+  community.general.ufw:
+    logging: "{{ base_firewall_logging }}"
+
+- name: "Config | Set default incoming firewall policy"
+  community.general.ufw:
+    default: "{{ base_firewall_default_incoming_policy }}"
+    direction: incoming
+
+- name: "Config | Set default outgoing firewall policy"
+  community.general.ufw:
+    default: "{{ base_firewall_default_outgoing_policy }}"
+    direction: outgoing
+
+- name: "Config | Ensure requested firewall rules are present"
+  community.general.ufw:
+    rule: "{{ item.rule }}"
+    direction: "{{ item.direction | default('in') }}"
+    from_ip: "{{ item.from_ip | default('any') }}"
+    to_ip: "{{ item.to_ip | default('any') }}"
+    to_port: "{{ item.port | default(omit) }}"
+    proto: "{{ item.proto | default(omit) }}"
+    comment: "{{ item.comment if item.comment is defined else omit }}"
+    log: "{{ item.log | default(omit) }}"
+  loop: "{{ base_firewall_rules }}"
+  loop_control:
+    label: >-
+      {{
+        item.comment
+        | default(item.rule ~ ' ' ~ (item.port | default(item.to_ip | default('any')) | string))
+      }}
+
+- name: "Config | Ensure firewall enabled state"
+  community.general.ufw:
+    state: "{{ 'enabled' if base_firewall_enabled else 'disabled' }}"
+
+- name: "Config | Store firewall state checksum"
+  ansible.builtin.copy:
+    dest: "{{ base_firewall_state_checksum_path }}"
+    content: "{{ base_firewall_desired_state_checksum }}\n"
+    owner: root
+    group: root
+    mode: "0600"

--- a/roles/base_firewall/tasks/install.yml
+++ b/roles/base_firewall/tasks/install.yml
@@ -1,0 +1,12 @@
+---
+# roles/base_firewall/tasks/install.yml
+# Install phase tasks for the `base_firewall` role.
+# Ensures the UFW package is present with APT before firewall configuration.
+
+- name: "Install | Ensure firewall packages are present"
+  ansible.builtin.apt:
+    name: "{{ base_firewall_packages }}"
+    state: present
+    update_cache: true
+    cache_valid_time: 3600
+  when: base_firewall_packages | length > 0

--- a/roles/base_firewall/tasks/main.yml
+++ b/roles/base_firewall/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+# roles/base_firewall/tasks/main.yml
+# Task entrypoint for the `base_firewall` role.
+# Imports the assert, install, config, and validate phase files in order.
+
+- name: Assert
+  ansible.builtin.import_tasks: assert.yml
+  tags: [assert, base_firewall, base_firewall_assert]
+
+- name: Install
+  ansible.builtin.import_tasks: install.yml
+  tags: [install, base_firewall, base_firewall_install]
+
+- name: Config
+  ansible.builtin.import_tasks: config.yml
+  tags: [config, base_firewall, base_firewall_config]
+
+- name: Validate
+  ansible.builtin.import_tasks: validate.yml
+  tags: [validate, base_firewall, base_firewall_validate]

--- a/roles/base_firewall/tasks/validate.yml
+++ b/roles/base_firewall/tasks/validate.yml
@@ -1,0 +1,124 @@
+---
+# roles/base_firewall/tasks/validate.yml
+# Validate phase tasks for the `base_firewall` role.
+# Verifies the effective UFW status and the stored managed rule commands after configuration.
+
+- name: "Validate | Read firewall status"
+  ansible.builtin.command: ufw status verbose
+  register: base_firewall_status
+  changed_when: false
+
+- name: "Validate | Read added firewall rules"
+  ansible.builtin.command: ufw show added
+  register: base_firewall_added_rules
+  changed_when: false
+
+- name: "Validate | Read stored firewall state checksum"
+  ansible.builtin.slurp:
+    path: "{{ base_firewall_state_checksum_path }}"
+  register: base_firewall_state_checksum_file
+  changed_when: false
+
+- name: "Validate | Assert firewall status"
+  vars:
+    base_firewall_expected_status: "{{ 'active' if base_firewall_enabled else 'inactive' }}"
+    base_firewall_expected_logging: >-
+      {{
+        'off'
+        if base_firewall_logging == 'off'
+        else 'on (' ~ ('low' if base_firewall_logging == 'on' else base_firewall_logging) ~ ')'
+      }}
+    base_firewall_expected_state_checksum: >-
+      {{
+        {
+          'enabled': base_firewall_enabled,
+          'logging': base_firewall_logging,
+          'default_incoming_policy': base_firewall_default_incoming_policy,
+          'default_outgoing_policy': base_firewall_default_outgoing_policy,
+          'rules': base_firewall_rules
+        }
+        | to_json
+        | hash('sha256')
+      }}
+    base_firewall_expected_default_prefix: >-
+      Default: {{ base_firewall_default_incoming_policy }} (incoming),
+      {{ base_firewall_default_outgoing_policy }} (outgoing)
+  ansible.builtin.assert:
+    that:
+      - "('Status: ' ~ base_firewall_expected_status) in base_firewall_status.stdout"
+      - >-
+        not base_firewall_enabled or
+        ('Logging: ' ~ base_firewall_expected_logging) in
+        base_firewall_status.stdout
+      - >-
+        not base_firewall_enabled or
+        base_firewall_expected_default_prefix in base_firewall_status.stdout
+      - >-
+        (base_firewall_state_checksum_file.content | b64decode | trim) ==
+        base_firewall_expected_state_checksum
+    fail_msg: >-
+      Configured firewall status does not match the requested base_firewall
+      values
+    quiet: true
+
+- name: "Validate | Assert requested firewall rules are recorded"
+  vars:
+    base_firewall_expected_rule_command_long: >-
+      {{
+        'ufw '
+        ~ item.rule
+        ~ ' '
+        ~ (item.direction | default('in'))
+        ~ (' log' if (item.log | default(false)) else '')
+        ~ ' from '
+        ~ (item.from_ip | default('any'))
+        ~ ' to '
+        ~ (item.to_ip | default('any'))
+        ~ (' port ' ~ (item.port | string) if (item.port is defined) else '')
+        ~ (' proto ' ~ item.proto if (item.proto is defined) else '')
+        ~ (" comment '" ~ item.comment ~ "'" if (item.comment is defined and item.comment | length > 0) else '')
+      }}
+    base_firewall_expected_rule_command_short: >-
+      {{
+        (
+          'ufw '
+          ~ item.rule
+          ~ ' '
+          ~ ((item.direction | default('in')) ~ ' ' if (item.direction | default('in')) == 'out' else '')
+          ~ ('log ' if (item.log | default(false)) else '')
+          ~ (item.port | string)
+          ~ ('/' ~ item.proto if (item.proto is defined and item.proto != 'any') else '')
+          ~ (" comment '" ~ item.comment ~ "'" if (item.comment is defined and item.comment | length > 0) else '')
+        )
+        if (
+          item.port is defined and
+          (item.from_ip | default('any')) == 'any' and
+          (item.to_ip | default('any')) == 'any'
+        )
+        else ''
+      }}
+    base_firewall_expected_rule_commands: >-
+      {{
+        [
+          base_firewall_expected_rule_command_long,
+          base_firewall_expected_rule_command_short
+        ]
+        | reject('equalto', '')
+        | unique
+        | list
+      }}
+  ansible.builtin.assert:
+    that:
+      - >-
+        (
+          base_firewall_expected_rule_commands
+          | intersect(base_firewall_added_rules.stdout_lines)
+          | length
+        ) > 0
+    fail_msg: >-
+      Requested firewall rule is missing from ufw show added.
+      Expected one of {{ base_firewall_expected_rule_commands | join(' || ') }}
+    quiet: true
+  loop: "{{ base_firewall_rules }}"
+  loop_control:
+    label: "{{ base_firewall_expected_rule_commands | first }}"


### PR DESCRIPTION
- Introduced `base_firewall` role to enforce a UFW baseline on Debian-family hosts.
- Added default variables for firewall configuration and management.
- Implemented tasks for installation, configuration, validation, and assertion of firewall rules.
- Updated documentation to include the new role and its usage.
- Modified existing roles and examples to integrate optional firewall management.