### PR TITLE
Add base_updates role for unattended-upgrades management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 Release history for `ansible-roles`.
 Documents notable changes across repository structure, roles, examples, and documentation.
 
+## [v0.19.0]
+### Added
+- Added the `base_updates` role for minimal unattended-upgrades management on Debian-family hosts, including defaults, full phase tasks, templates, role documentation, and example variables.
+- Added an example `monitoring_authorized_key.yml` inventory file so the example lab now shows the public variables for every current role with defaults.
+
+### Changed
+- Added `base_updates` to the aggregate `base` role as an explicit opt-in follow-up role gated by `base_include_updates`.
+- Updated repository, aggregate-role, and example documentation to describe the new optional updates role and its example variable file.
+- Aligned `monitoring_authorized_key` with the shared phase naming and its canonical `monitoring_authorized_key_*` variable names.
+
 ## [v0.18.0]
 ### Added
 - Added the `base_logging` role for persistent local journald management on Debian-family hosts, including defaults, handlers, full phase tasks, template, role documentation, and example variables.

--- a/README.md
+++ b/README.md
@@ -29,9 +29,10 @@ ansible-roles/
 
 ## Available Roles
 - `bootstrap`: Creates and validates the automation account used after the bootstrap phase.
-- `base`: Aggregates recurring base-phase configuration for Debian-family hosts through explicit `include_role` ordering in `roles/base/tasks/main.yml` for `base_packages`, `base_locale`, `base_timezone`, `base_ntp`, `base_hostname`, `base_sudo`, and `base_sshd`, with optional follow-up inclusion for `base_firewall` and `base_logging`.
+- `base`: Aggregates recurring base-phase configuration for Debian-family hosts through explicit `include_role` ordering in `roles/base/tasks/main.yml` for `base_packages`, `base_locale`, `base_timezone`, `base_ntp`, `base_hostname`, `base_sudo`, and `base_sshd`, with optional follow-up inclusion for `base_firewall`, `base_logging`, and `base_updates`.
 - `base_firewall`: Enforces an additive UFW baseline with managed default policies and requested allow or limit rules on Debian-family hosts during the base phase, with an optional purge mode for exact rebuilds.
 - `base_logging`: Enforces a persistent local journald baseline on Debian-family hosts during the base phase, with an optional volatile mode for non-persistent logs.
+- `base_updates`: Enforces a minimal unattended-upgrades baseline on Debian-family hosts during the base phase through managed APT periodic policy files.
 - `base_hostname`: Enforces the system hostname on Debian-family hosts during the base phase.
 - `base_locale`: Ensures requested locales exist and configures the system default locale on Debian-family hosts during the base phase.
 - `base_ntp`: Configures system time synchronization through `systemd-timesyncd` on Debian-family hosts during the base phase.

--- a/docs/01-examples.md
+++ b/docs/01-examples.md
@@ -58,9 +58,10 @@ ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/test_bas
 
 - The lab content is intentionally simple and meant as an example baseline.
 - The example inventory and variables assume Debian-family hosts and the repository's APT-based role behavior.
-- `group_vars/all/` is split by role prefix so example variables such as `base_packages.yml`, `base_hostname.yml`, `base_locale.yml`, `base_ntp.yml`, `base_sudo.yml`, `base_sshd.yml`, `base_firewall.yml`, `base_logging.yml`, and `base_timezone.yml` stay readable as the base stack grows.
+- `group_vars/all/` is split by role prefix so example variables such as `base_packages.yml`, `base_hostname.yml`, `base_locale.yml`, `base_ntp.yml`, `base_sudo.yml`, `base_sshd.yml`, `base_firewall.yml`, `base_logging.yml`, `base_updates.yml`, `base_timezone.yml`, and `monitoring_authorized_key.yml` stay readable as the stack grows.
 - `base_firewall.yml` sets `base_include_firewall: true`, which opts the example base run into the optional `base_firewall` role.
-- `base_logging.yml` keeps `base_include_logging: false` by default, while documenting the logging-role overrides you can enable for a site that wants persistent journald management.
+- `base_logging.yml` sets `base_include_logging: true`, which opts the example base run into the optional `base_logging` role with persistent journald storage enabled.
+- `base_updates.yml` sets `base_include_updates: true`, which opts the example base run into the optional `base_updates` role with unattended-upgrades enabled.
 - `ansible.cfg` sets `display_skipped_hosts = False`, so routine conditional skips from optional roles or gated tasks do not dominate the example output.
 - `hosts.ini` keeps default `ansible_user=ansible` in `[all:vars]`, while `[bootstrap:vars]` holds initial login values used only during bootstrap.
 - `playbooks/bootstrap.yml` prompts once for the bootstrap password and reuses it for both SSH login and sudo.

--- a/docs/02-role-workflow.md
+++ b/docs/02-role-workflow.md
@@ -87,11 +87,11 @@ Optional current follow-up:
 
 1. `base_firewall` when `base_include_firewall: true`
 2. `base_logging` when `base_include_logging: true`
+3. `base_updates` when `base_include_updates: true`
 
 Future optional follow-up roles should also be included explicitly from `roles/base/tasks/main.yml` and gated only by aggregate include flags:
 
-1. `base_updates` when `base_include_updates: true`
-2. `base_apparmor` when `base_include_apparmor: true`
+1. `base_apparmor` when `base_include_apparmor: true`
 
 ## Tag Usage
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,7 +10,7 @@ The inventory variables and role inputs assume the repository's Debian-family de
 ## Structure
 - `ansible.cfg`: Test-specific Ansible configuration that points at the example inventory and hides skipped-host output for quieter local runs.
 - `inventory/hosts.ini`: Test inventory.
-- `inventory/group_vars/all/`: Shared variables for test hosts, split into per-role files such as `bootstrap.yml`, `base_packages.yml`, `base_hostname.yml`, `base_locale.yml`, `base_ntp.yml`, `base_sudo.yml`, `base_sshd.yml`, `base_firewall.yml`, `base_logging.yml`, and `base_timezone.yml`.
+- `inventory/group_vars/all/`: Shared variables for test hosts, split into per-role files such as `bootstrap.yml`, `base_packages.yml`, `base_hostname.yml`, `base_locale.yml`, `base_ntp.yml`, `base_sudo.yml`, `base_sshd.yml`, `base_firewall.yml`, `base_logging.yml`, `base_updates.yml`, `base_timezone.yml`, and `monitoring_authorized_key.yml`.
 - `playbooks/bootstrap.yml`: Bootstrap phase playbook that connects with the initial admin account and applies the standalone `bootstrap` role.
 - `playbooks/base.yml`: Base phase playbook that connects as the automation account and applies the `base` role.
 - `playbooks/site.yml`: Base-phase entry playbook that imports `base.yml`.
@@ -49,8 +49,9 @@ ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/test_bas
 ```
 
 The SSH integration test playbook cleans up its temporary `/etc/ssh/sshd_config.d/` fixture files in an `always` block, so you do not need to remove them manually after the run.
-`inventory/group_vars/all/base_firewall.yml` also sets `base_include_firewall: true`, which opts the example base run into the optional `base_firewall` role.
-`inventory/group_vars/all/base_logging.yml` keeps `base_include_logging: false` by default while showing where site-specific journald overrides belong.
+`inventory/group_vars/all/base_firewall.yml` sets `base_include_firewall: true`, which opts the example base run into the optional `base_firewall` role.
+`inventory/group_vars/all/base_logging.yml` sets `base_include_logging: true`, which opts the example base run into the optional `base_logging` role with persistent journald storage enabled.
+`inventory/group_vars/all/base_updates.yml` sets `base_include_updates: true`, which opts the example base run into the optional `base_updates` role with unattended-upgrades enabled.
 `ansible.cfg` sets `display_skipped_hosts = False`, so optional-role and conditional-task skips are hidden during normal example runs.
 
 ## Bootstrap Credentials

--- a/examples/inventory/group_vars/all/base_firewall.yml
+++ b/examples/inventory/group_vars/all/base_firewall.yml
@@ -49,6 +49,11 @@ base_firewall_base_rules:
 # set base_firewall_additional_rules in host_vars.
 base_firewall_additional_rules: []
 
+# Effective managed firewall rules used by the role.
+# Keep this derived from the shared baseline plus host or group additions
+# unless you have a strong reason to replace the merge behavior directly.
+# base_firewall_rules: "{{ base_firewall_base_rules + base_firewall_additional_rules }}"
+
 # Example host-specific addition:
 # base_firewall_additional_rules:
 #   - rule: allow

--- a/examples/inventory/group_vars/all/base_logging.yml
+++ b/examples/inventory/group_vars/all/base_logging.yml
@@ -1,13 +1,25 @@
 ---
 # examples/inventory/group_vars/all/base_logging.yml
 # Shared logging variables for the example lab.
-# Defines the aggregate-role opt-in and optional journald overrides used during the base phase.
+# Defines the aggregate-role opt-in plus the journald package, service, storage, and retention values used during the base phase.
 
-# Keep the optional base_logging role disabled in the example lab by default.
+# Opt in to the optional base_logging role from the aggregate base role.
 base_include_logging: true
 
-# Optional site overrides for the base_logging role.
-# Uncomment these values when you want the example base run to manage
-# persistent journald storage explicitly.
+# Package list installed with APT before journald configuration.
+# Keep `systemd` here in the example lab so the journald package baseline is
+# explicitly present before the role manages configuration.
+base_logging_packages:
+  - systemd
+
+# Journald service name managed and validated during the base phase.
+base_logging_service_name: systemd-journald
+
+# Keep persistent journald storage enabled in the example lab.
 base_logging_storage: persistent
+
+# Compress larger journal objects to reduce disk usage.
+base_logging_compress: true
+
+# Limit persistent journal growth in the example lab.
 base_logging_system_max_use: 256M

--- a/examples/inventory/group_vars/all/base_updates.yml
+++ b/examples/inventory/group_vars/all/base_updates.yml
@@ -1,0 +1,25 @@
+---
+# examples/inventory/group_vars/all/base_updates.yml
+# Shared update variables for the example lab.
+# Defines the aggregate-role opt-in plus the unattended-upgrades package and automatic-update policy used during the base phase.
+
+# Opt in to the optional base_updates role from the aggregate base role.
+base_include_updates: true
+
+# Package list installed with APT to provide unattended-upgrades support.
+# Keep `unattended-upgrades` in this list whenever automatic upgrades stay
+# enabled so the backend package exists for the managed APT policy.
+base_updates_packages:
+  - unattended-upgrades  # automatic APT update package used by the base_updates role
+
+# Refresh package lists automatically before unattended-upgrades runs.
+base_updates_auto_update_package_lists: true
+
+# Keep unattended-upgrades enabled in the example lab.
+base_updates_unattended_upgrade: true
+
+# Clean old APT package archives every 3 days in the example lab.
+base_updates_autoclean_interval: 3
+
+# Remove unused dependencies automatically after unattended upgrades.
+base_updates_autoremove: true

--- a/examples/inventory/group_vars/all/monitoring_authorized_key.yml
+++ b/examples/inventory/group_vars/all/monitoring_authorized_key.yml
@@ -1,0 +1,14 @@
+---
+# examples/inventory/group_vars/all/monitoring_authorized_key.yml
+# Shared monitoring authorized-key variables for the example lab.
+# Defines the target user and SSH public key used when the
+# `monitoring_authorized_key` role is applied to a host or group.
+
+# User account that should receive the monitoring or backup SSH public key.
+# Keep `root` only if your monitoring flow truly requires direct root access.
+monitoring_authorized_key_user: root
+
+# Public SSH key allowed to connect for monitoring-style access.
+# Replace this example value with the real public key from your control or
+# monitoring host before applying the role outside of local testing.
+monitoring_authorized_key_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExampleMonitoringKey control-monitoring"

--- a/roles/base/README.md
+++ b/roles/base/README.md
@@ -10,7 +10,8 @@ Explains how the aggregate base role delegates recurring Debian-family host conf
 - Keeps aggregate include-task tags aligned with each child role's phase tags and role-specific tags so targeted runs such as `--tags validate` or `--tags base_packages_validate` stay predictable
 - Can include `base_firewall` as an explicit opt-in follow-up role when `base_include_firewall: true`
 - Can include `base_logging` as an explicit opt-in follow-up role when `base_include_logging: true`
-- Reserves `base_include_updates` and `base_include_apparmor` as future optional aggregate toggles
+- Can include `base_updates` as an explicit opt-in follow-up role when `base_include_updates: true`
+- Reserves `base_include_apparmor` as a future optional aggregate toggle
 
 ## Usage
 Use `base` on Debian-family hosts after the bootstrap phase has already created the automation account:
@@ -25,7 +26,7 @@ Use `base` on Debian-family hosts after the bootstrap phase has already created 
 ```
 
 Bootstrap is handled separately by the standalone `bootstrap` role/playbook.
-Role-specific inputs for `base` currently come from `base_packages_*`, `base_hostname_*`, `base_locale_*`, `base_ntp_*`, `base_sudo_*`, `base_sshd_*`, `base_timezone_*`, optional `base_include_firewall` plus `base_firewall_*`, optional `base_include_logging` plus `base_logging_*`, and the future aggregate toggles `base_include_updates` and `base_include_apparmor`.
+Role-specific inputs for `base` currently come from `base_packages_*`, `base_hostname_*`, `base_locale_*`, `base_ntp_*`, `base_sudo_*`, `base_sshd_*`, `base_timezone_*`, optional `base_include_firewall` plus `base_firewall_*`, optional `base_include_logging` plus `base_logging_*`, optional `base_include_updates` plus `base_updates_*`, and the future aggregate toggle `base_include_apparmor`.
 
 Current include order in `base` is:
 
@@ -47,11 +48,11 @@ Optional follow-up role:
 
 1. `base_firewall` when `base_include_firewall: true`
 2. `base_logging` when `base_include_logging: true`
+3. `base_updates` when `base_include_updates: true`
 
 Planned future optional follow-up roles after the current roles are:
 
-1. `base_updates` when `base_include_updates: true`
-2. `base_apparmor` when `base_include_apparmor: true`
+1. `base_apparmor` when `base_include_apparmor: true`
 
 ## License
 MIT

--- a/roles/base/tasks/main.yml
+++ b/roles/base/tasks/main.yml
@@ -67,3 +67,11 @@
       tags: [base, base_logging]
   when: base_include_logging | default(false)
   tags: [base, base_logging, assert, install, config, validate, base_logging_assert, base_logging_install, base_logging_config, base_logging_validate]
+
+- name: "Base | Include optional base_updates role"
+  ansible.builtin.include_role:
+    name: base_updates
+    apply:
+      tags: [base, base_updates]
+  when: base_include_updates | default(false)
+  tags: [base, base_updates, assert, install, config, validate, base_updates_assert, base_updates_install, base_updates_config, base_updates_validate]

--- a/roles/base_logging/README.md
+++ b/roles/base_logging/README.md
@@ -38,6 +38,8 @@ Example variables:
 
 ```yaml
 base_include_logging: true
+base_logging_packages:
+  - systemd
 base_logging_storage: persistent
 base_logging_system_max_use: 256M
 ```

--- a/roles/base_updates/README.md
+++ b/roles/base_updates/README.md
@@ -1,0 +1,56 @@
+# roles/base_updates/README.md
+
+Reference for the `base_updates` role.
+Explains how the role manages a minimal unattended-upgrades baseline on Debian-family hosts during the base phase.
+
+## Features
+- Installs the unattended-upgrades package baseline with APT before update-policy configuration
+- Validates the requested package list and minimal automatic-update policy inputs
+- Fully manages `/etc/apt/apt.conf.d/20auto-upgrades`
+- Fully manages `/etc/apt/apt.conf.d/50unattended-upgrades`
+- Keeps unattended-upgrades allowed origins configured for the current distro release and its security pocket
+- Verifies the managed APT policy files and requested package state after changes
+
+## Variables
+
+| Variable | Default | Required | Description |
+|----------|---------|----------|-------------|
+| `base_updates_packages` | `['unattended-upgrades']` | no | Package list installed with APT to provide unattended-upgrades support; must include `unattended-upgrades` when automatic upgrades are enabled |
+| `base_updates_auto_update_package_lists` | `true` | no | Whether APT should refresh package lists automatically |
+| `base_updates_unattended_upgrade` | `true` | no | Whether unattended-upgrades should run automatically |
+| `base_updates_autoclean_interval` | `7` | no | Autoclean interval in days written to the managed APT periodic policy |
+| `base_updates_autoremove` | `true` | no | Whether unattended-upgrades should remove unused dependencies automatically |
+
+## Usage
+
+The `base` role can include `base_updates` when `base_include_updates: true`.
+
+Direct usage:
+
+```yaml
+- hosts: all
+  become: true
+  roles:
+    - base_updates
+```
+
+Example variables:
+
+```yaml
+base_include_updates: true
+base_updates_packages:
+  - unattended-upgrades
+base_updates_unattended_upgrade: true
+base_updates_autoclean_interval: 3
+```
+
+Set `base_updates_unattended_upgrade: false` when you want automatic package-list refreshes without automatic unattended package installation; this role still manages the same APT policy files in that mode for explicit, reviewable state.
+
+## Dependencies
+None
+
+## License
+MIT
+
+## Author
+Tatbyte

--- a/roles/base_updates/defaults/main.yml
+++ b/roles/base_updates/defaults/main.yml
@@ -1,0 +1,11 @@
+---
+# roles/base_updates/defaults/main.yml
+# Default variables for the `base_updates` role.
+# Defines the unattended-upgrades package list and minimal automatic-update policy enforced during the base phase.
+
+base_updates_packages:
+  - unattended-upgrades
+base_updates_auto_update_package_lists: true
+base_updates_unattended_upgrade: true
+base_updates_autoclean_interval: 7
+base_updates_autoremove: true

--- a/roles/base_updates/tasks/assert.yml
+++ b/roles/base_updates/tasks/assert.yml
@@ -1,0 +1,33 @@
+---
+# roles/base_updates/tasks/assert.yml
+# Assert phase tasks for the `base_updates` role.
+# Validates the unattended-upgrades package list and minimal automatic-update policy inputs before installation and configuration run.
+
+- name: "Assert | Validate base_updates variable structure"
+  ansible.builtin.assert:
+    that:
+      - base_updates_packages is sequence
+      - base_updates_packages is not string
+      - base_updates_auto_update_package_lists is boolean
+      - base_updates_unattended_upgrade is boolean
+      - base_updates_autoremove is boolean
+      - base_updates_autoclean_interval is integer
+      - (base_updates_autoclean_interval | int) >= 0
+      - (base_updates_packages | map('string') | list | length) == (base_updates_packages | length)
+      - (base_updates_packages | map('trim') | reject('equalto', '') | list | length) == (base_updates_packages | length)
+    fail_msg: >-
+      base_updates_packages must be a list of package names,
+      base_updates_auto_update_package_lists, base_updates_unattended_upgrade,
+      and base_updates_autoremove must be booleans, and
+      base_updates_autoclean_interval must be a non-negative integer
+    quiet: true
+
+- name: "Assert | Require unattended-upgrades package when automatic upgrades are enabled"
+  ansible.builtin.assert:
+    that:
+      - "'unattended-upgrades' in base_updates_packages"
+    fail_msg: >-
+      base_updates_packages must include unattended-upgrades when
+      base_updates_unattended_upgrade is true
+    quiet: true
+  when: base_updates_unattended_upgrade

--- a/roles/base_updates/tasks/config.yml
+++ b/roles/base_updates/tasks/config.yml
@@ -1,0 +1,20 @@
+---
+# roles/base_updates/tasks/config.yml
+# Config phase tasks for the `base_updates` role.
+# Manages the minimal APT automatic-update and unattended-upgrades policy files during the base phase.
+
+- name: "Config | Render APT automatic updates policy"
+  ansible.builtin.template:
+    src: 20auto-upgrades.j2
+    dest: /etc/apt/apt.conf.d/20auto-upgrades
+    owner: root
+    group: root
+    mode: "0644"
+
+- name: "Config | Render unattended-upgrades policy"
+  ansible.builtin.template:
+    src: 50unattended-upgrades.j2
+    dest: /etc/apt/apt.conf.d/50unattended-upgrades
+    owner: root
+    group: root
+    mode: "0644"

--- a/roles/base_updates/tasks/install.yml
+++ b/roles/base_updates/tasks/install.yml
@@ -1,0 +1,12 @@
+---
+# roles/base_updates/tasks/install.yml
+# Install phase tasks for the `base_updates` role.
+# Ensures the unattended-upgrades package baseline is present before configuration.
+
+- name: "Install | Ensure update packages are present"
+  ansible.builtin.apt:
+    name: "{{ base_updates_packages }}"
+    state: present
+    update_cache: true
+    cache_valid_time: 3600
+  when: base_updates_packages | length > 0

--- a/roles/base_updates/tasks/main.yml
+++ b/roles/base_updates/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+# roles/base_updates/tasks/main.yml
+# Task entrypoint for the `base_updates` role.
+# Imports the assert, install, config, and validate phase files in order.
+
+- name: Assert
+  ansible.builtin.import_tasks: assert.yml
+  tags: [assert, base_updates, base_updates_assert]
+
+- name: Install
+  ansible.builtin.import_tasks: install.yml
+  tags: [install, base_updates, base_updates_install]
+
+- name: Config
+  ansible.builtin.import_tasks: config.yml
+  tags: [config, base_updates, base_updates_config]
+
+- name: Validate
+  ansible.builtin.import_tasks: validate.yml
+  tags: [validate, base_updates, base_updates_validate]

--- a/roles/base_updates/tasks/validate.yml
+++ b/roles/base_updates/tasks/validate.yml
@@ -1,0 +1,47 @@
+---
+# roles/base_updates/tasks/validate.yml
+# Validate phase tasks for the `base_updates` role.
+# Verifies the managed APT update policy files and the requested unattended-upgrades package state after configuration.
+
+- name: "Validate | Read APT automatic updates policy"
+  ansible.builtin.slurp:
+    path: /etc/apt/apt.conf.d/20auto-upgrades
+  register: base_updates_auto_updates_file
+
+- name: "Validate | Read unattended-upgrades policy"
+  ansible.builtin.slurp:
+    path: /etc/apt/apt.conf.d/50unattended-upgrades
+  register: base_updates_unattended_upgrades_file
+
+- name: "Validate | Gather package facts"
+  ansible.builtin.package_facts:
+    manager: auto
+
+- name: "Validate | Assert update state"
+  vars:
+    base_updates_expected_auto_updates: "{{ lookup('template', '20auto-upgrades.j2') }}"
+    base_updates_expected_unattended_upgrades: "{{ lookup('template', '50unattended-upgrades.j2') }}"
+  ansible.builtin.assert:
+    that:
+      - (base_updates_auto_updates_file.content | b64decode) == base_updates_expected_auto_updates
+      - >-
+        (
+          base_updates_unattended_upgrades_file.content
+          | b64decode
+        ) == base_updates_expected_unattended_upgrades
+      - >-
+        (
+          base_updates_packages
+          | difference(ansible_facts.packages.keys() | list)
+          | length
+        ) == 0
+      - >-
+        (
+          not base_updates_unattended_upgrade
+        ) or (
+          'unattended-upgrades' in (ansible_facts.packages.keys() | list)
+        )
+    fail_msg: >-
+      Configured update state does not match the requested base_updates
+      values
+    quiet: true

--- a/roles/base_updates/templates/20auto-upgrades.j2
+++ b/roles/base_updates/templates/20auto-upgrades.j2
@@ -1,0 +1,5 @@
+{# roles/base_updates/templates/20auto-upgrades.j2 #}
+{# Template for the managed `/etc/apt/apt.conf.d/20auto-upgrades` file in the `base_updates` role. #}
+APT::Periodic::Update-Package-Lists "{{ '1' if base_updates_auto_update_package_lists else '0' }}";
+APT::Periodic::Unattended-Upgrade "{{ '1' if base_updates_unattended_upgrade else '0' }}";
+APT::Periodic::AutocleanInterval "{{ base_updates_autoclean_interval }}";

--- a/roles/base_updates/templates/50unattended-upgrades.j2
+++ b/roles/base_updates/templates/50unattended-upgrades.j2
@@ -1,0 +1,8 @@
+{# roles/base_updates/templates/50unattended-upgrades.j2 #}
+{# Template for the managed `/etc/apt/apt.conf.d/50unattended-upgrades` file in the `base_updates` role. #}
+Unattended-Upgrade::Allowed-Origins {
+        "${distro_id}:${distro_codename}";
+        "${distro_id}:${distro_codename}-security";
+};
+
+Unattended-Upgrade::Remove-Unused-Dependencies "{{ 'true' if base_updates_autoremove else 'false' }}";

--- a/roles/monitoring_authorized_key/README.md
+++ b/roles/monitoring_authorized_key/README.md
@@ -11,22 +11,23 @@ Explains how the role installs an SSH authorized key for monitoring-style inter-
 
 | Variable | Default | Required | Description |
 |----------|---------|----------|-------------|
-| `monitoring_authorized_user` | `bootstrap_user` or `root` | no | User to add the key to |
-| `monitoring_authorized_key` | `""` | yes | SSH public key to authorize |
+| `monitoring_authorized_key_user` | `root` | no | User account that receives the SSH public key |
+| `monitoring_authorized_key_key` | `""` | yes | SSH public key to authorize |
 
 ## Usage
 
 ```yaml
 - hosts: dns
   roles:
-    - monitoring/authorized_key
+    - role: monitoring_authorized_key
 ```
 
-Set `monitoring_authorized_key` in group_vars for the target hosts:
+Set the role inputs in group or host variables for the target hosts:
 
 ```yaml
-# group_vars/dns/vars.yml
-monitoring_authorized_key: "ssh-ed25519 AAAA... user@control"
+# group_vars/dns/monitoring_authorized_key.yml
+monitoring_authorized_key_user: root
+monitoring_authorized_key_key: "ssh-ed25519 AAAA... user@control"
 ```
 
 ## Dependencies

--- a/roles/monitoring_authorized_key/defaults/main.yml
+++ b/roles/monitoring_authorized_key/defaults/main.yml
@@ -3,5 +3,5 @@
 # Default variables for the `monitoring_authorized_key` role.
 # Defines the target user and the SSH public key managed by this role.
 
-monitoring_authorized_key_user: "{{ monitoring_authorized_key_user | default('root') }}"
+monitoring_authorized_key_user: root
 monitoring_authorized_key_key: ""

--- a/roles/monitoring_authorized_key/tasks/assert.yml
+++ b/roles/monitoring_authorized_key/tasks/assert.yml
@@ -3,17 +3,17 @@
 # Assert phase tasks for the `monitoring_authorized_key` role.
 # Validates the managed user and SSH public key inputs before configuration.
 
-- name: Validate monitoring_authorized_key is defined and non-empty
+- name: Assert | Validate monitoring authorized key input
   ansible.builtin.assert:
     that:
-      - monitoring_authorized_key is defined
-      - monitoring_authorized_key | length > 0
-      - monitoring_authorized_key.startswith('ssh-')
-    fail_msg: "monitoring_authorized_key must be a valid SSH public key"
+      - monitoring_authorized_key_key is string
+      - monitoring_authorized_key_key | length > 0
+      - monitoring_authorized_key_key.startswith('ssh-')
+    fail_msg: "monitoring_authorized_key_key must be a valid SSH public key"
 
-- name: Validate monitoring_authorized_user is defined
+- name: Assert | Validate monitoring authorized key target user
   ansible.builtin.assert:
     that:
-      - monitoring_authorized_user is defined
-      - monitoring_authorized_user | length > 0
-    fail_msg: "monitoring_authorized_user must be defined"
+      - monitoring_authorized_key_user is string
+      - monitoring_authorized_key_user | length > 0
+    fail_msg: "monitoring_authorized_key_user must be defined"

--- a/roles/monitoring_authorized_key/tasks/config.yml
+++ b/roles/monitoring_authorized_key/tasks/config.yml
@@ -1,10 +1,10 @@
 ---
-# roles/monitoring_authorized_key/tasks/configure.yml
+# roles/monitoring_authorized_key/tasks/config.yml
 # Config phase tasks for the `monitoring_authorized_key` role.
 # Installs the requested public key into the target user's authorized_keys file.
 
-- name: Add monitoring authorized key
+- name: Config | Add monitoring authorized key
   ansible.posix.authorized_key:
-    user: "{{ monitoring_authorized_user }}"
+    user: "{{ monitoring_authorized_key_user }}"
     state: present
-    key: "{{ monitoring_authorized_key }}"
+    key: "{{ monitoring_authorized_key_key }}"

--- a/roles/monitoring_authorized_key/tasks/main.yml
+++ b/roles/monitoring_authorized_key/tasks/main.yml
@@ -1,15 +1,19 @@
 ---
 # roles/monitoring_authorized_key/tasks/main.yml
 # Task entrypoint for the `monitoring_authorized_key` role.
-# Imports the assert, configure, and validate phase files in order.
+# Imports the assert, install, config, and validate phase files in order.
 
 - name: Monitoring_authorized_key | Assert
   ansible.builtin.import_tasks: assert.yml
   tags: [monitoring, monitoring_authorized_key, assert]
 
-- name: Monitoring_authorized_key | Configure
-  ansible.builtin.import_tasks: configure.yml
-  tags: [monitoring, monitoring_authorized_key, configure]
+- name: Monitoring_authorized_key | Install
+  ansible.builtin.import_tasks: install.yml
+  tags: [monitoring, monitoring_authorized_key, install]
+
+- name: Monitoring_authorized_key | Config
+  ansible.builtin.import_tasks: config.yml
+  tags: [monitoring, monitoring_authorized_key, config]
 
 - name: Monitoring_authorized_key | Validate
   ansible.builtin.import_tasks: validate.yml

--- a/roles/monitoring_authorized_key/tasks/validate.yml
+++ b/roles/monitoring_authorized_key/tasks/validate.yml
@@ -3,35 +3,35 @@
 # Validate phase tasks for the `monitoring_authorized_key` role.
 # Verifies the target user home path and the installed authorized key state.
 
-- name: Get User Home Directory
+- name: Validate | Read target user account entry
   ansible.builtin.getent:
     database: passwd
     key: "{{ monitoring_authorized_key_user }}"
   register: monitoring_authorized_key_user_info
 
-- name: Set User Home Path
+- name: Validate | Derive target user home path
   ansible.builtin.set_fact:
     monitoring_authorized_key_user_home: "{{ monitoring_authorized_key_user_info.ansible_facts.getent_passwd[monitoring_authorized_key_user][4] }}"
 
-- name: Verify Authorized_keys File Exists For User
+- name: Validate | Read target authorized_keys path
   ansible.builtin.stat:
     path: "{{ monitoring_authorized_key_user_home }}/.ssh/authorized_keys"
   register: monitoring_authorized_key_auth_keys_file
 
-- name: Assert Authorized_keys File Exists
+- name: Validate | Assert authorized_keys file exists
   ansible.builtin.assert:
     that:
       - monitoring_authorized_key_auth_keys_file.stat.exists
     fail_msg: "authorized_keys file not found for user {{ monitoring_authorized_key_user }}"
 
-- name: Verify Monitoring Key Is Present In Authorized_keys
+- name: Validate | Check monitoring key presence in authorized_keys
   ansible.builtin.command:
     cmd: "grep -qF '{{ monitoring_authorized_key_key }}' {{ monitoring_authorized_key_user_home }}/.ssh/authorized_keys"
   changed_when: false
   failed_when: false
   register: monitoring_authorized_key_key_check
 
-- name: Assert Monitoring Key Is Present
+- name: Validate | Assert monitoring key is present
   ansible.builtin.assert:
     that:
       - monitoring_authorized_key_key_check.rc == 0


### PR DESCRIPTION
Introduce the `base_updates` role to manage unattended-upgrades, including default variables, task phases, and templates. Update documentation and examples to reflect this new role and its integration into the aggregate base role. Adjust related variable names for consistency.