### PR TITLE
base_apparmor: add an optional AppArmor baseline role for Debian-family hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 Release history for `ansible-roles`.
 Documents notable changes across repository structure, roles, examples, and documentation.
 
+## [v0.20.0]
+### Added
+- Added the `base_apparmor` role for Debian-family AppArmor baseline management, including defaults, full phase tasks, role documentation, and example variables.
+
+### Changed
+- Added `base_apparmor` to the aggregate `base` role as an explicit opt-in follow-up role gated by `base_include_apparmor`.
+
+### Documentation
+- Updated repository, aggregate-role, and example documentation to describe the new optional AppArmor role and its example variable file.
+
 ## [v0.19.0]
 ### Added
 - Added the `base_updates` role for minimal unattended-upgrades management on Debian-family hosts, including defaults, full phase tasks, templates, role documentation, and example variables.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,21 @@ Repository overview for `ansible-roles`.
 Explains the role collection layout, the intended consumption pattern from another repository, and the local example workflow.
 
 ## Overview
-This repository is a roles source repository. It is intended to be consumed by a separate infra repository that contains your environment-specific inventory and playbooks.
+This repository is a personal Ansible role collection for managing a homelab across multiple hosts.
+It is intended to be consumed by a separate infra repository that contains your environment-specific inventory and playbooks, while `examples/` provides a local validation harness for the roles themselves.
+
+It is being built to learn Ansible and Linux at the same time through repeatable, real-world automation instead of one-off host changes.
+The goal is to keep host setup explicit, rebuildable, and easy to evolve over time so it can serve as a solid baseline for backup, monitoring, recovery, and host recreation workflows in a small self-hosted environment.
+
+## Current Focus
+The current role set is centered on:
+
+- bootstrap access for the automation account
+- recurring base host configuration and hardening
+- monitoring-related access primitives
+
+This is a roles repository, not the full infrastructure repository.
+Inventory, host grouping, secrets, and environment-specific playbooks are expected to live in a separate consumer repo.
 
 ## Supported Platforms
 This repository currently targets Debian-family hosts such as Debian and Ubuntu.
@@ -29,7 +43,8 @@ ansible-roles/
 
 ## Available Roles
 - `bootstrap`: Creates and validates the automation account used after the bootstrap phase.
-- `base`: Aggregates recurring base-phase configuration for Debian-family hosts through explicit `include_role` ordering in `roles/base/tasks/main.yml` for `base_packages`, `base_locale`, `base_timezone`, `base_ntp`, `base_hostname`, `base_sudo`, and `base_sshd`, with optional follow-up inclusion for `base_firewall`, `base_logging`, and `base_updates`.
+- `base`: Aggregates recurring base-phase configuration for Debian-family hosts through explicit `include_role` ordering in `roles/base/tasks/main.yml` for `base_packages`, `base_locale`, `base_timezone`, `base_ntp`, `base_hostname`, `base_sudo`, and `base_sshd`, with optional follow-up inclusion for `base_firewall`, `base_logging`, `base_updates`, and `base_apparmor`.
+- `base_apparmor`: Enforces a minimal AppArmor package and service baseline on Debian-family hosts during the base phase.
 - `base_firewall`: Enforces an additive UFW baseline with managed default policies and requested allow or limit rules on Debian-family hosts during the base phase, with an optional purge mode for exact rebuilds.
 - `base_logging`: Enforces a persistent local journald baseline on Debian-family hosts during the base phase, with an optional volatile mode for non-persistent logs.
 - `base_updates`: Enforces a minimal unattended-upgrades baseline on Debian-family hosts during the base phase through managed APT periodic policy files.

--- a/docs/01-examples.md
+++ b/docs/01-examples.md
@@ -58,10 +58,11 @@ ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/test_bas
 
 - The lab content is intentionally simple and meant as an example baseline.
 - The example inventory and variables assume Debian-family hosts and the repository's APT-based role behavior.
-- `group_vars/all/` is split by role prefix so example variables such as `base_packages.yml`, `base_hostname.yml`, `base_locale.yml`, `base_ntp.yml`, `base_sudo.yml`, `base_sshd.yml`, `base_firewall.yml`, `base_logging.yml`, `base_updates.yml`, `base_timezone.yml`, and `monitoring_authorized_key.yml` stay readable as the stack grows.
+- `group_vars/all/` is split by role prefix so example variables such as `base_packages.yml`, `base_hostname.yml`, `base_locale.yml`, `base_ntp.yml`, `base_sudo.yml`, `base_sshd.yml`, `base_firewall.yml`, `base_logging.yml`, `base_updates.yml`, `base_apparmor.yml`, `base_timezone.yml`, and `monitoring_authorized_key.yml` stay readable as the stack grows.
 - `base_firewall.yml` sets `base_include_firewall: true`, which opts the example base run into the optional `base_firewall` role.
 - `base_logging.yml` sets `base_include_logging: true`, which opts the example base run into the optional `base_logging` role with persistent journald storage enabled.
 - `base_updates.yml` sets `base_include_updates: true`, which opts the example base run into the optional `base_updates` role with unattended-upgrades enabled.
+- `base_apparmor.yml` sets `base_include_apparmor: true`, which opts the example base run into the optional `base_apparmor` role with the AppArmor service enabled.
 - `ansible.cfg` sets `display_skipped_hosts = False`, so routine conditional skips from optional roles or gated tasks do not dominate the example output.
 - `hosts.ini` keeps default `ansible_user=ansible` in `[all:vars]`, while `[bootstrap:vars]` holds initial login values used only during bootstrap.
 - `playbooks/bootstrap.yml` prompts once for the bootstrap password and reuses it for both SSH login and sudo.

--- a/docs/02-role-workflow.md
+++ b/docs/02-role-workflow.md
@@ -88,10 +88,9 @@ Optional current follow-up:
 1. `base_firewall` when `base_include_firewall: true`
 2. `base_logging` when `base_include_logging: true`
 3. `base_updates` when `base_include_updates: true`
+4. `base_apparmor` when `base_include_apparmor: true`
 
-Future optional follow-up roles should also be included explicitly from `roles/base/tasks/main.yml` and gated only by aggregate include flags:
-
-1. `base_apparmor` when `base_include_apparmor: true`
+Future optional follow-up roles should also be included explicitly from `roles/base/tasks/main.yml` and gated only by aggregate include flags.
 
 ## Tag Usage
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,7 +10,7 @@ The inventory variables and role inputs assume the repository's Debian-family de
 ## Structure
 - `ansible.cfg`: Test-specific Ansible configuration that points at the example inventory and hides skipped-host output for quieter local runs.
 - `inventory/hosts.ini`: Test inventory.
-- `inventory/group_vars/all/`: Shared variables for test hosts, split into per-role files such as `bootstrap.yml`, `base_packages.yml`, `base_hostname.yml`, `base_locale.yml`, `base_ntp.yml`, `base_sudo.yml`, `base_sshd.yml`, `base_firewall.yml`, `base_logging.yml`, `base_updates.yml`, `base_timezone.yml`, and `monitoring_authorized_key.yml`.
+- `inventory/group_vars/all/`: Shared variables for test hosts, split into per-role files such as `bootstrap.yml`, `base_packages.yml`, `base_hostname.yml`, `base_locale.yml`, `base_ntp.yml`, `base_sudo.yml`, `base_sshd.yml`, `base_firewall.yml`, `base_logging.yml`, `base_updates.yml`, `base_apparmor.yml`, `base_timezone.yml`, and `monitoring_authorized_key.yml`.
 - `playbooks/bootstrap.yml`: Bootstrap phase playbook that connects with the initial admin account and applies the standalone `bootstrap` role.
 - `playbooks/base.yml`: Base phase playbook that connects as the automation account and applies the `base` role.
 - `playbooks/site.yml`: Base-phase entry playbook that imports `base.yml`.
@@ -52,6 +52,7 @@ The SSH integration test playbook cleans up its temporary `/etc/ssh/sshd_config.
 `inventory/group_vars/all/base_firewall.yml` sets `base_include_firewall: true`, which opts the example base run into the optional `base_firewall` role.
 `inventory/group_vars/all/base_logging.yml` sets `base_include_logging: true`, which opts the example base run into the optional `base_logging` role with persistent journald storage enabled.
 `inventory/group_vars/all/base_updates.yml` sets `base_include_updates: true`, which opts the example base run into the optional `base_updates` role with unattended-upgrades enabled.
+`inventory/group_vars/all/base_apparmor.yml` sets `base_include_apparmor: true`, which opts the example base run into the optional `base_apparmor` role with the AppArmor service enabled.
 `ansible.cfg` sets `display_skipped_hosts = False`, so optional-role and conditional-task skips are hidden during normal example runs.
 
 ## Bootstrap Credentials

--- a/examples/inventory/group_vars/all/base_apparmor.yml
+++ b/examples/inventory/group_vars/all/base_apparmor.yml
@@ -1,0 +1,21 @@
+---
+# examples/inventory/group_vars/all/base_apparmor.yml
+# Shared AppArmor variables for the example lab.
+# Defines the aggregate-role opt-in plus the AppArmor package, service, and enabled-state baseline enforced during the base phase.
+
+# Opt in to the optional base_apparmor role from the aggregate base role.
+base_include_apparmor: true
+
+# Package list installed with APT to provide the AppArmor baseline and
+# validation tooling used by the role.
+base_apparmor_packages:
+  - apparmor
+  - apparmor-utils
+
+# AppArmor service name managed and validated during the base phase.
+base_apparmor_service_name: apparmor
+
+# Keep AppArmor enabled and running in the example lab.
+# Set this to false only on hosts where you explicitly want the package
+# baseline installed without the service being active.
+base_apparmor_enabled: true

--- a/roles/base/README.md
+++ b/roles/base/README.md
@@ -11,7 +11,7 @@ Explains how the aggregate base role delegates recurring Debian-family host conf
 - Can include `base_firewall` as an explicit opt-in follow-up role when `base_include_firewall: true`
 - Can include `base_logging` as an explicit opt-in follow-up role when `base_include_logging: true`
 - Can include `base_updates` as an explicit opt-in follow-up role when `base_include_updates: true`
-- Reserves `base_include_apparmor` as a future optional aggregate toggle
+- Can include `base_apparmor` as an explicit opt-in follow-up role when `base_include_apparmor: true`
 
 ## Usage
 Use `base` on Debian-family hosts after the bootstrap phase has already created the automation account:
@@ -26,7 +26,7 @@ Use `base` on Debian-family hosts after the bootstrap phase has already created 
 ```
 
 Bootstrap is handled separately by the standalone `bootstrap` role/playbook.
-Role-specific inputs for `base` currently come from `base_packages_*`, `base_hostname_*`, `base_locale_*`, `base_ntp_*`, `base_sudo_*`, `base_sshd_*`, `base_timezone_*`, optional `base_include_firewall` plus `base_firewall_*`, optional `base_include_logging` plus `base_logging_*`, optional `base_include_updates` plus `base_updates_*`, and the future aggregate toggle `base_include_apparmor`.
+Role-specific inputs for `base` currently come from `base_packages_*`, `base_hostname_*`, `base_locale_*`, `base_ntp_*`, `base_sudo_*`, `base_sshd_*`, `base_timezone_*`, optional `base_include_firewall` plus `base_firewall_*`, optional `base_include_logging` plus `base_logging_*`, optional `base_include_updates` plus `base_updates_*`, and optional `base_include_apparmor` plus `base_apparmor_*`.
 
 Current include order in `base` is:
 
@@ -49,10 +49,7 @@ Optional follow-up role:
 1. `base_firewall` when `base_include_firewall: true`
 2. `base_logging` when `base_include_logging: true`
 3. `base_updates` when `base_include_updates: true`
-
-Planned future optional follow-up roles after the current roles are:
-
-1. `base_apparmor` when `base_include_apparmor: true`
+4. `base_apparmor` when `base_include_apparmor: true`
 
 ## License
 MIT

--- a/roles/base/tasks/main.yml
+++ b/roles/base/tasks/main.yml
@@ -75,3 +75,11 @@
       tags: [base, base_updates]
   when: base_include_updates | default(false)
   tags: [base, base_updates, assert, install, config, validate, base_updates_assert, base_updates_install, base_updates_config, base_updates_validate]
+
+- name: "Base | Include optional base_apparmor role"
+  ansible.builtin.include_role:
+    name: base_apparmor
+    apply:
+      tags: [base, base_apparmor]
+  when: base_include_apparmor | default(false)
+  tags: [base, base_apparmor, assert, install, config, validate, base_apparmor_assert, base_apparmor_install, base_apparmor_config, base_apparmor_validate]

--- a/roles/base_apparmor/README.md
+++ b/roles/base_apparmor/README.md
@@ -1,0 +1,53 @@
+# roles/base_apparmor/README.md
+
+Reference for the `base_apparmor` role.
+Explains how the role manages a minimal AppArmor baseline on Debian-family hosts during the base phase.
+
+## Features
+- Validates the requested AppArmor package, service, and enabled-state inputs
+- Installs the requested AppArmor package baseline with APT before service configuration
+- Ensures the AppArmor service is enabled and triggers the profile-load path when requested
+- Verifies the requested package state, service enabled state, parser path, and active AppArmor kernel interface after changes
+- Keeps scope intentionally narrow by not authoring custom profiles or changing per-profile enforcement modes
+
+## Variables
+
+| Variable | Default | Required | Description |
+|----------|---------|----------|-------------|
+| `base_apparmor_packages` | `['apparmor', 'apparmor-utils']` | no | Package list installed with APT to provide the AppArmor userspace baseline and status tooling |
+| `base_apparmor_service_name` | `apparmor` | no | AppArmor service name managed and validated by the role |
+| `base_apparmor_enabled` | `true` | no | Whether the role should keep the AppArmor service enabled and trigger profile loading during the base phase |
+
+## Usage
+
+The `base` role can include `base_apparmor` when `base_include_apparmor: true`.
+
+Direct usage:
+
+```yaml
+- hosts: all
+  become: true
+  roles:
+    - base_apparmor
+```
+
+Example variables:
+
+```yaml
+base_include_apparmor: true
+base_apparmor_packages:
+  - apparmor
+  - apparmor-utils
+base_apparmor_enabled: true
+```
+
+Set `base_apparmor_enabled: false` only when you intentionally want to keep the AppArmor package baseline installed while stopping and disabling the service; this role does not manage kernel boot parameters or per-profile modes in that path.
+
+## Dependencies
+None
+
+## License
+MIT
+
+## Author
+Tatbyte

--- a/roles/base_apparmor/defaults/main.yml
+++ b/roles/base_apparmor/defaults/main.yml
@@ -1,0 +1,10 @@
+---
+# roles/base_apparmor/defaults/main.yml
+# Default variables for the `base_apparmor` role.
+# Defines the AppArmor package list, service, and enabled state enforced during the base phase.
+
+base_apparmor_packages:
+  - apparmor
+  - apparmor-utils
+base_apparmor_service_name: apparmor
+base_apparmor_enabled: true

--- a/roles/base_apparmor/tasks/assert.yml
+++ b/roles/base_apparmor/tasks/assert.yml
@@ -1,0 +1,21 @@
+---
+# roles/base_apparmor/tasks/assert.yml
+# Assert phase tasks for the `base_apparmor` role.
+# Validates the requested AppArmor package, service, and enabled-state inputs before installation and configuration run.
+
+- name: "Assert | Validate base_apparmor variable structure"
+  ansible.builtin.assert:
+    that:
+      - base_apparmor_packages is sequence
+      - base_apparmor_packages is not string
+      - base_apparmor_service_name is string
+      - base_apparmor_service_name | trim | length > 0
+      - base_apparmor_enabled is boolean
+      - (base_apparmor_packages | map('string') | list | length) == (base_apparmor_packages | length)
+      - (base_apparmor_packages | map('trim') | reject('equalto', '') | list | length) == (base_apparmor_packages | length)
+      - "'apparmor' in base_apparmor_packages"
+    fail_msg: >-
+      base_apparmor_packages must be a list of non-empty package names that
+      includes apparmor, base_apparmor_service_name must be a non-empty
+      service name, and base_apparmor_enabled must be a boolean
+    quiet: true

--- a/roles/base_apparmor/tasks/config.yml
+++ b/roles/base_apparmor/tasks/config.yml
@@ -1,0 +1,10 @@
+---
+# roles/base_apparmor/tasks/config.yml
+# Config phase tasks for the `base_apparmor` role.
+# Manages the requested AppArmor service enabled state and triggers profile loading during the base phase.
+
+- name: "Config | Ensure AppArmor service enabled state and load path"
+  ansible.builtin.service:
+    name: "{{ base_apparmor_service_name }}"
+    enabled: "{{ base_apparmor_enabled }}"
+    state: "{{ 'started' if base_apparmor_enabled else 'stopped' }}"

--- a/roles/base_apparmor/tasks/install.yml
+++ b/roles/base_apparmor/tasks/install.yml
@@ -1,0 +1,11 @@
+---
+# roles/base_apparmor/tasks/install.yml
+# Install phase tasks for the `base_apparmor` role.
+# Ensures the requested AppArmor packages are present before service configuration and validation.
+
+- name: "Install | Ensure AppArmor packages are present"
+  ansible.builtin.apt:
+    name: "{{ base_apparmor_packages }}"
+    state: present
+    update_cache: true
+    cache_valid_time: 3600

--- a/roles/base_apparmor/tasks/main.yml
+++ b/roles/base_apparmor/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+# roles/base_apparmor/tasks/main.yml
+# Task entrypoint for the `base_apparmor` role.
+# Imports the assert, install, config, and validate phase files in order.
+
+- name: Assert
+  ansible.builtin.import_tasks: assert.yml
+  tags: [assert, base_apparmor, base_apparmor_assert]
+
+- name: Install
+  ansible.builtin.import_tasks: install.yml
+  tags: [install, base_apparmor, base_apparmor_install]
+
+- name: Config
+  ansible.builtin.import_tasks: config.yml
+  tags: [config, base_apparmor, base_apparmor_config]
+
+- name: Validate
+  ansible.builtin.import_tasks: validate.yml
+  tags: [validate, base_apparmor, base_apparmor_validate]

--- a/roles/base_apparmor/tasks/validate.yml
+++ b/roles/base_apparmor/tasks/validate.yml
@@ -1,0 +1,133 @@
+---
+# roles/base_apparmor/tasks/validate.yml
+# Validate phase tasks for the `base_apparmor` role.
+# Verifies the requested package state, service enabled state, parser path, and active AppArmor kernel interface after configuration.
+
+- name: "Validate | Gather package facts"
+  ansible.builtin.package_facts:
+    manager: auto
+
+- name: "Validate | Gather service facts"
+  ansible.builtin.service_facts:
+
+- name: "Validate | Read AppArmor profile directory state"
+  ansible.builtin.stat:
+    path: /etc/apparmor.d
+  register: base_apparmor_profile_directory
+
+- name: "Validate | Read AppArmor profile file list"
+  ansible.builtin.find:
+    paths: /etc/apparmor.d
+    file_type: file
+    recurse: false
+  register: base_apparmor_profile_files
+  when: base_apparmor_profile_directory.stat.exists
+
+- name: "Validate | Read AppArmor parser path at /sbin"
+  ansible.builtin.stat:
+    path: /sbin/apparmor_parser
+  register: base_apparmor_parser_binary_sbin
+
+- name: "Validate | Read AppArmor parser path at /usr/sbin"
+  ansible.builtin.stat:
+    path: /usr/sbin/apparmor_parser
+  register: base_apparmor_parser_binary_usr_sbin
+
+- name: "Validate | Read AppArmor kernel module state"
+  ansible.builtin.stat:
+    path: /sys/module/apparmor
+  register: base_apparmor_kernel_module
+
+- name: "Validate | Read AppArmor kernel enabled flag"
+  ansible.builtin.slurp:
+    path: /sys/module/apparmor/parameters/enabled
+  register: base_apparmor_kernel_enabled_file
+  when: base_apparmor_kernel_module.stat.exists
+
+- name: "Validate | Read AppArmor loaded-profiles interface state"
+  ansible.builtin.stat:
+    path: /sys/kernel/security/apparmor/profiles
+  register: base_apparmor_loaded_profiles_interface
+
+- name: "Validate | Read loaded AppArmor profiles"
+  ansible.builtin.slurp:
+    path: /sys/kernel/security/apparmor/profiles
+  register: base_apparmor_loaded_profiles_file
+  when:
+    - base_apparmor_enabled
+    - base_apparmor_loaded_profiles_interface.stat.exists
+
+- name: "Validate | Assert AppArmor state"
+  vars:
+    base_apparmor_service_unit: >-
+      {{
+        base_apparmor_service_name
+        if base_apparmor_service_name.endswith('.service')
+        else (base_apparmor_service_name ~ '.service')
+      }}
+    base_apparmor_expected_service_statuses: >-
+      {{
+        ['enabled', 'enabled-runtime']
+        if base_apparmor_enabled
+        else ['disabled']
+      }}
+  ansible.builtin.assert:
+    that:
+      - >-
+        (
+          base_apparmor_packages
+          | difference(ansible_facts.packages.keys() | list)
+          | length
+        ) == 0
+      - base_apparmor_service_unit in ansible_facts.services
+      - ansible_facts.services[base_apparmor_service_unit].status in base_apparmor_expected_service_statuses
+      - base_apparmor_profile_directory.stat.exists
+      - base_apparmor_profile_directory.stat.isdir
+      - (base_apparmor_profile_files.matched | default(0) | int) > 0
+      - >-
+        (
+          base_apparmor_parser_binary_sbin.stat.exists
+          | default(false)
+        )
+        or
+        (
+          base_apparmor_parser_binary_usr_sbin.stat.exists
+          | default(false)
+        )
+      - base_apparmor_kernel_module.stat.exists
+      - >-
+        (
+          not base_apparmor_enabled
+        ) or (
+          base_apparmor_kernel_enabled_file is defined
+          and
+          (
+            base_apparmor_kernel_enabled_file.content
+            | b64decode
+            | trim
+            | lower
+          ) in ['y', 'yes', '1']
+        )
+      - >-
+        (
+          not base_apparmor_enabled
+        ) or (
+          base_apparmor_loaded_profiles_interface.stat.exists
+        )
+      - >-
+        (
+          not base_apparmor_enabled
+        ) or (
+          base_apparmor_loaded_profiles_file is defined
+          and
+          (
+            base_apparmor_loaded_profiles_file.content
+            | b64decode
+            | trim
+            | length
+          ) > 0
+        )
+    fail_msg: >-
+      Configured AppArmor state does not match the requested base_apparmor
+      values
+    quiet: true


### PR DESCRIPTION
Introduce the `base_apparmor` role to provide a minimal AppArmor baseline for Debian-family hosts. This role installs necessary AppArmor packages, ensures the service is enabled and running, and validates the active AppArmor state. The implementation includes structured tasks for assertion, installation, configuration, and validation, enhancing host hardening and maintaining consistency within the aggregate base role framework.

Fixes #38