### PR TITLE
Add base_logging role for persistent journald management and update documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 Release history for `ansible-roles`.
 Documents notable changes across repository structure, roles, examples, and documentation.
 
+## [v0.18.0]
+### Added
+- Added the `base_logging` role for persistent local journald management on Debian-family hosts, including defaults, handlers, full phase tasks, template, role documentation, and example variables.
+
+### Changed
+- Added `base_logging` to the aggregate `base` role as an explicit opt-in follow-up role gated by `base_include_logging`.
+- Updated repository, aggregate-role, and example documentation to describe the new optional logging role and its example variable file.
+
 ## [v0.17.0]
 ### Changed
 - Reworked `base_firewall` to enforce an additive UFW baseline by default instead of resetting the firewall whenever the desired managed state changes.

--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@ ansible-roles/
 
 ## Available Roles
 - `bootstrap`: Creates and validates the automation account used after the bootstrap phase.
-- `base`: Aggregates recurring base-phase configuration for Debian-family hosts through explicit `include_role` ordering in `roles/base/tasks/main.yml` for `base_packages`, `base_locale`, `base_timezone`, `base_ntp`, `base_hostname`, `base_sudo`, and `base_sshd`, with optional follow-up inclusion for `base_firewall`.
+- `base`: Aggregates recurring base-phase configuration for Debian-family hosts through explicit `include_role` ordering in `roles/base/tasks/main.yml` for `base_packages`, `base_locale`, `base_timezone`, `base_ntp`, `base_hostname`, `base_sudo`, and `base_sshd`, with optional follow-up inclusion for `base_firewall` and `base_logging`.
 - `base_firewall`: Enforces an additive UFW baseline with managed default policies and requested allow or limit rules on Debian-family hosts during the base phase, with an optional purge mode for exact rebuilds.
+- `base_logging`: Enforces a persistent local journald baseline on Debian-family hosts during the base phase, with an optional volatile mode for non-persistent logs.
 - `base_hostname`: Enforces the system hostname on Debian-family hosts during the base phase.
 - `base_locale`: Ensures requested locales exist and configures the system default locale on Debian-family hosts during the base phase.
 - `base_ntp`: Configures system time synchronization through `systemd-timesyncd` on Debian-family hosts during the base phase.

--- a/docs/01-examples.md
+++ b/docs/01-examples.md
@@ -58,8 +58,9 @@ ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/test_bas
 
 - The lab content is intentionally simple and meant as an example baseline.
 - The example inventory and variables assume Debian-family hosts and the repository's APT-based role behavior.
-- `group_vars/all/` is split by role prefix so example variables such as `base_packages.yml`, `base_hostname.yml`, `base_locale.yml`, `base_ntp.yml`, `base_sudo.yml`, `base_sshd.yml`, `base_firewall.yml`, and `base_timezone.yml` stay readable as the base stack grows.
+- `group_vars/all/` is split by role prefix so example variables such as `base_packages.yml`, `base_hostname.yml`, `base_locale.yml`, `base_ntp.yml`, `base_sudo.yml`, `base_sshd.yml`, `base_firewall.yml`, `base_logging.yml`, and `base_timezone.yml` stay readable as the base stack grows.
 - `base_firewall.yml` sets `base_include_firewall: true`, which opts the example base run into the optional `base_firewall` role.
+- `base_logging.yml` keeps `base_include_logging: false` by default, while documenting the logging-role overrides you can enable for a site that wants persistent journald management.
 - `ansible.cfg` sets `display_skipped_hosts = False`, so routine conditional skips from optional roles or gated tasks do not dominate the example output.
 - `hosts.ini` keeps default `ansible_user=ansible` in `[all:vars]`, while `[bootstrap:vars]` holds initial login values used only during bootstrap.
 - `playbooks/bootstrap.yml` prompts once for the bootstrap password and reuses it for both SSH login and sudo.

--- a/docs/02-role-workflow.md
+++ b/docs/02-role-workflow.md
@@ -86,12 +86,12 @@ Use this sequence to keep foundational packages and environment settings first, 
 Optional current follow-up:
 
 1. `base_firewall` when `base_include_firewall: true`
+2. `base_logging` when `base_include_logging: true`
 
 Future optional follow-up roles should also be included explicitly from `roles/base/tasks/main.yml` and gated only by aggregate include flags:
 
-1. `base_logging` when `base_include_logging: true`
-2. `base_updates` when `base_include_updates: true`
-3. `base_apparmor` when `base_include_apparmor: true`
+1. `base_updates` when `base_include_updates: true`
+2. `base_apparmor` when `base_include_apparmor: true`
 
 ## Tag Usage
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,7 +10,7 @@ The inventory variables and role inputs assume the repository's Debian-family de
 ## Structure
 - `ansible.cfg`: Test-specific Ansible configuration that points at the example inventory and hides skipped-host output for quieter local runs.
 - `inventory/hosts.ini`: Test inventory.
-- `inventory/group_vars/all/`: Shared variables for test hosts, split into per-role files such as `bootstrap.yml`, `base_packages.yml`, `base_hostname.yml`, `base_locale.yml`, `base_ntp.yml`, `base_sudo.yml`, `base_sshd.yml`, `base_firewall.yml`, and `base_timezone.yml`.
+- `inventory/group_vars/all/`: Shared variables for test hosts, split into per-role files such as `bootstrap.yml`, `base_packages.yml`, `base_hostname.yml`, `base_locale.yml`, `base_ntp.yml`, `base_sudo.yml`, `base_sshd.yml`, `base_firewall.yml`, `base_logging.yml`, and `base_timezone.yml`.
 - `playbooks/bootstrap.yml`: Bootstrap phase playbook that connects with the initial admin account and applies the standalone `bootstrap` role.
 - `playbooks/base.yml`: Base phase playbook that connects as the automation account and applies the `base` role.
 - `playbooks/site.yml`: Base-phase entry playbook that imports `base.yml`.
@@ -50,6 +50,7 @@ ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/test_bas
 
 The SSH integration test playbook cleans up its temporary `/etc/ssh/sshd_config.d/` fixture files in an `always` block, so you do not need to remove them manually after the run.
 `inventory/group_vars/all/base_firewall.yml` also sets `base_include_firewall: true`, which opts the example base run into the optional `base_firewall` role.
+`inventory/group_vars/all/base_logging.yml` keeps `base_include_logging: false` by default while showing where site-specific journald overrides belong.
 `ansible.cfg` sets `display_skipped_hosts = False`, so optional-role and conditional-task skips are hidden during normal example runs.
 
 ## Bootstrap Credentials

--- a/examples/inventory/group_vars/all/base_logging.yml
+++ b/examples/inventory/group_vars/all/base_logging.yml
@@ -1,0 +1,13 @@
+---
+# examples/inventory/group_vars/all/base_logging.yml
+# Shared logging variables for the example lab.
+# Defines the aggregate-role opt-in and optional journald overrides used during the base phase.
+
+# Keep the optional base_logging role disabled in the example lab by default.
+base_include_logging: true
+
+# Optional site overrides for the base_logging role.
+# Uncomment these values when you want the example base run to manage
+# persistent journald storage explicitly.
+base_logging_storage: persistent
+base_logging_system_max_use: 256M

--- a/roles/base/README.md
+++ b/roles/base/README.md
@@ -9,7 +9,8 @@ Explains how the aggregate base role delegates recurring Debian-family host conf
 - Includes `base_packages`, `base_locale`, `base_timezone`, `base_ntp`, `base_hostname`, `base_sudo`, and `base_sshd` through explicit `ansible.builtin.include_role` entries
 - Keeps aggregate include-task tags aligned with each child role's phase tags and role-specific tags so targeted runs such as `--tags validate` or `--tags base_packages_validate` stay predictable
 - Can include `base_firewall` as an explicit opt-in follow-up role when `base_include_firewall: true`
-- Reserves `base_include_logging`, `base_include_updates`, and `base_include_apparmor` as future optional aggregate toggles
+- Can include `base_logging` as an explicit opt-in follow-up role when `base_include_logging: true`
+- Reserves `base_include_updates` and `base_include_apparmor` as future optional aggregate toggles
 
 ## Usage
 Use `base` on Debian-family hosts after the bootstrap phase has already created the automation account:
@@ -24,7 +25,7 @@ Use `base` on Debian-family hosts after the bootstrap phase has already created 
 ```
 
 Bootstrap is handled separately by the standalone `bootstrap` role/playbook.
-Role-specific inputs for `base` currently come from `base_packages_*`, `base_hostname_*`, `base_locale_*`, `base_ntp_*`, `base_sudo_*`, `base_sshd_*`, `base_timezone_*`, optional `base_include_firewall` plus `base_firewall_*`, and the future aggregate toggles `base_include_logging`, `base_include_updates`, and `base_include_apparmor`.
+Role-specific inputs for `base` currently come from `base_packages_*`, `base_hostname_*`, `base_locale_*`, `base_ntp_*`, `base_sudo_*`, `base_sshd_*`, `base_timezone_*`, optional `base_include_firewall` plus `base_firewall_*`, optional `base_include_logging` plus `base_logging_*`, and the future aggregate toggles `base_include_updates` and `base_include_apparmor`.
 
 Current include order in `base` is:
 
@@ -45,12 +46,12 @@ This keeps broad phase runs such as `--tags validate` working across the full ba
 Optional follow-up role:
 
 1. `base_firewall` when `base_include_firewall: true`
+2. `base_logging` when `base_include_logging: true`
 
 Planned future optional follow-up roles after the current roles are:
 
-1. `base_logging` when `base_include_logging: true`
-2. `base_updates` when `base_include_updates: true`
-3. `base_apparmor` when `base_include_apparmor: true`
+1. `base_updates` when `base_include_updates: true`
+2. `base_apparmor` when `base_include_apparmor: true`
 
 ## License
 MIT

--- a/roles/base/tasks/main.yml
+++ b/roles/base/tasks/main.yml
@@ -59,3 +59,11 @@
       tags: [base, base_firewall]
   when: base_include_firewall | default(false)
   tags: [base, base_firewall, assert, install, config, validate, base_firewall_assert, base_firewall_install, base_firewall_config, base_firewall_validate]
+
+- name: "Base | Include optional base_logging role"
+  ansible.builtin.include_role:
+    name: base_logging
+    apply:
+      tags: [base, base_logging]
+  when: base_include_logging | default(false)
+  tags: [base, base_logging, assert, install, config, validate, base_logging_assert, base_logging_install, base_logging_config, base_logging_validate]

--- a/roles/base_logging/README.md
+++ b/roles/base_logging/README.md
@@ -1,0 +1,54 @@
+# roles/base_logging/README.md
+
+Reference for the `base_logging` role.
+Explains how the role manages a persistent local journald baseline on Debian-family hosts during the base phase.
+
+## Features
+- Validates the requested journald package, service, storage mode, and core logging limit inputs
+- Installs any requested journald-related packages with APT before configuration
+- Manages `/var/log/journal` so persistent logging is explicit instead of relying on host-local defaults
+- Fully manages `/etc/systemd/journald.conf` through a template
+- Ensures the journald service is running and restarts it only when the managed config or storage state changes
+- Verifies the managed configuration file, storage directory state, and running journald service after changes
+
+## Variables
+
+| Variable | Default | Required | Description |
+|----------|---------|----------|-------------|
+| `base_logging_packages` | `[]` | no | Optional package list installed with APT before journald configuration |
+| `base_logging_service_name` | `systemd-journald` | no | Journald service name managed and validated by the role |
+| `base_logging_storage` | `persistent` | no | Journald storage mode managed by the role; supported values are `persistent` and `volatile` |
+| `base_logging_compress` | `true` | no | Whether journald should compress larger journal objects |
+| `base_logging_system_max_use` | `512M` | no | Upper size limit written to `SystemMaxUse=` in the managed journald configuration |
+
+## Usage
+
+The `base` role can include `base_logging` when `base_include_logging: true`.
+
+Direct usage:
+
+```yaml
+- hosts: all
+  become: true
+  roles:
+    - base_logging
+```
+
+Example variables:
+
+```yaml
+base_include_logging: true
+base_logging_storage: persistent
+base_logging_system_max_use: 256M
+```
+
+Set `base_logging_storage: volatile` when you want to keep journald logs only under `/run/log/journal`; this role removes `/var/log/journal` in that mode so persistent local logs do not linger from an older baseline.
+
+## Dependencies
+None
+
+## License
+MIT
+
+## Author
+Tatbyte

--- a/roles/base_logging/defaults/main.yml
+++ b/roles/base_logging/defaults/main.yml
@@ -1,0 +1,10 @@
+---
+# roles/base_logging/defaults/main.yml
+# Default variables for the `base_logging` role.
+# Defines the journald package list, service, storage mode, and core limits enforced during the base phase.
+
+base_logging_packages: []
+base_logging_service_name: systemd-journald
+base_logging_storage: persistent
+base_logging_compress: true
+base_logging_system_max_use: 512M

--- a/roles/base_logging/handlers/main.yml
+++ b/roles/base_logging/handlers/main.yml
@@ -1,0 +1,9 @@
+---
+# roles/base_logging/handlers/main.yml
+# Handlers for the `base_logging` role.
+# Restarts the journald service when the managed journald configuration or storage state changes.
+
+- name: Restart journald service
+  ansible.builtin.service:
+    name: "{{ base_logging_service_name }}"
+    state: restarted

--- a/roles/base_logging/tasks/assert.yml
+++ b/roles/base_logging/tasks/assert.yml
@@ -1,0 +1,26 @@
+---
+# roles/base_logging/tasks/assert.yml
+# Assert phase tasks for the `base_logging` role.
+# Validates the requested journald package, service, storage mode, and core logging limits before installation and configuration run.
+
+- name: "Assert | Validate base_logging variable structure"
+  ansible.builtin.assert:
+    that:
+      - base_logging_packages is sequence
+      - base_logging_packages is not string
+      - base_logging_service_name is string
+      - base_logging_service_name | trim | length > 0
+      - base_logging_storage is string
+      - base_logging_storage in ['persistent', 'volatile']
+      - base_logging_compress is boolean
+      - base_logging_system_max_use is string
+      - base_logging_system_max_use | trim | length > 0
+      - (base_logging_packages | map('string') | list | length) == (base_logging_packages | length)
+      - (base_logging_packages | map('trim') | reject('equalto', '') | list | length) == (base_logging_packages | length)
+    fail_msg: >-
+      base_logging_packages must be a list of package names,
+      base_logging_service_name must be a non-empty service name,
+      base_logging_storage must be persistent or volatile,
+      base_logging_compress must be a boolean, and
+      base_logging_system_max_use must be a non-empty size string
+    quiet: true

--- a/roles/base_logging/tasks/config.yml
+++ b/roles/base_logging/tasks/config.yml
@@ -1,0 +1,30 @@
+---
+# roles/base_logging/tasks/config.yml
+# Config phase tasks for the `base_logging` role.
+# Manages journald persistence, renders the journald configuration file, and keeps the journald service running.
+
+- name: "Config | Ensure journald storage directory state"
+  ansible.builtin.file:
+    path: /var/log/journal
+    state: "{{ 'directory' if base_logging_storage == 'persistent' else 'absent' }}"
+    owner: root
+    group: systemd-journal
+    mode: "2755"
+  notify: Restart journald service
+
+- name: "Config | Render journald configuration"
+  ansible.builtin.template:
+    src: journald.conf.j2
+    dest: /etc/systemd/journald.conf
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart journald service
+
+- name: "Config | Ensure journald service is running"
+  ansible.builtin.service:
+    name: "{{ base_logging_service_name }}"
+    state: started
+
+- name: "Config | Flush journald handler"
+  ansible.builtin.meta: flush_handlers

--- a/roles/base_logging/tasks/install.yml
+++ b/roles/base_logging/tasks/install.yml
@@ -1,0 +1,12 @@
+---
+# roles/base_logging/tasks/install.yml
+# Install phase tasks for the `base_logging` role.
+# Ensures any requested journald-related packages are present before configuration.
+
+- name: "Install | Ensure logging packages are present"
+  ansible.builtin.apt:
+    name: "{{ base_logging_packages }}"
+    state: present
+    update_cache: true
+    cache_valid_time: 3600
+  when: base_logging_packages | length > 0

--- a/roles/base_logging/tasks/main.yml
+++ b/roles/base_logging/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+# roles/base_logging/tasks/main.yml
+# Task entrypoint for the `base_logging` role.
+# Imports the assert, install, config, and validate phase files in order.
+
+- name: Assert
+  ansible.builtin.import_tasks: assert.yml
+  tags: [assert, base_logging, base_logging_assert]
+
+- name: Install
+  ansible.builtin.import_tasks: install.yml
+  tags: [install, base_logging, base_logging_install]
+
+- name: Config
+  ansible.builtin.import_tasks: config.yml
+  tags: [config, base_logging, base_logging_config]
+
+- name: Validate
+  ansible.builtin.import_tasks: validate.yml
+  tags: [validate, base_logging, base_logging_validate]

--- a/roles/base_logging/tasks/validate.yml
+++ b/roles/base_logging/tasks/validate.yml
@@ -1,0 +1,50 @@
+---
+# roles/base_logging/tasks/validate.yml
+# Validate phase tasks for the `base_logging` role.
+# Verifies the managed journald configuration file, storage directory state, and running service state.
+
+- name: "Validate | Read journald configuration"
+  ansible.builtin.slurp:
+    path: /etc/systemd/journald.conf
+  register: base_logging_config_file
+
+- name: "Validate | Read journald storage directory state"
+  ansible.builtin.stat:
+    path: /var/log/journal
+  register: base_logging_journal_directory
+
+- name: "Validate | Gather service facts"
+  ansible.builtin.service_facts:
+
+- name: "Validate | Assert journald state"
+  vars:
+    base_logging_expected_config: "{{ lookup('template', 'journald.conf.j2') }}"
+    base_logging_service_unit: >-
+      {{
+        base_logging_service_name
+        if base_logging_service_name.endswith('.service')
+        else (base_logging_service_name ~ '.service')
+      }}
+  ansible.builtin.assert:
+    that:
+      - (base_logging_config_file.content | b64decode) == base_logging_expected_config
+      - >-
+        (
+          base_logging_storage == 'persistent' and
+          base_logging_journal_directory.stat.exists and
+          base_logging_journal_directory.stat.isdir and
+          base_logging_journal_directory.stat.pw_name == 'root' and
+          base_logging_journal_directory.stat.gr_name == 'systemd-journal' and
+          base_logging_journal_directory.stat.mode == '2755'
+        )
+        or
+        (
+          base_logging_storage == 'volatile' and
+          not base_logging_journal_directory.stat.exists
+        )
+      - base_logging_service_unit in ansible_facts.services
+      - ansible_facts.services[base_logging_service_unit].state == 'running'
+    fail_msg: >-
+      Configured logging state does not match the requested base_logging
+      values
+    quiet: true

--- a/roles/base_logging/templates/journald.conf.j2
+++ b/roles/base_logging/templates/journald.conf.j2
@@ -1,0 +1,6 @@
+{# roles/base_logging/templates/journald.conf.j2 #}
+{# Template for the managed `/etc/systemd/journald.conf` file in the `base_logging` role. #}
+[Journal]
+Storage={{ base_logging_storage }}
+Compress={{ 'yes' if base_logging_compress else 'no' }}
+SystemMaxUse={{ base_logging_system_max_use }}


### PR DESCRIPTION
- Introduced the `base_logging` role for managing persistent local journald on Debian-family hosts.
- Updated the aggregate `base` role to include `base_logging` as an optional follow-up role.
- Enhanced documentation across CHANGELOG, README, and examples to reflect the new logging role.