### PR TITLE
Refactor base role to use explicit role includes for aggregate ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,362 +3,236 @@
 Release history for `ansible-roles`.
 Documents notable changes across repository structure, roles, examples, and documentation.
 
+## [v0.16.0]
+### Changed
+- Moved aggregate `base` orchestration from meta dependencies to explicit `ansible.builtin.include_role` ordering, making `roles/base/tasks/main.yml` the single source of truth for the base stack.
+- Aligned aggregate include-task tags with child role phase tags and role-specific tags so both broad runs such as `--tags validate` and narrow runs such as `--tags base_packages_validate` behave predictably.
+- Added future aggregate include toggles for `base_logging`, `base_updates`, and `base_apparmor` alongside the existing firewall opt-in variable.
+- Removed the ad hoc `Prepare` step from `base_locale` and kept its derived locale state inside the config and validate phases so the role cleanly follows the shared phase structure.
+- Updated repository and role documentation to match the explicit aggregate-role ordering and tag behavior.
+
 ## [v0.15.0]
 ### Added
-- `roles/base_firewall/`: New role for enforcing a UFW baseline during the base phase.
-- `roles/base_firewall/defaults/main.yml`: Added `base_firewall_packages`, `base_firewall_enabled`, `base_firewall_logging`, `base_firewall_default_incoming_policy`, `base_firewall_default_outgoing_policy`, `base_firewall_state_checksum_path`, and `base_firewall_rules` defaults.
-- `roles/base_firewall/tasks/`: Added assert, install, config, and validate phase task files for Debian-family UFW management.
-- `roles/base_firewall/README.md`: Added role documentation for firewall management and direct usage.
-- `examples/inventory/group_vars/all/base_firewall.yml`: Added example firewall variables for the Debian-family example lab.
-- `roles/base/defaults/main.yml`: Added `base_include_firewall` so the aggregate base role can opt in to firewall management without changing existing hosts by default.
+- Added the `base_firewall` role for Debian-family UFW management, including defaults, full phase tasks, role documentation, and example variables.
+- Added `base_include_firewall` so the aggregate `base` role can opt into firewall enforcement without changing existing consumers by default.
 
 ### Changed
-- `roles/base/tasks/main.yml`: Optionally includes `base_firewall` only when `base_include_firewall` is true, so existing aggregate base runs do not start enforcing a firewall unexpectedly.
-- `roles/base/meta/main.yml` and `roles/base/README.md`: Restored the aggregate base dependency order to the existing always-on roles and documented `base_firewall` as an explicit opt-in follow-up role.
-- `roles/base_firewall/tasks/assert.yml`: Added a safety check that refuses to enable a deny-or-reject incoming firewall policy unless the managed rules still allow SSH or Ansible access on the management port.
-- `roles/base_firewall/tasks/config.yml` and `roles/base_firewall/tasks/validate.yml`: Added checksum-based convergent reapply behavior so managed rule or comment changes reset and rebuild the stored UFW state instead of leaving stale rules behind.
-- `README.md`: Added `base_firewall` to the available roles list and clarified that the aggregate `base` role includes it only as an explicit opt-in follow-up.
-- `examples/README.md`, `docs/01-examples.md`, and `examples/inventory/group_vars/all/base_firewall.yml`: Updated the example documentation and variables to include the new firewall role file plus the aggregate opt-in variable.
-- `docs/02-role-workflow.md`: Updated the documented aggregate base-role order so `base_firewall` is described as an optional current follow-up instead of a default dependency.
+- Updated the aggregate `base` role to include `base_firewall` only when explicitly enabled.
+- Added checksum-based convergent firewall reapply behavior so managed rule changes rebuild UFW state cleanly instead of leaving stale rules behind.
+- Added an early safety check that refuses deny or reject incoming firewall policies unless the managed rules still allow SSH or Ansible access.
+- Updated repository, role, and example documentation to describe `base_firewall` as an optional current follow-up role instead of a default dependency.
 
 ## [v0.14.0]
 ### Added
-- `roles/base_sshd/`: New role for enforcing an SSH daemon baseline during the base phase.
-- `roles/base_sshd/defaults/main.yml`: Added `base_sshd_packages`, `base_sshd_service_name`, `base_sshd_port`, `base_sshd_permit_root_login`, `base_sshd_password_authentication`, `base_sshd_pubkey_authentication`, and `base_sshd_allow_users` defaults.
-- `roles/base_sshd/tasks/`: Added assert, install, config, and validate phase task files for Debian-family SSH daemon management.
-- `roles/base_sshd/handlers/main.yml`: Added a handler that restarts the managed SSH service after drop-in changes.
-- `roles/base_sshd/templates/sshd_base.conf.j2`: Added a template for the managed `/etc/ssh/sshd_config.d/90-base-sshd.conf` drop-in.
-- `roles/base_sshd/README.md`: Added role documentation for SSH daemon management and direct usage.
-- `examples/inventory/group_vars/all/base_sshd.yml`: Added example SSH daemon variables for the Debian-family example lab.
-- `examples/playbooks/test_base_sshd.yml`: Added an example integration test playbook that temporarily creates extra SSH daemon fragments to exercise merged `AllowUsers` and `Match User` behavior around `base_sshd`.
+- Added the `base_sshd` role for Debian-family SSH daemon management, including defaults, handlers, templates, role documentation, example variables, and an integration test playbook.
 
 ### Changed
-- `roles/base/meta/main.yml`: Added `base_sshd` as a dependency of the `base` role with `base` and `base_sshd` tags.
-- `roles/base/README.md`: Updated base role documentation to reflect the `base_sshd` dependency, inputs, and active dependency order.
-- `README.md`: Added `base_sshd` to the available roles list and aligned the `base` role description.
-- `examples/README.md`, `docs/01-examples.md`, and `README.md`: Updated the example documentation to include the new `base_sshd.yml` role-scoped variables file and the optional `base_sshd` integration test playbook.
-- `docs/02-role-workflow.md`: Updated the documented aggregate base-role order so `base_sshd` is part of the active sequence and removed it from the future placeholder order.
+- Added `base_sshd` to the active aggregate `base` role order and updated the related repository and example documentation.
+- Expanded the example lab to cover `base_sshd` variables and an optional integration run against merged `sshd_config.d` behavior.
 
 ### Fixed
-- `roles/base_sshd/tasks/validate.yml`, `roles/base_sshd/README.md`, and `examples/inventory/group_vars/all/base_sshd.yml`: Validation and documentation now treat `AllowUsers` as effective SSH daemon state instead of implying that an empty `base_sshd_allow_users` list clears constraints defined elsewhere.
-- `roles/base_sshd/tasks/validate.yml`: Normalized `sshd -T` `AllowUsers` parsing so validation compares the full effective user list instead of only the first reported entry.
-- `roles/base_sshd/tasks/validate.yml`: Relaxed `AllowUsers` validation so the role confirms its required users are present after OpenSSH merges config sources instead of requiring this drop-in to own the complete effective list.
-- `roles/base_sshd/tasks/validate.yml`: Runs `sshd -T` with a representative `-C` connection context and ignores duplicated `allowusers` tokens in merged output so validation behaves better on hosts with `Match` rules or accumulated `AllowUsers` entries.
-- `roles/base_sshd/tasks/validate.yml`: Validates `AllowUsers` per required user context with `sshd -T -C` and checks the reported values without discarding the literal `allowusers` string as a special-case token.
-- `roles/base_sshd/tasks/validate.yml` and `examples/playbooks/test_base_sshd.yml`: Use an IP-only fallback for `sshd -T -C addr=` so validation does not depend on `ansible_host` being an address.
-- `examples/playbooks/test_base_sshd.yml`: Applies `base_sshd` before writing temporary SSH fixture fragments so the integration test still works when `/etc/ssh/sshd_config.d/` does not exist yet.
-- `roles/base_sshd/tasks/validate.yml`: Validates baseline SSH daemon settings with `sshd -T` without a connection-specific context so external `Match` rules do not cause false failures in the role's general setting checks.
-- `examples/playbooks/test_base_sshd.yml`, `examples/README.md`, and `docs/01-examples.md`: Expanded the `base_sshd` integration coverage to exercise a temporary `Match Address` fixture in addition to merged `AllowUsers` and `Match User`.
+- Reworked `base_sshd` validation to treat `AllowUsers` as effective merged SSH state rather than assuming the managed drop-in owns the full result.
+- Improved `sshd -T` validation behavior for representative connection contexts, duplicate merged tokens, and environments where `ansible_host` is not an address.
+- Updated the example integration flow so it still works when `/etc/ssh/sshd_config.d/` does not exist yet and now exercises both `Match User` and `Match Address` behavior.
 
 ## [v0.13.0]
 ### Added
-- `roles/base_sudo/`: New role for enforcing recurring sudo policy during the base phase.
-- `roles/base_sudo/defaults/main.yml`: Added `base_sudo_packages`, `base_sudo_user`, and `base_sudo_group` defaults.
-- `roles/base_sudo/tasks/`: Added assert, install, config, and validate phase task files for Debian-family sudo management.
-- `roles/base_sudo/README.md`: Added role documentation for sudo management and direct usage.
-- `examples/inventory/group_vars/all/base_sudo.yml`: Added example sudo variables for the Debian-family example lab.
+- Added the `base_sudo` role for recurring sudo policy management, including defaults, full phase tasks, role documentation, and example variables.
 
 ### Changed
-- `roles/base_sudo/tasks/config.yml` and `roles/base_sudo/tasks/validate.yml`: Simplified the role to always enforce the managed passwordless sudo drop-in so the base phase keeps a stable, homelab-friendly sudo path.
-- `roles/base_sudo/tasks/assert.yml`: Removed the passwordless-toggle and confirmation-variable handling so validation stays focused on package, user, and group inputs.
-- `roles/base_sudo/README.md`, `examples/inventory/group_vars/all/base_sudo.yml`, and `README.md`: Updated the documentation to reflect the always-managed passwordless sudo behavior.
-- `roles/base/meta/main.yml`: Added `base_sudo` as a dependency of the `base` role with `base` and `base_sudo` tags.
-- `roles/base/README.md`: Updated base role documentation to reflect the `base_sudo` dependency, inputs, and active dependency order.
-- `examples/README.md` and `docs/01-examples.md`: Updated the example documentation to include the new `base_sudo.yml` role-scoped variables file.
-- `docs/02-role-workflow.md`: Updated the documented aggregate base-role order so `base_sudo` is part of the active sequence and removed it from the future placeholder order.
+- Simplified `base_sudo` to always enforce the managed passwordless sudo drop-in for a stable homelab-oriented sudo path.
+- Removed the old passwordless toggle and confirmation-variable flow from `base_sudo` so validation stays focused on package, user, and group inputs.
+- Added `base_sudo` to the active aggregate `base` role order and updated the related repository and example documentation.
 
 ### Fixed
-- `roles/base_sudo/tasks/assert.yml` and `roles/base_sudo/tasks/config.yml`: Fail early when `base_sudo_user` does not already exist so the role enforces sudo policy for an existing account instead of silently creating one.
-- `README.md`: Restored `base_locale` to the aggregate `base` role description so the top-level dependency summary matches the implemented role order.
+- Made `base_sudo` fail early when the managed user does not already exist instead of silently creating it.
+- Restored `base_locale` to the top-level `base` role description so the documented aggregate role order matches the implementation.
 
 ## [v0.12.0]
 ### Added
-- `roles/base_hostname/`: New role for enforcing the system hostname during the base phase.
-- `roles/base_hostname/defaults/main.yml`: Added `base_hostname_name` defaults for hostname management.
-- `roles/base_hostname/tasks/`: Added assert, config, and validate phase task files for Debian-family hostname management.
-- `roles/base_hostname/README.md`: Added role documentation for hostname management and direct usage.
-- `examples/inventory/group_vars/all/base_hostname.yml`: Added example hostname variables for the Debian-family example lab.
+- Added the `base_hostname` role for Debian-family hostname management, including defaults, tasks, role documentation, and example variables.
 
 ### Changed
-- `roles/base/meta/main.yml`: Added `base_hostname` as a dependency of the `base` role with `base` and `base_hostname` tags.
-- `roles/base/README.md`: Updated base role documentation to reflect the `base_hostname` dependency and inputs.
-- `README.md`: Added `base_hostname` to the available roles list and aligned the `base` role description.
-- `examples/README.md` and `docs/01-examples.md`: Updated the example documentation to include the new `base_hostname.yml` role-scoped variables file.
-- `roles/base/meta/main.yml`, `roles/base/README.md`, and `docs/02-role-workflow.md`: Documented and aligned the aggregate base-role execution order as packages, locale, timezone, NTP, then hostname, followed by the planned future base roles.
+- Added `base_hostname` to the active aggregate `base` role order and updated the related repository and example documentation.
+- Documented the aggregate base stack as packages, locale, timezone, NTP, then hostname, followed by future planned roles.
 
 ### Fixed
-- `roles/base_hostname/tasks/assert.yml`: Tightened hostname validation to require real DNS-style hostname labels instead of only rejecting whitespace and edge punctuation.
-- `roles/base_hostname/tasks/validate.yml`: Validates the managed `/etc/hostname` value separately from the current short hostname so FQDN inputs such as `lab.example.internal` align with hosts that report `lab`.
+- Tightened hostname validation to require real DNS-style labels instead of only rejecting obvious punctuation and whitespace problems.
+- Split hostname validation between the managed `/etc/hostname` content and the current short hostname so FQDN inputs validate correctly.
 
 ### Documentation
-- `roles/base_hostname/README.md` and `examples/inventory/group_vars/all/base_hostname.yml`: Clarified that the role writes the full hostname or FQDN to `/etc/hostname` while validating the current short hostname against the first label.
+- Clarified that `base_hostname` writes the full hostname or FQDN to `/etc/hostname` while validating the current short hostname against the first label.
 
 ## [v0.11.0]
 ### Added
-- `roles/base_ntp/`: New role for configuring time synchronization through `systemd-timesyncd` during the base phase.
-- `roles/base_ntp/defaults/main.yml`: Added `base_ntp_packages`, `base_ntp_service_name`, `base_ntp_servers`, and `base_ntp_fallback_servers` defaults.
-- `roles/base_ntp/tasks/`: Added assert, install, config, and validate phase task files for Debian-family NTP management, including managed timesyncd configuration and service-state validation.
-- `roles/base_ntp/handlers/main.yml`: Added a handler that restarts the managed NTP service after configuration changes.
-- `roles/base_ntp/templates/timesyncd.conf.j2`: Added a template for the managed `/etc/systemd/timesyncd.conf` file.
-- `roles/base_ntp/README.md`: Added role documentation for NTP configuration and direct usage.
-- `examples/inventory/group_vars/all/base_ntp.yml`: Added example NTP variables for the Debian-family example lab.
+- Added the `base_ntp` role for Debian-family time synchronization through `systemd-timesyncd`, including defaults, handlers, templates, role documentation, and example variables.
 
 ### Changed
-- `roles/base/meta/main.yml`: Added `base_ntp` as a dependency of the `base` role with `base` and `base_ntp` tags.
-- `roles/base/README.md`: Updated base role documentation to reflect the `base_ntp` dependency and inputs.
-- `README.md`: Added `base_ntp` to the available roles list and aligned the `base` role description.
-- `examples/README.md` and `docs/01-examples.md`: Updated the example documentation to include the new `base_ntp.yml` role-scoped variables file.
+- Added `base_ntp` to the active aggregate `base` role order and updated the related repository and example documentation.
 
 ## [v0.10.0]
 ### Added
-- `roles/base_locale/handlers/main.yml`: Added a locale regeneration handler for managed `/etc/locale.gen` changes.
-- `roles/base_locale/templates/`: Added `locale.gen.j2` and `default_locale.j2` so locale files are rendered from shared templates instead of inline task content.
+- Added shared `base_locale` templates for `/etc/locale.gen` and `/etc/default/locale` plus a handler for locale regeneration.
 
 ### Changed
-- `roles/base_locale/tasks/main.yml`: Derives `base_locale_generated_locales` once at runtime so generated locale state stays internal to the role.
-- `roles/base_locale/tasks/config.yml`: Simplified the config flow to render `/etc/locale.gen` and `/etc/default/locale` from templates, notify a handler for `locale-gen`, and flush that handler before validation-relevant follow-up work.
-- `roles/base_locale/tasks/validate.yml`: Reused the same templates for managed file assertions so config and validate stay aligned with one rendering path.
+- Simplified `base_locale` to render locale files from templates and reuse the same rendering path during validation.
+- Kept generated locale state as runtime-derived role state so inventory cannot override it independently of `base_locale_present`.
 
 ### Fixed
-- `.pre-commit-config.yaml`: Excluded `roles/base_locale/templates/locale.gen.j2` from `end-of-file-fixer` so the empty `/etc/locale.gen` case keeps rendering as a truly empty file.
-- `roles/base_locale/defaults/main.yml` and `roles/base_locale/tasks/main.yml`: Moved `base_locale_generated_locales` back to runtime-derived role state so inventory cannot override the generated locale list independently of `base_locale_present`.
+- Preserved the truly empty `/etc/locale.gen` case by excluding the template from the `end-of-file-fixer` pre-commit hook.
 
 ### Removed
-- `roles/base_locale/tasks/config.yml`: Removed the `localedef` fallback path to keep locale generation behavior minimal and centered on `locale-gen`.
+- Removed the `localedef` fallback path so locale generation stays centered on `locale-gen`.
 
 ### Documentation
-- `roles/base_locale/README.md`: Updated locale generation wording to reflect the template-based flow and removal of the `localedef` fallback.
+- Updated the `base_locale` documentation to reflect the template-based flow and removal of the `localedef` fallback.
 
 ## [v0.9.0]
 ### Added
-- `roles/base_locale/`: New role for managing generated locales and system locale categories during the base phase on Debian-family hosts.
-- `roles/base_locale/defaults/main.yml`: Added `base_locale_lang`, `base_locale_lc_all`, `base_locale_lc_time`, `base_locale_packages`, and `base_locale_present` defaults.
-- `roles/base_locale/tasks/`: Added assert, install, config, and validate phase task files for Debian-family locale management.
-- `roles/base_locale/README.md`: Added role documentation for locale management, `LC_TIME` usage, and direct usage.
-- `examples/inventory/group_vars/all/base_locale.yml`: Added example locale variables for the Debian-family example lab.
+- Added the `base_locale` role for Debian-family locale management, including defaults, full phase tasks, role documentation, and example variables.
 
 ### Changed
-- `roles/base/meta/main.yml`: Added `base_locale` as a dependency of the `base` role with `base` and `base_locale` tags.
-- `roles/base_packages/tasks/install.yml`: Switched package installation to `ansible.builtin.apt` with APT cache refresh.
-- `roles/base_packages/tasks/config.yml`: Switched package removal to `ansible.builtin.apt`.
-- `roles/base_packages/tasks/validate.yml`: Updated package validation to gather package facts with `manager: apt`.
-- `roles/base_locale/tasks/install.yml`: Uses `ansible.builtin.apt` for locale package installation on Debian-family hosts.
-- `roles/base_locale/tasks/assert.yml`: Tightened supported locale inputs to built-in locales plus Debian-style `ll_CC.CHARMAP` names.
-- `roles/base_locale/tasks/config.yml`: Now fully manages `/etc/locale.gen`, runs `locale-gen` when the managed file changes, and keeps `localedef` only as a fallback for minimal/container environments.
-- `roles/base_locale/tasks/validate.yml`: Now validates the full managed `/etc/locale.gen` content in addition to generated locale availability and configured locale categories.
-- `roles/base_timezone/tasks/install.yml`: Uses `ansible.builtin.apt` for timezone package installation on Debian-family hosts.
-- `README.md`: Added an explicit Debian-family support note and updated role descriptions to match current repository scope.
-- `examples/README.md`: Documented the Debian-family scope of the example lab.
-- `docs/01-examples.md`: Clarified that the example inventory and variables target Debian-family hosts.
-- `docs/02-role-workflow.md`: Clarified that repository role implementations currently assume Debian-family behavior such as APT and Debian-family file locations.
-- `roles/base/README.md`, `roles/bootstrap/README.md`, and `roles/base_timezone/README.md`: Updated wording to reflect Debian-family scope and current role behavior.
+- Added `base_locale` to the aggregate `base` role and updated package, timezone, and locale tasks to use APT-based behavior consistently on Debian-family hosts.
+- Tightened `base_locale` input validation and fully managed `/etc/locale.gen` plus `/etc/default/locale` as canonical role-owned state.
+- Updated repository, role, and example documentation to state the Debian-family scope explicitly and describe the current locale-generation behavior.
 
 ### Fixed
-- `roles/base_locale/tasks/validate.yml`: Resolved register overwrite and invalid assert-option failures in locale validation.
-- `roles/base_locale/tasks/config.yml` and `roles/base_locale/tasks/validate.yml`: Restored correct locale normalization logic after lint-driven refactoring so generated locale checks operate on real lists.
-- `roles/base_locale/tasks/config.yml`: Replaced malformed or stale locale state by rewriting `/etc/locale.gen` to the requested canonical Debian entries during convergence.
-- `roles/base_locale/tasks/`: Brought locale tasks into `yamllint` and `ansible-lint` compliance without changing intended behavior.
+- Resolved several `base_locale` validation and normalization issues, including register overwrite problems, malformed locale state handling, and lint-driven logic regressions.
+- Brought locale tasks back into `yamllint` and `ansible-lint` compliance without changing the intended behavior.
 
 ### Documentation
-- Updated repository and role documentation to state that the repository currently targets Debian-family hosts such as Debian and Ubuntu.
-- Documented 24-hour time configuration through `base_locale_lc_time` in the `base_locale` role README and example variables.
-- Clarified in the `base_locale` role README that locale generation is driven by a fully managed `/etc/locale.gen` file and that supported locale names are built-ins plus `ll_CC.CHARMAP`.
+- Documented 24-hour time configuration through `base_locale_lc_time` and clarified the supported locale-name formats.
 
 ## [v0.8.0]
 ### Added
-- `roles/base_timezone/`: New role for enforcing the system timezone during the base phase.
-- `roles/base_timezone/defaults/main.yml`: Added `base_timezone_packages` and `base_timezone_name` defaults for timezone management.
-- `roles/base_timezone/tasks/`: Added assert, install, config, and validate phase task files for timezone management.
-- `roles/base_timezone/README.md`: Added role documentation for timezone management and direct usage.
-- `examples/inventory/group_vars/all/`: Split example shared variables into role-scoped files:
-  - `bootstrap.yml`
-  - `base_packages.yml`
-  - `base_timezone.yml`
+- Added the `base_timezone` role for timezone management, including defaults, full phase tasks, role documentation, and example variables.
+- Split example shared variables into role-scoped files in `examples/inventory/group_vars/all/`.
 
 ### Changed
-- `roles/base/meta/main.yml`: Added `base_timezone` as a dependency of the `base` role with `base` and `base_timezone` tags.
-- `roles/base/README.md`: Updated base role documentation to reflect the `base_timezone` dependency and inputs.
-- `README.md`: Added `base_timezone` to the available roles list and aligned role descriptions.
-- `examples/inventory/group_vars/`: Replaced the single `all.yml` file with a role-scoped `all/` directory for better readability.
-- `roles/base_packages/tasks/validate.yml`: Consolidated package validation into one assertion for installed packages and one assertion for removed packages to reduce noisy per-item output.
-- `roles/base_timezone/tasks/assert.yml`: Assert phase now validates timezone input only, leaving timezone-data verification to the install/validate flow.
-- `roles/base_timezone/tasks/validate.yml`: Compact validate phase now checks zoneinfo presence and final timezone state with fewer tasks and avoids Jinja delimiters in assert conditions.
+- Added `base_timezone` to the aggregate `base` role and updated the related repository and example documentation.
+- Replaced the single example `all.yml` file with a role-scoped `all/` directory for readability.
+- Simplified timezone validation and kept timezone-data ownership inside the role instead of depending on `base_packages`.
 
 ### Fixed
-- Resolved `base_timezone` validation warning caused by Jinja templating delimiters inside `assert` conditions.
-- Resolved `base_timezone` standalone failure path by making the role install its own timezone-data package instead of relying on `base_packages`.
+- Resolved timezone validation warnings caused by Jinja delimiters inside assert conditions.
+- Fixed standalone `base_timezone` runs by making the role install its own timezone package requirements.
 
 ### Documentation
-- Updated `docs/02-role-workflow.md` with guidance for compact, low-noise roles that still keep the phase-based structure.
-- Updated `examples/README.md` and `docs/01-examples.md` to document the split `group_vars/all/` directory layout.
+- Added guidance for compact low-noise roles while preserving the shared phase structure and documented the split example variable layout.
 
 ## [v0.7.1]
 ### Changed
-- Normalized file headers across tracked repository files to use a consistent path-first format followed by a short purpose description.
-- Updated example files, role files, repository docs, and tracked dotfiles to use the same header style and wording for bootstrap-phase and base-phase concepts.
-- Replaced older header variants such as generic titles, `# file:` comments, and `## File:` metadata blocks with the shared repository format.
+- Normalized tracked file headers across the repository to use a consistent path-first format with short purpose text.
+- Replaced older header styles such as generic titles and `# file:` comments with one shared repository-wide pattern.
 
 ### Documentation
-- Expanded file-level explanations so each tracked document, playbook, config, defaults file, task file, and metadata file now states its repository path and purpose at the top.
-- Clarified intentionally empty role entrypoints by documenting their purpose directly in:
-  - `roles/monitoring/tasks/main.yml`
-  - `roles/monitoring_authorized_key/tasks/install.yml`
-- Added `docs/03-file-consistency.md` to define the repository-wide file header format, wording rules, and review checklist.
+- Added `docs/03-file-consistency.md` to define the repository-wide header format, wording rules, and review checklist.
+- Clarified intentionally empty role entrypoints by documenting their purpose directly in the affected task files.
 
 ## [v0.7.0]
 ### Added
-- `examples/playbooks/bootstrap.yml`: New bootstrap phase playbook to run initial provisioning with bootstrap inventory credentials.
-- `examples/inventory/hosts.ini`: Added `[bootstrap:vars]` with dedicated bootstrap login/become variables used only by bootstrap phase.
-- `roles/bootstrap/`: New standalone bootstrap role replacing the old `base_bootstrap` role path.
-- `roles/bootstrap/defaults/main.yml`: Added `bootstrap_passwordless_sudo` (default `false`) and the new `bootstrap_*` defaults.
-- `roles/bootstrap/tasks/config.yml`: Added task to optionally manage `/etc/sudoers.d/90-<user>` with `NOPASSWD` for the bootstrap-managed automation account.
+- Added the standalone `bootstrap` role, a dedicated bootstrap playbook, and the related example inventory layout for initial provisioning.
+- Added bootstrap defaults for the renamed role and support for optionally managing passwordless sudo for the automation account.
 
 ### Changed
-- `roles/base/meta/main.yml`: Removed the bootstrap dependency; `base` now only orchestrates recurring base roles such as `base_packages`.
-- `roles/base/tasks/main.yml`: Kept as a placeholder task file while orchestration stays in meta dependencies.
-- `examples/playbooks/bootstrap.yml`: Now runs the standalone `bootstrap` role with the `bootstrap` phase tag and prompts once for the bootstrap admin password, reusing it for both SSH login and sudo.
-- `examples/playbooks/base.yml`: Simplified to run `base` only, with the `base` phase tag and no phase-switch variable.
-- `examples/playbooks/site.yml`: Now imports only `base.yml`, leaving bootstrap as an explicit separate step instead of part of the default site flow.
-- `examples/inventory/group_vars/all.yml`: Renamed bootstrap example variables from `base_bootstrap_*` to `bootstrap_*`.
-- `examples/inventory/hosts.ini`: Removed example bootstrap password values so the inventory keeps only the bootstrap login user and relies on the playbook prompt for the shared password.
-- `roles/bootstrap/tasks/config.yml`: User primary group assignment targets the ensured group by name.
+- Removed bootstrap orchestration from the aggregate `base` role so bootstrap and recurring base configuration run as separate phases.
+- Simplified the example flow to an explicit two-step sequence: run bootstrap first, then run `base` or `site`.
+- Updated example inventory variables, password handling, and task tags to match the new standalone bootstrap model.
 
 ### Fixed
-- Corrected bootstrap connection precedence by using dedicated bootstrap variables from inventory in `examples/playbooks/bootstrap.yml` instead of relying on `remote_user` against `ansible_user` from `[all:vars]`.
-- Resolved bootstrap failure path where `Group <gid> does not exist` by ensuring the primary group before user creation.
-- Resolved example `Missing sudo password` follow-up by enabling optional passwordless sudo in bootstrap-managed account for the example flow.
-- `roles/bootstrap/tasks/main.yml`: Phase tags are now `bootstrap`, `bootstrap_assert`, `bootstrap_config`, and `bootstrap_validate`.
-- `examples/playbooks/bootstrap.yml`: Removed the duplicate SSH and sudo password prompts from the example bootstrap flow by using one shared prompted value.
+- Corrected example bootstrap connection precedence and removed duplicate SSH and sudo password prompts by reusing one prompted value.
+- Fixed bootstrap user-creation failures by ensuring the primary group exists before user creation.
+- Fixed the example follow-up sudo path by enabling optional passwordless sudo for the bootstrap-managed automation account.
 
 ### Documentation
-- Updated docs and READMEs to match current example topology and execution flow:
-  - `README.md`
-  - `examples/README.md`
-  - `docs/01-examples.md`
-  - `roles/base/README.md`
-  - `roles/bootstrap/README.md`
-- Documented the example run order as an explicit two-step flow: run `examples/playbooks/bootstrap.yml` first, then run `examples/playbooks/site.yml` or `examples/playbooks/base.yml`.
-- Updated example credential documentation to reflect that `examples/playbooks/bootstrap.yml` prompts once for the bootstrap password and reuses it for both SSH login and sudo.
+- Updated repository and role documentation to match the new example topology, credential flow, and execution order.
 
 ### Removed
-- `roles/base_bootstrap/`: Removed the old bootstrap role path after renaming it to the standalone `bootstrap` role.
-- `base_run_bootstrap`: Removed the phase-switch variable from the example playbooks and bootstrap-related vars.
+- Removed the old `roles/base_bootstrap/` path and the `base_run_bootstrap` phase-switch variable.
 
 ## [v0.6.0]
 ### Added
-- `roles/base_packages/`: New role for managing common packages. Includes assert, install, config, and validate phase tasks.
-- `roles/base/meta/main.yml`: Enabled base_packages role as a dependency of base.
-- `examples/`: New directory for example lab files (inventory, group_vars, playbooks, ansible.cfg).
-- `examples/README.md`: Documentation for example test lab usage and structure.
-- `docs/01-examples.md`: Example lab documentation, replacing test lab setup.
-- `docs/02-role-workflow.md`: Role workflow guide, including phase structure and note that not all phases are required.
+- Added the `base_packages` role for common package management.
+- Added the `examples/` directory and moved the example lab docs and files into a dedicated example-focused layout.
+- Added `docs/02-role-workflow.md` to document the shared role lifecycle and note that not all phases are required in every role.
 
 ### Changed
-- Migrated test lab files from `tests/` to `examples/` for clarity and separation of tests vs examples.
-- Removed `tests/inventory/group_vars/all.yml` (now in `examples/inventory/group_vars/all.yml`).
-- Updated `roles/base_bootstrap/tasks/main.yml` to simplify tags and remove redundant prefixes.
+- Migrated the old test lab layout from `tests/` to `examples/`.
+- Simplified `base_bootstrap` task tags and naming while enabling `base_packages` through the aggregate `base` role.
 
 ## [v0.5.1]
 ### Changed
-- `roles/base_bootstrap/tasks/main.yml`: Removed redundant `Base_bootstrap | ` prefix from imported task block names to avoid duplicated role name in Ansible output.
-- `roles/base_bootstrap/tasks/validate.yml`: Consolidated `getent` lookups into a single looped task and merged all assertions into one task. Added authorized key presence check against the admin user's `authorized_keys` file.
-- `roles/base_bootstrap/tasks/assert.yml`: Combined user/shell/uid/gid assertions into a single task for reduced output noise.
-- `roles/base_bootstrap/tasks/config.yml`: No structural changes; aligned with updated task naming conventions.
+- Reduced `base_bootstrap` task output noise by simplifying imported task names and consolidating validation assertions.
+- Added authorized-key validation against the admin user's `authorized_keys` file and aligned the task naming conventions across the role.
 
 ## [v0.5.0]
 ### Refactored
-- Refactored variable naming in all roles to use role-specific prefixes for ansible-lint compliance.
-- Capitalized all task names for lint and readability.
-- Fixed YAML syntax, indentation, and document start markers in all task files.
-- Updated and added roles/monitoring_authorized_key/tasks/main.yml for new task structure and lint compliance.
+- Renamed role variables to use role-specific prefixes, capitalized task names, and cleaned up YAML formatting for lint compliance.
+- Updated the `monitoring_authorized_key` task entrypoint to match the newer task structure.
 
 ### Changed
-- Added granular phase-specific tags (`base_bootstrap_assert`, `base_bootstrap_config`, `base_bootstrap_validate`) to each imported task block in `roles/base_bootstrap/tasks/main.yml` for finer tag-based execution control.
+- Added granular phase-specific tags to `base_bootstrap` for finer targeted execution.
 
 ### Fixed
-- Corrected all `base_bootstrap` task variables in `assert.yml` from bare `bootstrap_*` / `user_shell` names to the proper `base_bootstrap_*` prefix.
-- Prefixed all task names in `assert.yml`, `config.yml`, and `validate.yml` with their phase name (e.g. `assert |`, `config |`, `validate |`) for consistency.
-- Fixed register variable collision in `validate.yml`: renamed `base_bootstrap_sudo_group` register to `base_bootstrap_sudo_group_check` to avoid shadowing the variable.
-- Improved sudo group membership assertion in `validate.yml` to correctly parse the group members list (trim, reject empty, map).
-- Updated `tests/inventory/group_vars/all.yml` to use `base_bootstrap_*` variable names and removed deprecated `base_bootstrap_enabled` and bare `bootstrap_*` variables.
+- Corrected several `base_bootstrap` variable names, register names, and sudo-group membership validation logic.
+- Updated the example inventory variables to use the new `base_bootstrap_*` naming consistently.
 
 ## [v0.4.0]
 ### Added
-- Added tests/README.md with documentation for new test files and structure.
-- Created docs/01-test-lab.md for test lab setup documentation.
+- Added test lab documentation in `tests/README.md` and `docs/01-test-lab.md`.
 
 ### Changed
-- Renamed docs/01.md to docs/01-test-lab.md for clarity.
+- Renamed `docs/01.md` to `docs/01-test-lab.md` for clarity.
 
 ## [v0.3.2]
 ### Added
-- Documentation for pre-commit installation, usage, and linting setup for all roles (`docs/00-pre-commit.mb`).
-- Added troubleshooting/common failure guidance for local pre-commit environments (cache permissions, missing `ansible-lint`, hook bootstrap issues).
+- Added pre-commit setup and troubleshooting documentation in `docs/00-pre-commit.mb`.
 
 ### Changed
-- Updated `.pre-commit-config.yaml` for a roles-only repo:
-  - Added `minimum_pre_commit_version` and default hook install types (`pre-commit`, `pre-push`).
-  - Added `meta` self-check hooks (`check-hooks-apply`, `check-useless-excludes`).
-  - Added safety hooks (`check-case-conflict`, `detect-private-key`).
-  - Simplified ansible-lint trigger to YAML files only.
-- Updated root `README.md` pre-commit section and quick start instructions for accuracy.
+- Tightened `.pre-commit-config.yaml` for a roles-only repository with clearer hook defaults, self-checks, safety hooks, and a simpler `ansible-lint` trigger.
+- Updated the root `README.md` pre-commit guidance to match the repository setup.
 
 ### Removed
-- Removed root `ansible.cfg` (not required for this roles-only repository).
+- Removed the root `ansible.cfg`, which was not needed in the roles-only repository.
 
 ### Merged
-- Merged PR #11: Enhance pre-commit setup, clean up ansible-lint configuration, and add documentation for installation and usage.
+- Merged PR #11 for the pre-commit and linting documentation cleanup.
 
 ## [v0.3.1]
 ### Added
-- `.pre-commit-config.yaml`: Added and refined pre-commit configuration for linting and hygiene (trailing whitespace, EOF, merge conflicts, YAML validation, yamllint, ansible-lint).
-- Pre-commit now uses relaxed yamllint rules for Ansible YAML conventions.
+- Added and refined `.pre-commit-config.yaml` for linting and repository hygiene.
 
 ### Changed
-- Updated `base_bootstrap/tasks/config.yml`, `_common/vars/task_flow.yml`, and `monitoring/authorized_key/tasks/configure.yml` for ansible-lint compliance (canonical FQCNs, truthy values, YAML formatting).
-- Cleaned up `.pre-commit-config.yaml` to remove broken requirements.yml hook and duplicate keys.
+- Updated task files and supporting config for `ansible-lint` compliance and cleaned up the pre-commit configuration.
 
 ### Fixed
-- All pre-commit hooks now pass successfully after configuration and code fixes.
+- Brought the full pre-commit hook set to a passing state.
 
 ## [v0.3.0] - 2026-03-02
 ### Added
-- `base/meta/main.yml`: Declared `base_bootstrap` as a dependency for the `base` role, with tags for orchestration.
-- `base/tasks/main.yml`: Placeholder for future base role tasks.
-- `base_bootstrap/tasks/config.yml`: Now always ensures the admin user exists and is in the correct group, regardless of prior existence.
+- Added aggregate orchestration for `base_bootstrap` through `base/meta/main.yml`.
+- Added a placeholder `base/tasks/main.yml` file and made bootstrap configuration always ensure the admin user exists and is grouped correctly.
 
 ### Changed
-- `_common/tasks/task_flow.yml`:
-	- Improved path resolution for shared vars.
-	- Pre-check for phase task files now runs on localhost without privilege escalation, ensuring correct detection and avoiding sudo errors.
-	- Added `become_user` and `run_once` for robust local checks.
-	- Fixed tag application logic for included phase tasks.
-- `base_bootstrap/defaults/main.yml`: Added `bootstrap_sudo_group` default variable.
-- `base_bootstrap/tasks/main.yml`: Updated to use the correct include path and streamlined variables for the task flow.
-- `base_bootstrap/tasks/validate.yml`: Now dynamically checks group membership using the `bootstrap_sudo_group` variable.
+- Improved `_common/tasks/task_flow.yml` path resolution, local pre-check behavior, and tag application for included phase tasks.
+- Added `bootstrap_sudo_group` defaults and updated `base_bootstrap` tasks to use the corrected include path and variables.
+- Made `base_bootstrap` validation check group membership through the new `bootstrap_sudo_group` variable.
 
 ## [v0.2.0]
 ### Added
-- Introduced `_common` role directory with shared `tasks/task_flow.yml` orchestrator for consistent role execution flow (assert, install, configure, validate).
+- Added the `_common` role directory with a shared `tasks/task_flow.yml` orchestrator for assert, install, configure, and validate.
+
 ### Changed
-- Added `base_bootstrap` role tag variable (`_role_tag: base_bootstrap`) to orchestrated task flow.
+- Added the `base_bootstrap` role tag variable so the shared task flow could expose role-specific tags.
 
 ## [v0.1.0] - 2026-02-27
 ### Added
-- Project-wide README at root with usage, features, and contribution guidelines
-- `_common/README.md` explaining the shared task flow orchestrator
-- Role: `monitoring/authorized_key` for inter-host SSH key management
-- Test playbook for `monitoring/authorized_key` in `homelab/ansible/playbooks/tests/monitoring/00-authorized_key.yml`
+- Added the initial root `README.md`, the `_common` task-flow documentation, and the first split of roles into a dedicated repository.
+- Added the early `monitoring/authorized_key` role and its test playbook.
+- Added the early `base/bootstrap` role and the shared `_common/tasks/task_flow.yml` orchestrator.
 
 ### Changed
-- All roles now use the shared `_common/tasks/task_flow.yml` orchestrator (assert → install → configure → validate)
-- Improved variable validation and post-deployment checks in all roles
-- Consistent task naming and file structure across roles
+- Standardized the initial role flow around assert, install, configure, and validate with more consistent task naming and structure.
 
 ### Fixed
-- Corrected shell index and variable references in `base/bootstrap` validation tasks
-
-### Added
-- Initial split of roles into dedicated repository
-- Role: `base/bootstrap` for admin user and SSH key setup
-- Shared `_common/tasks/task_flow.yml` orchestrator
+- Corrected shell index and variable references in the early bootstrap validation tasks.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ ansible-roles/
 
 ## Available Roles
 - `bootstrap`: Creates and validates the automation account used after the bootstrap phase.
-- `base`: Aggregates recurring base-phase configuration for Debian-family hosts through dependency roles such as `base_packages`, `base_locale`, `base_hostname`, `base_ntp`, `base_sudo`, `base_sshd`, and `base_timezone`, with optional follow-up inclusion for `base_firewall`.
+- `base`: Aggregates recurring base-phase configuration for Debian-family hosts through explicit `include_role` ordering in `roles/base/tasks/main.yml` for `base_packages`, `base_locale`, `base_timezone`, `base_ntp`, `base_hostname`, `base_sudo`, and `base_sshd`, with optional follow-up inclusion for `base_firewall`.
 - `base_firewall`: Enforces a UFW baseline with managed default policies and requested allow or limit rules on Debian-family hosts during the base phase.
 - `base_hostname`: Enforces the system hostname on Debian-family hosts during the base phase.
 - `base_locale`: Ensures requested locales exist and configures the system default locale on Debian-family hosts during the base phase.
@@ -120,7 +120,7 @@ See [docs/00-pre-commit.mb](docs/00-pre-commit.mb) for full setup details.
 Core repository docs:
 
 - [docs/01-examples.md](docs/01-examples.md): Example lab layout and execution flow
-- [docs/02-role-workflow.md](docs/02-role-workflow.md): Shared role phase structure
+- [docs/02-role-workflow.md](docs/02-role-workflow.md): Shared role phase structure and aggregate base-role ordering
 - [docs/03-file-consistency.md](docs/03-file-consistency.md): File header and wording consistency rules
 
 ## License

--- a/docs/02-role-workflow.md
+++ b/docs/02-role-workflow.md
@@ -67,7 +67,9 @@ Use this compact style when it improves readability and reduces task noise witho
 
 ## Aggregate Base Order
 
-The aggregate `base` role in this repository applies its dependency roles in a stable order.
+The aggregate `base` role in this repository applies its component roles in a stable order.
+`roles/base/tasks/main.yml` is the single source of truth and uses explicit `ansible.builtin.include_role` entries for the aggregate sequence.
+Its include-task tags should mirror the generic phase tags plus the child role's role-specific tags so both broad and narrow tagged runs behave predictably.
 
 Current order:
 
@@ -85,11 +87,11 @@ Optional current follow-up:
 
 1. `base_firewall` when `base_include_firewall: true`
 
-Planned future additions should follow after the current foundational roles:
+Future optional follow-up roles should also be included explicitly from `roles/base/tasks/main.yml` and gated only by aggregate include flags:
 
-1. `base_logging`
-2. `base_updates`
-3. `base_apparmor`
+1. `base_logging` when `base_include_logging: true`
+2. `base_updates` when `base_include_updates: true`
+3. `base_apparmor` when `base_include_apparmor: true`
 
 ## Tag Usage
 
@@ -101,5 +103,9 @@ ansible-playbook ... --tags install
 ansible-playbook ... --tags config
 ansible-playbook ... --tags validate
 ```
+
+For aggregate roles that use explicit `include_role` orchestration, tag the include tasks with the same generic phase tags and role-specific tags exposed by the child roles.
+This keeps `--tags validate` working across the aggregate stack and also allows targeted runs such as `--tags base_packages_validate` without entering unrelated roles.
+When you add a new aggregate child role or change a child role's tags, update the parent include-task tags to match so targeted execution keeps working as documented.
 
 Run the full workflow by running the playbook with no tag filter.

--- a/roles/base/README.md
+++ b/roles/base/README.md
@@ -1,13 +1,15 @@
 # roles/base/README.md
 
 Reference for the `base` role.
-Explains how the aggregate base role delegates recurring Debian-family host configuration through role dependencies.
+Explains how the aggregate base role delegates recurring Debian-family host configuration through explicit role includes.
 
 ## Features
 - Runs the recurring base configuration on every `base` execution
-- Keeps the always-on base-role orchestration in `roles/base/meta/main.yml`
-- Includes `base_packages`, `base_locale`, `base_timezone`, `base_ntp`, `base_hostname`, `base_sudo`, and `base_sshd` through role dependencies
+- Keeps the aggregate base-role execution order in `roles/base/tasks/main.yml`
+- Includes `base_packages`, `base_locale`, `base_timezone`, `base_ntp`, `base_hostname`, `base_sudo`, and `base_sshd` through explicit `ansible.builtin.include_role` entries
+- Keeps aggregate include-task tags aligned with each child role's phase tags and role-specific tags so targeted runs such as `--tags validate` or `--tags base_packages_validate` stay predictable
 - Can include `base_firewall` as an explicit opt-in follow-up role when `base_include_firewall: true`
+- Reserves `base_include_logging`, `base_include_updates`, and `base_include_apparmor` as future optional aggregate toggles
 
 ## Usage
 Use `base` on Debian-family hosts after the bootstrap phase has already created the automation account:
@@ -22,9 +24,9 @@ Use `base` on Debian-family hosts after the bootstrap phase has already created 
 ```
 
 Bootstrap is handled separately by the standalone `bootstrap` role/playbook.
-Role-specific inputs for `base` currently come from `base_packages_*`, `base_hostname_*`, `base_locale_*`, `base_ntp_*`, `base_sudo_*`, `base_sshd_*`, optional `base_include_firewall` plus `base_firewall_*`, and `base_timezone_*`.
+Role-specific inputs for `base` currently come from `base_packages_*`, `base_hostname_*`, `base_locale_*`, `base_ntp_*`, `base_sudo_*`, `base_sshd_*`, `base_timezone_*`, optional `base_include_firewall` plus `base_firewall_*`, and the future aggregate toggles `base_include_logging`, `base_include_updates`, and `base_include_apparmor`.
 
-Current dependency order in `base` is:
+Current include order in `base` is:
 
 1. `base_packages`
 2. `base_locale`
@@ -34,17 +36,21 @@ Current dependency order in `base` is:
 6. `base_sudo`
 7. `base_sshd`
 
+`roles/base/tasks/main.yml` is the single source of truth for this sequence.
 This keeps foundational packages and system environment first, then time synchronization, then final host identity, sudo policy, and SSH daemon policy.
+
+Aggregate include-task tags in `roles/base/tasks/main.yml` intentionally mirror the child role phase tags and role-specific tags.
+This keeps broad phase runs such as `--tags validate` working across the full base stack while also allowing narrow runs such as `--tags base_packages` or `--tags base_packages_validate` without noisy unrelated role execution.
 
 Optional follow-up role:
 
 1. `base_firewall` when `base_include_firewall: true`
 
-Planned future dependency order after the current roles is:
+Planned future optional follow-up roles after the current roles are:
 
-1. `base_logging`
-2. `base_updates`
-3. `base_apparmor`
+1. `base_logging` when `base_include_logging: true`
+2. `base_updates` when `base_include_updates: true`
+3. `base_apparmor` when `base_include_apparmor: true`
 
 ## License
 MIT

--- a/roles/base/defaults/main.yml
+++ b/roles/base/defaults/main.yml
@@ -4,3 +4,6 @@
 # Defines optional aggregate-role toggles that extend the base phase without changing existing consumers by default.
 
 base_include_firewall: false
+base_include_logging: false
+base_include_updates: false
+base_include_apparmor: false

--- a/roles/base/meta/main.yml
+++ b/roles/base/meta/main.yml
@@ -1,26 +1,6 @@
 ---
 # roles/base/meta/main.yml
 # Role metadata for `base`.
-# Declares dependency roles that are applied when the base phase runs.
+# Leaves dependencies empty because aggregate base-role ordering is defined in `roles/base/tasks/main.yml`.
 
-dependencies:
-  - role: base_packages
-    tags: [base, base_packages]
-  - role: base_locale
-    tags: [base, base_locale]
-  - role: base_timezone
-    tags: [base, base_timezone]
-  - role: base_ntp
-    tags: [base, base_ntp]
-  - role: base_hostname
-    tags: [base, base_hostname]
-  - role: base_sudo
-    tags: [base, base_sudo]
-  - role: base_sshd
-    tags: [base, base_sshd]
-
-# Future base dependencies:
-# - role: base_firewall
-# - role: base_logging
-# - role: base_updates
-# - role: base_apparmor
+dependencies: []

--- a/roles/base/tasks/main.yml
+++ b/roles/base/tasks/main.yml
@@ -1,12 +1,61 @@
 ---
 # roles/base/tasks/main.yml
 # Task entrypoint for the `base` role.
-# Keeps core orchestration in meta dependencies and includes optional follow-up roles when explicitly enabled.
+# Defines the aggregate base-role execution order through explicit role includes.
 
-- name: "Base | Include optional firewall role"
+- name: "Base | Include base_packages role"
+  ansible.builtin.include_role:
+    name: base_packages
+    apply:
+      tags: [base, base_packages]
+  tags: [base, base_packages, assert, install, config, validate, base_packages_assert, base_packages_install, base_packages_config, base_packages_validate]
+
+- name: "Base | Include base_locale role"
+  ansible.builtin.include_role:
+    name: base_locale
+    apply:
+      tags: [base, base_locale]
+  tags: [base, base_locale, assert, install, config, validate, base_locale_assert, base_locale_install, base_locale_config, base_locale_validate]
+
+- name: "Base | Include base_timezone role"
+  ansible.builtin.include_role:
+    name: base_timezone
+    apply:
+      tags: [base, base_timezone]
+  tags: [base, base_timezone, assert, install, config, validate, base_timezone_assert, base_timezone_install, base_timezone_config, base_timezone_validate]
+
+- name: "Base | Include base_ntp role"
+  ansible.builtin.include_role:
+    name: base_ntp
+    apply:
+      tags: [base, base_ntp]
+  tags: [base, base_ntp, assert, install, config, validate, base_ntp_assert, base_ntp_install, base_ntp_config, base_ntp_validate]
+
+- name: "Base | Include base_hostname role"
+  ansible.builtin.include_role:
+    name: base_hostname
+    apply:
+      tags: [base, base_hostname]
+  tags: [base, base_hostname, assert, config, validate, base_hostname_assert, base_hostname_config, base_hostname_validate]
+
+- name: "Base | Include base_sudo role"
+  ansible.builtin.include_role:
+    name: base_sudo
+    apply:
+      tags: [base, base_sudo]
+  tags: [base, base_sudo, assert, install, config, validate, base_sudo_assert, base_sudo_install, base_sudo_config, base_sudo_validate]
+
+- name: "Base | Include base_sshd role"
+  ansible.builtin.include_role:
+    name: base_sshd
+    apply:
+      tags: [base, base_sshd]
+  tags: [base, base_sshd, assert, install, config, validate, base_sshd_assert, base_sshd_install, base_sshd_config, base_sshd_validate]
+
+- name: "Base | Include optional base_firewall role"
   ansible.builtin.include_role:
     name: base_firewall
     apply:
       tags: [base, base_firewall]
   when: base_include_firewall | default(false)
-  tags: [base, base_firewall]
+  tags: [base, base_firewall, assert, install, config, validate, base_firewall_assert, base_firewall_install, base_firewall_config, base_firewall_validate]

--- a/roles/base_locale/README.md
+++ b/roles/base_locale/README.md
@@ -26,7 +26,7 @@ This role intentionally supports built-in locales (`C`, `C.UTF-8`, `POSIX`) plus
 
 ## Usage
 
-The `base` role includes `base_locale` through meta dependencies.
+The `base` role includes `base_locale` through explicit aggregate ordering in `roles/base/tasks/main.yml`.
 
 Direct usage:
 

--- a/roles/base_locale/tasks/config.yml
+++ b/roles/base_locale/tasks/config.yml
@@ -4,6 +4,13 @@
 # Ensures `/etc/locale.gen` is fully managed, requested locales are generated for Debian-family hosts, and the locale category configuration file is written.
 
 - name: "Config | Render locale.gen"
+  vars:
+    base_locale_generated_locales: >-
+      {{
+        base_locale_present
+        | reject('in', ['C', 'C.UTF-8', 'POSIX'])
+        | list
+      }}
   ansible.builtin.template:
     src: locale.gen.j2
     dest: /etc/locale.gen

--- a/roles/base_locale/tasks/main.yml
+++ b/roles/base_locale/tasks/main.yml
@@ -1,17 +1,7 @@
 ---
 # roles/base_locale/tasks/main.yml
 # Task entrypoint for the `base_locale` role.
-# Derives shared locale state, then imports the assert, install, config, and validate phase files in order.
-
-- name: Prepare
-  ansible.builtin.set_fact:
-    base_locale_generated_locales: >-
-      {{
-        base_locale_present
-        | reject('in', ['C', 'C.UTF-8', 'POSIX'])
-        | list
-      }}
-  tags: [always]
+# Imports the assert, install, config, and validate phase files in order.
 
 - name: Assert
   ansible.builtin.import_tasks: assert.yml

--- a/roles/base_locale/tasks/validate.yml
+++ b/roles/base_locale/tasks/validate.yml
@@ -20,6 +20,12 @@
 
 - name: "Validate | Assert managed locale files"
   vars:
+    base_locale_generated_locales: >-
+      {{
+        base_locale_present
+        | reject('in', ['C', 'C.UTF-8', 'POSIX'])
+        | list
+      }}
     base_locale_expected_locale_gen: "{{ lookup('template', 'locale.gen.j2') }}"
     base_locale_expected_default_locale: "{{ lookup('template', 'default_locale.j2') }}"
   ansible.builtin.assert:


### PR DESCRIPTION
- Updated README.md to clarify the use of explicit `include_role` ordering in the `base` role.
- Revised documentation in docs/02-role-workflow.md to reflect changes in role orchestration and tagging practices.
- Modified roles/base/README.md to explain the new execution order and the alignment of include-task tags with child role tags.
- Added optional aggregate toggles for logging, updates, and AppArmor in roles/base/defaults/main.yml.
- Cleared dependencies in roles/base/meta/main.yml as they are now defined in tasks/main.yml.
- Implemented explicit role includes in roles/base/tasks/main.yml for `base_packages`, `base_locale`, `base_timezone`, `base_ntp`, `base_hostname`, `base_sudo`, and `base_sshd`.
- Updated roles/base_locale documentation to reflect the new inclusion method.
- Refactored tasks in roles/base_locale to remove unnecessary preparation steps and ensure proper task imports. #30