### PR TITLE
base_firewall: make role idempotent without resetting UFW state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@
 Release history for `ansible-roles`.
 Documents notable changes across repository structure, roles, examples, and documentation.
 
+## [v0.17.0]
+### Changed
+- Reworked `base_firewall` to enforce an additive UFW baseline by default instead of resetting the firewall whenever the desired managed state changes.
+- Split firewall rule inputs into `base_firewall_base_rules` and `base_firewall_additional_rules`, while keeping `base_firewall_rules` as the effective merged ruleset used by the role.
+- Added the optional `base_firewall_purge_unmanaged_rules` path so exact rebuilds are explicit instead of automatic.
+- Updated the example Ansible configuration to hide skipped-host output for quieter local role runs.
+
+### Fixed
+- Fixed `base_firewall` purge mode so an empty managed ruleset no longer fails on undefined purge-comparison facts and now converges cleanly.
+
+### Documentation
+- Updated repository, role, and example documentation to describe the additive `base_firewall` behavior, the split firewall rule variables, and the quieter example output defaults.
+
 ## [v0.16.0]
 ### Changed
 - Moved aggregate `base` orchestration from meta dependencies to explicit `ansible.builtin.include_role` ordering, making `roles/base/tasks/main.yml` the single source of truth for the base stack.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ ansible-roles/
 ## Available Roles
 - `bootstrap`: Creates and validates the automation account used after the bootstrap phase.
 - `base`: Aggregates recurring base-phase configuration for Debian-family hosts through explicit `include_role` ordering in `roles/base/tasks/main.yml` for `base_packages`, `base_locale`, `base_timezone`, `base_ntp`, `base_hostname`, `base_sudo`, and `base_sshd`, with optional follow-up inclusion for `base_firewall`.
-- `base_firewall`: Enforces a UFW baseline with managed default policies and requested allow or limit rules on Debian-family hosts during the base phase.
+- `base_firewall`: Enforces an additive UFW baseline with managed default policies and requested allow or limit rules on Debian-family hosts during the base phase, with an optional purge mode for exact rebuilds.
 - `base_hostname`: Enforces the system hostname on Debian-family hosts during the base phase.
 - `base_locale`: Ensures requested locales exist and configures the system default locale on Debian-family hosts during the base phase.
 - `base_ntp`: Configures system time synchronization through `systemd-timesyncd` on Debian-family hosts during the base phase.

--- a/docs/01-examples.md
+++ b/docs/01-examples.md
@@ -17,7 +17,7 @@ The example content assumes Debian-family targets such as Debian and Ubuntu.
 
 ## Example Files
 
-- `examples/ansible.cfg`: Example Ansible configuration for local test runs.
+- `examples/ansible.cfg`: Example Ansible configuration for local test runs that also hides skipped-host output for quieter example runs.
 - `examples/inventory/hosts.ini`: Example hosts and groups.
 - `examples/inventory/group_vars/all/`: Example variables for all hosts, split into role-scoped files.
 - `examples/playbooks/bootstrap.yml`: Bootstrap phase playbook that uses initial host credentials and applies the standalone `bootstrap` role.
@@ -60,6 +60,7 @@ ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/test_bas
 - The example inventory and variables assume Debian-family hosts and the repository's APT-based role behavior.
 - `group_vars/all/` is split by role prefix so example variables such as `base_packages.yml`, `base_hostname.yml`, `base_locale.yml`, `base_ntp.yml`, `base_sudo.yml`, `base_sshd.yml`, `base_firewall.yml`, and `base_timezone.yml` stay readable as the base stack grows.
 - `base_firewall.yml` sets `base_include_firewall: true`, which opts the example base run into the optional `base_firewall` role.
+- `ansible.cfg` sets `display_skipped_hosts = False`, so routine conditional skips from optional roles or gated tasks do not dominate the example output.
 - `hosts.ini` keeps default `ansible_user=ansible` in `[all:vars]`, while `[bootstrap:vars]` holds initial login values used only during bootstrap.
 - `playbooks/bootstrap.yml` prompts once for the bootstrap password and reuses it for both SSH login and sudo.
 - `playbooks/test_base_sshd.yml` removes its temporary SSH fixture files in an `always` block after the integration run, so the example host is returned to the normal post-test state.

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,7 +8,7 @@ This example lab targets Debian-family hosts such as Debian and Ubuntu.
 The inventory variables and role inputs assume the repository's Debian-family defaults and filesystem paths.
 
 ## Structure
-- `ansible.cfg`: Test-specific Ansible configuration.
+- `ansible.cfg`: Test-specific Ansible configuration that points at the example inventory and hides skipped-host output for quieter local runs.
 - `inventory/hosts.ini`: Test inventory.
 - `inventory/group_vars/all/`: Shared variables for test hosts, split into per-role files such as `bootstrap.yml`, `base_packages.yml`, `base_hostname.yml`, `base_locale.yml`, `base_ntp.yml`, `base_sudo.yml`, `base_sshd.yml`, `base_firewall.yml`, and `base_timezone.yml`.
 - `playbooks/bootstrap.yml`: Bootstrap phase playbook that connects with the initial admin account and applies the standalone `bootstrap` role.
@@ -50,6 +50,7 @@ ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/test_bas
 
 The SSH integration test playbook cleans up its temporary `/etc/ssh/sshd_config.d/` fixture files in an `always` block, so you do not need to remove them manually after the run.
 `inventory/group_vars/all/base_firewall.yml` also sets `base_include_firewall: true`, which opts the example base run into the optional `base_firewall` role.
+`ansible.cfg` sets `display_skipped_hosts = False`, so optional-role and conditional-task skips are hidden during normal example runs.
 
 ## Bootstrap Credentials
 The example inventory stores only the bootstrap login user:

--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -5,6 +5,7 @@
 [defaults]
 inventory = inventory/hosts.ini
 roles_path = ../roles
+display_skipped_hosts = False
 
 [privilege_escalation]
 become = True

--- a/examples/inventory/group_vars/all/base_firewall.yml
+++ b/examples/inventory/group_vars/all/base_firewall.yml
@@ -1,7 +1,7 @@
 ---
 # examples/inventory/group_vars/all/base_firewall.yml
 # Shared firewall variables for the example lab.
-# Defines the aggregate-role opt-in, UFW package, enabled state, default policies, and managed rule list enforced during the base phase.
+# Defines the aggregate-role opt-in, UFW package, enabled state, default policies, baseline rules, and optional host additions enforced during the base phase.
 
 # Opt in to the optional base_firewall role from the aggregate base role.
 base_include_firewall: true
@@ -22,27 +22,38 @@ base_firewall_default_incoming_policy: deny
 # Default outbound policy for traffic leaving the host.
 base_firewall_default_outgoing_policy: allow
 
+# Keep unmanaged or manual UFW rules by default.
+# Set this to true only when you want the role to reset UFW and rebuild
+# the firewall from base_firewall_rules.
+base_firewall_purge_unmanaged_rules: false
+
 # Path used by the role to store the checksum of the requested managed
-# firewall state. Keep the default unless you have a host-specific reason
-# to place this state file somewhere else under /etc.
+# firewall state after configuration. Keep the default unless you have a
+# host-specific reason to place this state file somewhere else under /etc.
 base_firewall_state_checksum_path: /etc/ufw/.base_firewall_state.sha256
 
-# Firewall rules that must exist in UFW.
+# Firewall baseline rules that must exist in UFW on every host.
 # When the default incoming policy is deny or reject, keep at least one
 # incoming allow or limit rule for the SSH or Ansible management port.
 # This example follows the SSH port managed by base_sshd and rate-limits
 # new connections.
-base_firewall_rules:
+base_firewall_base_rules:
   - rule: limit
     direction: in
     port: "{{ base_sshd_port | string }}"
     proto: tcp
     comment: Limit SSH access
 
-  # Optional service example:
-  # - rule: allow
-  #   direction: in
-  #   port: "8080"
-  #   proto: tcp
-  #   from_ip: 192.168.1.0/24
-  #   comment: Allow Traefik dashboard from LAN
+# Extra rules can be added per host or per group without replacing the
+# shared baseline. For example, a host that runs the Traefik dashboard can
+# set base_firewall_additional_rules in host_vars.
+base_firewall_additional_rules: []
+
+# Example host-specific addition:
+# base_firewall_additional_rules:
+#   - rule: allow
+#     direction: in
+#     port: "8080"
+#     proto: tcp
+#     from_ip: 192.168.1.0/24
+#     comment: Allow Traefik dashboard from LAN

--- a/roles/base_firewall/README.md
+++ b/roles/base_firewall/README.md
@@ -8,9 +8,10 @@ Explains how the role manages a UFW baseline on Debian-family hosts during the b
 - Validates the requested package, state, logging, default-policy, and rule inputs
 - Refuses to enable a deny-or-reject incoming firewall baseline unless the managed rules still allow SSH or Ansible access on the management port
 - Configures UFW logging plus default incoming and outgoing policies
-- Resets and reapplies the managed UFW ruleset when the requested firewall state changes
+- Ensures the requested UFW rules exist without resetting the firewall by default
+- Can optionally purge unmanaged UFW rules by resetting and rebuilding the managed ruleset
 - Enables or disables UFW according to the role input
-- Verifies effective firewall status, the stored state checksum, and the stored added-rule commands after changes
+- Verifies effective firewall status, the stored desired-state checksum, and the stored added-rule commands after changes
 
 ## Variables
 
@@ -21,8 +22,11 @@ Explains how the role manages a UFW baseline on Debian-family hosts during the b
 | `base_firewall_logging` | `low` | no | UFW logging level; supported values are `off`, `on`, `low`, `medium`, `high`, and `full` |
 | `base_firewall_default_incoming_policy` | `deny` | no | Default UFW policy for incoming traffic |
 | `base_firewall_default_outgoing_policy` | `allow` | no | Default UFW policy for outgoing traffic |
-| `base_firewall_state_checksum_path` | `/etc/ufw/.base_firewall_state.sha256` | no | Path used to store the checksum of the requested managed firewall state so rule changes can be reapplied convergently |
-| `base_firewall_rules` | SSH rate-limit rule on `base_sshd_port` | no | Ordered list of UFW rules to ensure are present; supported keys are `rule`, `direction`, `port`, `proto`, `from_ip`, `to_ip`, `comment`, and `log` |
+| `base_firewall_purge_unmanaged_rules` | `false` | no | When `true`, reset UFW and rebuild only the managed rules when the current added-rule list no longer matches `base_firewall_rules` |
+| `base_firewall_state_checksum_path` | `/etc/ufw/.base_firewall_state.sha256` | no | Path used to store the checksum of the requested managed firewall state after configuration |
+| `base_firewall_base_rules` | SSH rate-limit rule on `base_sshd_port` | no | Baseline rules managed by the role for every host |
+| `base_firewall_additional_rules` | `[]` | no | Extra per-host or per-group firewall rules appended to the baseline, such as a Traefik dashboard allow rule |
+| `base_firewall_rules` | `base_firewall_base_rules + base_firewall_additional_rules` | no | Effective ordered list of UFW rules to ensure are present; supported keys are `rule`, `direction`, `port`, `proto`, `from_ip`, `to_ip`, `comment`, and `log` |
 
 ## Usage
 
@@ -50,22 +54,20 @@ Example variables:
 base_include_firewall: true
 base_firewall_default_incoming_policy: deny
 base_firewall_default_outgoing_policy: allow
-base_firewall_rules:
-  - rule: limit
-    direction: in
-    port: "{{ base_sshd_port | default(22) }}"
-    proto: tcp
-    comment: Limit SSH access
+base_firewall_purge_unmanaged_rules: false
+base_firewall_additional_rules:
   - rule: allow
     direction: in
-    port: "443"
+    port: "8080"
     proto: tcp
-    comment: Allow HTTPS
+    from_ip: 192.168.1.0/24
+    comment: Allow Traefik dashboard from LAN
 ```
 
-This role resets and reapplies the managed UFW state when the requested firewall variables change, so removed or changed managed rules do not linger from an older run.
-If you set `base_firewall_default_incoming_policy` to `deny` or `reject`, keep at least one incoming `allow` or `limit` rule for the SSH or Ansible management port in `base_firewall_rules` or the role will fail early.
-Set `comment: ""` on a managed rule when you want the role to clear an older stored UFW comment during the next convergent reapply.
+This role applies an additive firewall baseline by default, so it ensures the requested rules exist while leaving unrelated or manually added UFW rules in place.
+Set `base_firewall_purge_unmanaged_rules: true` when you want the role to reset UFW and rebuild only the managed rules from `base_firewall_rules`.
+Use `base_firewall_base_rules` for the shared baseline and `base_firewall_additional_rules` for host-specific additions such as a Traefik dashboard port on only one host.
+If you set `base_firewall_default_incoming_policy` to `deny` or `reject`, keep at least one incoming `allow` or `limit` rule for the SSH or Ansible management port in the effective `base_firewall_rules` list or the role will fail early.
 Keep `base_firewall_rules` ordered for readability and stable `ufw show added` output.
 Rule directions use `in` and `out` so the stored commands match the long-form syntax used by the Ansible UFW module.
 

--- a/roles/base_firewall/defaults/main.yml
+++ b/roles/base_firewall/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # roles/base_firewall/defaults/main.yml
 # Default variables for the `base_firewall` role.
-# Defines the UFW package, enabled state, default policies, and managed rule list enforced during the base phase.
+# Defines the UFW package, enabled state, default policies, baseline rules, additional rules, and optional purge mode enforced during the base phase.
 
 base_firewall_packages:
   - ufw
@@ -9,10 +9,13 @@ base_firewall_enabled: true
 base_firewall_logging: low
 base_firewall_default_incoming_policy: deny
 base_firewall_default_outgoing_policy: allow
+base_firewall_purge_unmanaged_rules: false
 base_firewall_state_checksum_path: /etc/ufw/.base_firewall_state.sha256
-base_firewall_rules:
+base_firewall_base_rules:
   - rule: limit
     direction: in
     port: "{{ base_sshd_port | default(22) | string }}"
     proto: tcp
     comment: Limit SSH access
+base_firewall_additional_rules: []
+base_firewall_rules: "{{ base_firewall_base_rules + base_firewall_additional_rules }}"

--- a/roles/base_firewall/tasks/assert.yml
+++ b/roles/base_firewall/tasks/assert.yml
@@ -15,8 +15,13 @@
       - base_firewall_default_incoming_policy in ['allow', 'deny', 'reject']
       - base_firewall_default_outgoing_policy is string
       - base_firewall_default_outgoing_policy in ['allow', 'deny', 'reject']
+      - base_firewall_purge_unmanaged_rules is boolean
       - base_firewall_state_checksum_path is string
       - base_firewall_state_checksum_path | trim | length > 0
+      - base_firewall_base_rules is sequence
+      - base_firewall_base_rules is not string
+      - base_firewall_additional_rules is sequence
+      - base_firewall_additional_rules is not string
       - base_firewall_rules is sequence
       - base_firewall_rules is not string
       - (base_firewall_packages | map('string') | list | length) == (base_firewall_packages | length)
@@ -26,8 +31,10 @@
       base_firewall_enabled must be a boolean, base_firewall_logging must use
       a supported UFW logging level, base_firewall_default_incoming_policy and
       base_firewall_default_outgoing_policy must use supported UFW policy
-      values, base_firewall_state_checksum_path must be a non-empty path, and
-      base_firewall_rules must be a list
+      values, base_firewall_purge_unmanaged_rules must be a boolean,
+      base_firewall_state_checksum_path must be a non-empty path,
+      base_firewall_base_rules and base_firewall_additional_rules must be
+      lists, and base_firewall_rules must be a list
     quiet: true
 
 - name: "Assert | Validate base_firewall rule structure"

--- a/roles/base_firewall/tasks/config.yml
+++ b/roles/base_firewall/tasks/config.yml
@@ -1,15 +1,8 @@
 ---
 # roles/base_firewall/tasks/config.yml
 # Config phase tasks for the `base_firewall` role.
-# Resets and reapplies the managed UFW state when requested firewall inputs change.
-# Then enforces logging, default policies, rules, and the final enabled state.
-
-- name: "Config | Read stored firewall state checksum"
-  ansible.builtin.slurp:
-    path: "{{ base_firewall_state_checksum_path }}"
-  register: base_firewall_state_checksum_file
-  failed_when: false
-  changed_when: false
+# Enforces logging, default policies, required rules, and the final enabled state additively by default.
+# Optionally purges unmanaged rules by resetting UFW before rebuilding the managed ruleset.
 
 - name: "Config | Derive desired firewall state checksum"
   ansible.builtin.set_fact:
@@ -20,25 +13,108 @@
           'logging': base_firewall_logging,
           'default_incoming_policy': base_firewall_default_incoming_policy,
           'default_outgoing_policy': base_firewall_default_outgoing_policy,
+          'purge_unmanaged_rules': base_firewall_purge_unmanaged_rules,
           'rules': base_firewall_rules
         }
         | to_json
         | hash('sha256')
       }}
-    base_firewall_current_state_checksum: >-
+
+- name: "Config | Read added firewall rules for purge comparison"
+  ansible.builtin.command: ufw show added
+  register: base_firewall_added_rules
+  changed_when: false
+  when: base_firewall_purge_unmanaged_rules
+
+- name: "Config | Initialize expected firewall rule variants for purge comparison"
+  ansible.builtin.set_fact:
+    base_firewall_config_expected_rule_command_variants: []
+  when: base_firewall_purge_unmanaged_rules
+
+- name: "Config | Collect expected firewall rule variants for purge comparison"
+  vars:
+    base_firewall_expected_rule_command_long: >-
+      {{
+        'ufw '
+        ~ item.rule
+        ~ ' '
+        ~ (item.direction | default('in'))
+        ~ (' log' if (item.log | default(false)) else '')
+        ~ ' from '
+        ~ (item.from_ip | default('any'))
+        ~ ' to '
+        ~ (item.to_ip | default('any'))
+        ~ (' port ' ~ (item.port | string) if (item.port is defined) else '')
+        ~ (' proto ' ~ item.proto if (item.proto is defined) else '')
+        ~ (" comment '" ~ item.comment ~ "'" if (item.comment is defined and item.comment | length > 0) else '')
+      }}
+    base_firewall_expected_rule_command_short: >-
       {{
         (
-          base_firewall_state_checksum_file.content
-          | default('', true)
-          | b64decode
-          | trim
+          'ufw '
+          ~ item.rule
+          ~ ' '
+          ~ ((item.direction | default('in')) ~ ' ' if (item.direction | default('in')) == 'out' else '')
+          ~ ('log ' if (item.log | default(false)) else '')
+          ~ (item.port | string)
+          ~ ('/' ~ item.proto if (item.proto is defined and item.proto != 'any') else '')
+          ~ (" comment '" ~ item.comment ~ "'" if (item.comment is defined and item.comment | length > 0) else '')
         )
+        if (
+          item.port is defined and
+          (item.from_ip | default('any')) == 'any' and
+          (item.to_ip | default('any')) == 'any'
+        )
+        else ''
       }}
+  ansible.builtin.set_fact:
+    base_firewall_config_expected_rule_command_variants: >-
+      {{
+        (base_firewall_config_expected_rule_command_variants | default([]))
+        +
+        [
+          [
+            base_firewall_expected_rule_command_long,
+            base_firewall_expected_rule_command_short
+          ]
+          | reject('equalto', '')
+          | unique
+          | list
+        ]
+      }}
+  loop: "{{ base_firewall_rules }}"
+  loop_control:
+    label: >-
+      {{
+        item.comment
+        | default(item.rule ~ ' ' ~ (item.port | default(item.to_ip | default('any')) | string))
+      }}
+  when: base_firewall_purge_unmanaged_rules
 
-- name: "Config | Reset firewall before reapplying changed managed state"
+- name: "Config | Reset firewall before purging unmanaged rules"
+  vars:
+    base_firewall_missing_purge_rule_count: >-
+      {{
+        base_firewall_config_expected_rule_command_variants
+        | map('intersect', base_firewall_added_rules.stdout_lines)
+        | map('length')
+        | select('equalto', 0)
+        | list
+        | length
+      }}
+    base_firewall_requires_rule_purge: >-
+      {{
+        (base_firewall_added_rules.stdout_lines | length)
+        !=
+        (base_firewall_config_expected_rule_command_variants | length)
+        or
+        (base_firewall_missing_purge_rule_count | int) > 0
+      }}
   community.general.ufw:
     state: reset
-  when: base_firewall_current_state_checksum != base_firewall_desired_state_checksum
+  when:
+    - base_firewall_purge_unmanaged_rules
+    - base_firewall_requires_rule_purge
 
 - name: "Config | Set firewall logging level"
   community.general.ufw:

--- a/roles/base_firewall/tasks/validate.yml
+++ b/roles/base_firewall/tasks/validate.yml
@@ -35,6 +35,7 @@
           'logging': base_firewall_logging,
           'default_incoming_policy': base_firewall_default_incoming_policy,
           'default_outgoing_policy': base_firewall_default_outgoing_policy,
+          'purge_unmanaged_rules': base_firewall_purge_unmanaged_rules,
           'rules': base_firewall_rules
         }
         | to_json
@@ -122,3 +123,89 @@
   loop: "{{ base_firewall_rules }}"
   loop_control:
     label: "{{ base_firewall_expected_rule_commands | first }}"
+
+- name: "Validate | Initialize expected firewall rule variants for purge validation"
+  ansible.builtin.set_fact:
+    base_firewall_validate_expected_rule_command_variants: []
+  when: base_firewall_purge_unmanaged_rules
+
+- name: "Validate | Collect expected firewall rule variants for purge validation"
+  vars:
+    base_firewall_expected_rule_command_long: >-
+      {{
+        'ufw '
+        ~ item.rule
+        ~ ' '
+        ~ (item.direction | default('in'))
+        ~ (' log' if (item.log | default(false)) else '')
+        ~ ' from '
+        ~ (item.from_ip | default('any'))
+        ~ ' to '
+        ~ (item.to_ip | default('any'))
+        ~ (' port ' ~ (item.port | string) if (item.port is defined) else '')
+        ~ (' proto ' ~ item.proto if (item.proto is defined) else '')
+        ~ (" comment '" ~ item.comment ~ "'" if (item.comment is defined and item.comment | length > 0) else '')
+      }}
+    base_firewall_expected_rule_command_short: >-
+      {{
+        (
+          'ufw '
+          ~ item.rule
+          ~ ' '
+          ~ ((item.direction | default('in')) ~ ' ' if (item.direction | default('in')) == 'out' else '')
+          ~ ('log ' if (item.log | default(false)) else '')
+          ~ (item.port | string)
+          ~ ('/' ~ item.proto if (item.proto is defined and item.proto != 'any') else '')
+          ~ (" comment '" ~ item.comment ~ "'" if (item.comment is defined and item.comment | length > 0) else '')
+        )
+        if (
+          item.port is defined and
+          (item.from_ip | default('any')) == 'any' and
+          (item.to_ip | default('any')) == 'any'
+        )
+        else ''
+      }}
+  ansible.builtin.set_fact:
+    base_firewall_validate_expected_rule_command_variants: >-
+      {{
+        (base_firewall_validate_expected_rule_command_variants | default([]))
+        +
+        [
+          [
+            base_firewall_expected_rule_command_long,
+            base_firewall_expected_rule_command_short
+          ]
+          | reject('equalto', '')
+          | unique
+          | list
+        ]
+      }}
+  loop: "{{ base_firewall_rules }}"
+  loop_control:
+    label: >-
+      {{
+        item.comment
+        | default(item.rule ~ ' ' ~ (item.port | default(item.to_ip | default('any')) | string))
+      }}
+  when: base_firewall_purge_unmanaged_rules
+
+- name: "Validate | Assert purge mode rebuilt only managed firewall rules"
+  vars:
+    base_firewall_missing_purge_rule_count: >-
+      {{
+        base_firewall_validate_expected_rule_command_variants
+        | map('intersect', base_firewall_added_rules.stdout_lines)
+        | map('length')
+        | select('equalto', 0)
+        | list
+        | length
+      }}
+  ansible.builtin.assert:
+    that:
+      - (base_firewall_added_rules.stdout_lines | length) == (base_firewall_validate_expected_rule_command_variants | length)
+      - (base_firewall_missing_purge_rule_count | int) == 0
+    fail_msg: >-
+      base_firewall_purge_unmanaged_rules expects ufw show added to contain
+      only the managed firewall rules requested by base_firewall_rules
+    quiet: true
+  when: base_firewall_purge_unmanaged_rules


### PR DESCRIPTION
Refactor the `base_firewall` role to enforce an additive UFW baseline, eliminating the automatic reset on checksum changes. Introduce an optional purge mode for unmanaged rules, allowing for explicit control over firewall state. Update variable definitions to separate base and additional rules while ensuring existing unmanaged rules are preserved. Enhance documentation to reflect these changes and improve usability during local runs by suppressing skipped-host output.

Fixes #32