### PR TITLE
Add base_upgrade role for explicit package upgrades and update documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 Release history for `ansible-roles`.
 Documents notable changes across repository structure, roles, examples, and documentation.
 
+## [v0.21.0]
+### Added
+- Added the `base_upgrade` role for explicit Debian-family package upgrades, including defaults, full phase tasks, role documentation, and example variables.
+
+### Changed
+- Added `base_upgrade` to the aggregate `base` role as an explicit opt-in follow-up role gated by `base_include_upgrade`.
+
+### Documentation
+- Updated repository, aggregate-role, and example documentation to describe the new optional upgrade role, its example variable file, and the `serial: 1` example base-playbook behavior for safer reboot-capable runs.
+
 ## [v0.20.0]
 ### Added
 - Added the `base_apparmor` role for Debian-family AppArmor baseline management, including defaults, full phase tasks, role documentation, and example variables.

--- a/README.md
+++ b/README.md
@@ -43,10 +43,11 @@ ansible-roles/
 
 ## Available Roles
 - `bootstrap`: Creates and validates the automation account used after the bootstrap phase.
-- `base`: Aggregates recurring base-phase configuration for Debian-family hosts through explicit `include_role` ordering in `roles/base/tasks/main.yml` for `base_packages`, `base_locale`, `base_timezone`, `base_ntp`, `base_hostname`, `base_sudo`, and `base_sshd`, with optional follow-up inclusion for `base_firewall`, `base_logging`, `base_updates`, and `base_apparmor`.
+- `base`: Aggregates recurring base-phase configuration for Debian-family hosts through explicit `include_role` ordering in `roles/base/tasks/main.yml` for `base_packages`, `base_locale`, `base_timezone`, `base_ntp`, `base_hostname`, `base_sudo`, and `base_sshd`, with optional follow-up inclusion for `base_firewall`, `base_logging`, `base_updates`, `base_apparmor`, and `base_upgrade`.
 - `base_apparmor`: Enforces a minimal AppArmor package and service baseline on Debian-family hosts during the base phase.
 - `base_firewall`: Enforces an additive UFW baseline with managed default policies and requested allow or limit rules on Debian-family hosts during the base phase, with an optional purge mode for exact rebuilds.
 - `base_logging`: Enforces a persistent local journald baseline on Debian-family hosts during the base phase, with an optional volatile mode for non-persistent logs.
+- `base_upgrade`: Applies an explicit APT upgrade pass with optional autoremove and reboot handling on Debian-family hosts during the base phase.
 - `base_updates`: Enforces a minimal unattended-upgrades baseline on Debian-family hosts during the base phase through managed APT periodic policy files.
 - `base_hostname`: Enforces the system hostname on Debian-family hosts during the base phase.
 - `base_locale`: Ensures requested locales exist and configures the system default locale on Debian-family hosts during the base phase.

--- a/docs/01-examples.md
+++ b/docs/01-examples.md
@@ -21,7 +21,7 @@ The example content assumes Debian-family targets such as Debian and Ubuntu.
 - `examples/inventory/hosts.ini`: Example hosts and groups.
 - `examples/inventory/group_vars/all/`: Example variables for all hosts, split into role-scoped files.
 - `examples/playbooks/bootstrap.yml`: Bootstrap phase playbook that uses initial host credentials and applies the standalone `bootstrap` role.
-- `examples/playbooks/base.yml`: Base phase playbook for post-bootstrap role execution.
+- `examples/playbooks/base.yml`: Base phase playbook for post-bootstrap role execution that applies the aggregate base role one host at a time for safer reboot-capable runs.
 - `examples/playbooks/site.yml`: Base-phase entry playbook that imports `base.yml`.
 - `examples/playbooks/test_base_sshd.yml`: Optional integration test playbook for exercising merged `sshd_config.d` fragments plus `Match User` and `Match Address` behavior around the `base_sshd` role.
 
@@ -58,11 +58,13 @@ ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/test_bas
 
 - The lab content is intentionally simple and meant as an example baseline.
 - The example inventory and variables assume Debian-family hosts and the repository's APT-based role behavior.
-- `group_vars/all/` is split by role prefix so example variables such as `base_packages.yml`, `base_hostname.yml`, `base_locale.yml`, `base_ntp.yml`, `base_sudo.yml`, `base_sshd.yml`, `base_firewall.yml`, `base_logging.yml`, `base_updates.yml`, `base_apparmor.yml`, `base_timezone.yml`, and `monitoring_authorized_key.yml` stay readable as the stack grows.
+- `group_vars/all/` is split by role prefix so example variables such as `base_packages.yml`, `base_hostname.yml`, `base_locale.yml`, `base_ntp.yml`, `base_sudo.yml`, `base_sshd.yml`, `base_firewall.yml`, `base_logging.yml`, `base_updates.yml`, `base_apparmor.yml`, `base_upgrade.yml`, `base_timezone.yml`, and `monitoring_authorized_key.yml` stay readable as the stack grows.
 - `base_firewall.yml` sets `base_include_firewall: true`, which opts the example base run into the optional `base_firewall` role.
 - `base_logging.yml` sets `base_include_logging: true`, which opts the example base run into the optional `base_logging` role with persistent journald storage enabled.
 - `base_updates.yml` sets `base_include_updates: true`, which opts the example base run into the optional `base_updates` role with unattended-upgrades enabled.
 - `base_apparmor.yml` sets `base_include_apparmor: true`, which opts the example base run into the optional `base_apparmor` role with the AppArmor service enabled.
+- `base_upgrade.yml` keeps `base_include_upgrade: false` by default, so the example lab documents the role inputs without turning every base run into an immediate package-maintenance operation.
+- `playbooks/base.yml` uses `serial: 1`, which is safer when optional roles such as `base_upgrade` may reboot a host during the run.
 - `ansible.cfg` sets `display_skipped_hosts = False`, so routine conditional skips from optional roles or gated tasks do not dominate the example output.
 - `hosts.ini` keeps default `ansible_user=ansible` in `[all:vars]`, while `[bootstrap:vars]` holds initial login values used only during bootstrap.
 - `playbooks/bootstrap.yml` prompts once for the bootstrap password and reuses it for both SSH login and sudo.

--- a/docs/02-role-workflow.md
+++ b/docs/02-role-workflow.md
@@ -89,6 +89,7 @@ Optional current follow-up:
 2. `base_logging` when `base_include_logging: true`
 3. `base_updates` when `base_include_updates: true`
 4. `base_apparmor` when `base_include_apparmor: true`
+5. `base_upgrade` when `base_include_upgrade: true`
 
 Future optional follow-up roles should also be included explicitly from `roles/base/tasks/main.yml` and gated only by aggregate include flags.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,9 +10,9 @@ The inventory variables and role inputs assume the repository's Debian-family de
 ## Structure
 - `ansible.cfg`: Test-specific Ansible configuration that points at the example inventory and hides skipped-host output for quieter local runs.
 - `inventory/hosts.ini`: Test inventory.
-- `inventory/group_vars/all/`: Shared variables for test hosts, split into per-role files such as `bootstrap.yml`, `base_packages.yml`, `base_hostname.yml`, `base_locale.yml`, `base_ntp.yml`, `base_sudo.yml`, `base_sshd.yml`, `base_firewall.yml`, `base_logging.yml`, `base_updates.yml`, `base_apparmor.yml`, `base_timezone.yml`, and `monitoring_authorized_key.yml`.
+- `inventory/group_vars/all/`: Shared variables for test hosts, split into per-role files such as `bootstrap.yml`, `base_packages.yml`, `base_hostname.yml`, `base_locale.yml`, `base_ntp.yml`, `base_sudo.yml`, `base_sshd.yml`, `base_firewall.yml`, `base_logging.yml`, `base_updates.yml`, `base_apparmor.yml`, `base_upgrade.yml`, `base_timezone.yml`, and `monitoring_authorized_key.yml`.
 - `playbooks/bootstrap.yml`: Bootstrap phase playbook that connects with the initial admin account and applies the standalone `bootstrap` role.
-- `playbooks/base.yml`: Base phase playbook that connects as the automation account and applies the `base` role.
+- `playbooks/base.yml`: Base phase playbook that connects as the automation account, applies the `base` role, and uses `serial: 1` so reboot-capable base runs process one host at a time.
 - `playbooks/site.yml`: Base-phase entry playbook that imports `base.yml`.
 - `playbooks/test_base_sshd.yml`: Integration test playbook that temporarily adds extra SSH daemon fragments, runs `base_sshd`, verifies merged `AllowUsers` plus `Match User` and `Match Address` behavior, and removes the temporary fixtures.
 
@@ -53,6 +53,8 @@ The SSH integration test playbook cleans up its temporary `/etc/ssh/sshd_config.
 `inventory/group_vars/all/base_logging.yml` sets `base_include_logging: true`, which opts the example base run into the optional `base_logging` role with persistent journald storage enabled.
 `inventory/group_vars/all/base_updates.yml` sets `base_include_updates: true`, which opts the example base run into the optional `base_updates` role with unattended-upgrades enabled.
 `inventory/group_vars/all/base_apparmor.yml` sets `base_include_apparmor: true`, which opts the example base run into the optional `base_apparmor` role with the AppArmor service enabled.
+`inventory/group_vars/all/base_upgrade.yml` keeps `base_include_upgrade: false` by default, so the example lab documents the role inputs without making every base run apply immediate package upgrades.
+`playbooks/base.yml` uses `serial: 1`, which is safer when optional roles such as `base_upgrade` may reboot a host during the run.
 `ansible.cfg` sets `display_skipped_hosts = False`, so optional-role and conditional-task skips are hidden during normal example runs.
 
 ## Bootstrap Credentials

--- a/examples/inventory/group_vars/all/base_upgrade.yml
+++ b/examples/inventory/group_vars/all/base_upgrade.yml
@@ -1,0 +1,33 @@
+---
+# examples/inventory/group_vars/all/base_upgrade.yml
+# Shared upgrade variables for the example lab.
+# Defines the aggregate-role opt-in plus the immediate APT upgrade behavior available during the base phase.
+
+# Keep the optional base_upgrade role disabled by default in the example lab.
+# This role performs immediate package maintenance, so `false` is the safer
+# normal value when you do not want every base run to apply upgrades, restart
+# services indirectly, or leave the host waiting for reboot.
+# It is set to `true` here only while actively testing the role behavior.
+# The example base playbook uses `serial: 1` so reboot-capable runs can
+# process one host at a time instead of upgrading and rebooting everything
+# in parallel.
+base_include_upgrade: true
+
+# Refresh package metadata on every explicit upgrade run in the example lab.
+base_upgrade_cache_valid_time: 0
+
+# Use the safer upgrade mode by default so packages that require broader
+# dependency changes stay reviewable.
+base_upgrade_mode: safe
+
+# Keep autoremove disabled by default for explicit example runs.
+base_upgrade_autoremove: false
+
+# Never reboot automatically during the example base run unless you
+# explicitly opt into that behavior. If you do enable automatic reboot,
+# keep the example playbook's `serial: 1` behavior so hosts are handled
+# one at a time.
+base_upgrade_allow_reboot: false
+
+# Expose reboot-required state without failing the example run by default.
+base_upgrade_fail_if_reboot_required: false

--- a/examples/playbooks/base.yml
+++ b/examples/playbooks/base.yml
@@ -1,11 +1,12 @@
 ---
 # examples/playbooks/base.yml
 # Base phase playbook for the example lab.
-# Connects as the automation account after bootstrap and applies the `base` role.
+# Connects as the automation account after bootstrap and applies the `base` role one host at a time for safer reboot-capable runs.
 
 - name: Apply base role after bootstrap
   hosts: all
+  # Run one host at a time so optional reboot-capable roles stay safer.
+  serial: 1
   become: true
   roles:
     - role: base
-      tags: [base]

--- a/roles/base/README.md
+++ b/roles/base/README.md
@@ -12,6 +12,7 @@ Explains how the aggregate base role delegates recurring Debian-family host conf
 - Can include `base_logging` as an explicit opt-in follow-up role when `base_include_logging: true`
 - Can include `base_updates` as an explicit opt-in follow-up role when `base_include_updates: true`
 - Can include `base_apparmor` as an explicit opt-in follow-up role when `base_include_apparmor: true`
+- Can include `base_upgrade` as an explicit opt-in follow-up role when `base_include_upgrade: true`
 
 ## Usage
 Use `base` on Debian-family hosts after the bootstrap phase has already created the automation account:
@@ -26,7 +27,7 @@ Use `base` on Debian-family hosts after the bootstrap phase has already created 
 ```
 
 Bootstrap is handled separately by the standalone `bootstrap` role/playbook.
-Role-specific inputs for `base` currently come from `base_packages_*`, `base_hostname_*`, `base_locale_*`, `base_ntp_*`, `base_sudo_*`, `base_sshd_*`, `base_timezone_*`, optional `base_include_firewall` plus `base_firewall_*`, optional `base_include_logging` plus `base_logging_*`, optional `base_include_updates` plus `base_updates_*`, and optional `base_include_apparmor` plus `base_apparmor_*`.
+Role-specific inputs for `base` currently come from `base_packages_*`, `base_hostname_*`, `base_locale_*`, `base_ntp_*`, `base_sudo_*`, `base_sshd_*`, `base_timezone_*`, optional `base_include_firewall` plus `base_firewall_*`, optional `base_include_logging` plus `base_logging_*`, optional `base_include_updates` plus `base_updates_*`, optional `base_include_apparmor` plus `base_apparmor_*`, and optional `base_include_upgrade` plus `base_upgrade_*`.
 
 Current include order in `base` is:
 
@@ -50,6 +51,7 @@ Optional follow-up role:
 2. `base_logging` when `base_include_logging: true`
 3. `base_updates` when `base_include_updates: true`
 4. `base_apparmor` when `base_include_apparmor: true`
+5. `base_upgrade` when `base_include_upgrade: true`
 
 ## License
 MIT

--- a/roles/base/defaults/main.yml
+++ b/roles/base/defaults/main.yml
@@ -7,3 +7,4 @@ base_include_firewall: false
 base_include_logging: false
 base_include_updates: false
 base_include_apparmor: false
+base_include_upgrade: false

--- a/roles/base/tasks/main.yml
+++ b/roles/base/tasks/main.yml
@@ -83,3 +83,11 @@
       tags: [base, base_apparmor]
   when: base_include_apparmor | default(false)
   tags: [base, base_apparmor, assert, install, config, validate, base_apparmor_assert, base_apparmor_install, base_apparmor_config, base_apparmor_validate]
+
+- name: "Base | Include optional base_upgrade role"
+  ansible.builtin.include_role:
+    name: base_upgrade
+    apply:
+      tags: [base, base_upgrade]
+  when: base_include_upgrade | default(false)
+  tags: [base, base_upgrade, assert, config, validate, base_upgrade_assert, base_upgrade_config, base_upgrade_validate]

--- a/roles/base_updates/README.md
+++ b/roles/base_updates/README.md
@@ -45,6 +45,7 @@ base_updates_autoclean_interval: 3
 ```
 
 Set `base_updates_unattended_upgrade: false` when you want automatic package-list refreshes without automatic unattended package installation; this role still manages the same APT policy files in that mode for explicit, reviewable state.
+Use `base_upgrade` separately when you want the current Ansible run to apply upgrades immediately instead of only managing future automatic-update policy.
 
 ## Dependencies
 None

--- a/roles/base_upgrade/README.md
+++ b/roles/base_upgrade/README.md
@@ -1,0 +1,60 @@
+# roles/base_upgrade/README.md
+
+Reference for the `base_upgrade` role.
+Explains how the role applies explicit APT package upgrades on Debian-family hosts during the base phase.
+
+## Features
+- Validates the requested APT cache, upgrade mode, autoremove, and reboot-handling inputs
+- Refreshes APT package metadata before applying upgrades
+- Applies either a safe upgrade or a full upgrade explicitly during the run
+- Optionally removes unused packages after the upgrade
+- Detects whether the host requires reboot after package maintenance
+- Can reboot automatically only when explicitly enabled
+- Verifies the requested upgrade convergence and resulting reboot-required state after changes
+
+## Variables
+
+| Variable | Default | Required | Description |
+|----------|---------|----------|-------------|
+| `base_upgrade_cache_valid_time` | `0` | no | APT cache age in seconds before the role refreshes package metadata; `0` forces a refresh on every role run |
+| `base_upgrade_mode` | `safe` | no | Upgrade mode applied during the run; supported values are `safe` and `full` |
+| `base_upgrade_autoremove` | `false` | no | Whether the role should remove unused dependency packages after the requested upgrade |
+| `base_upgrade_allow_reboot` | `false` | no | Whether the role may reboot the host automatically when package maintenance requires it |
+| `base_upgrade_fail_if_reboot_required` | `false` | no | Whether the role should fail validation when the host still requires reboot after package maintenance |
+
+## Usage
+
+The `base` role can include `base_upgrade` when `base_include_upgrade: true`.
+
+Direct usage:
+
+```yaml
+- hosts: all
+  serial: 1
+  become: true
+  roles:
+    - base_upgrade
+```
+
+Example variables:
+
+```yaml
+base_include_upgrade: true
+base_upgrade_mode: safe
+base_upgrade_autoremove: false
+base_upgrade_allow_reboot: false
+base_upgrade_fail_if_reboot_required: false
+```
+
+Use `base_updates` when you want to manage unattended-upgrades policy for future automatic maintenance.
+Use `base_upgrade` when you want a reviewable, immediate upgrade action during the current Ansible run.
+When `base_upgrade_allow_reboot: true`, prefer running the play with `serial: 1` so only one host upgrades and reboots at a time.
+
+## Dependencies
+None
+
+## License
+MIT
+
+## Author
+Tatbyte

--- a/roles/base_upgrade/defaults/main.yml
+++ b/roles/base_upgrade/defaults/main.yml
@@ -1,0 +1,10 @@
+---
+# roles/base_upgrade/defaults/main.yml
+# Default variables for the `base_upgrade` role.
+# Defines the APT cache policy, upgrade mode, autoremove behavior, and reboot handling enforced during the base phase.
+
+base_upgrade_cache_valid_time: 0
+base_upgrade_mode: safe
+base_upgrade_autoremove: false
+base_upgrade_allow_reboot: false
+base_upgrade_fail_if_reboot_required: false

--- a/roles/base_upgrade/tasks/assert.yml
+++ b/roles/base_upgrade/tasks/assert.yml
@@ -1,0 +1,21 @@
+---
+# roles/base_upgrade/tasks/assert.yml
+# Assert phase tasks for the `base_upgrade` role.
+# Validates the requested APT cache, upgrade mode, autoremove, and reboot-handling inputs before package maintenance runs.
+
+- name: "Assert | Validate base_upgrade variable structure"
+  ansible.builtin.assert:
+    that:
+      - base_upgrade_cache_valid_time is integer
+      - (base_upgrade_cache_valid_time | int) >= 0
+      - base_upgrade_mode is string
+      - base_upgrade_mode in ['safe', 'full']
+      - base_upgrade_autoremove is boolean
+      - base_upgrade_allow_reboot is boolean
+      - base_upgrade_fail_if_reboot_required is boolean
+    fail_msg: >-
+      base_upgrade_cache_valid_time must be a non-negative integer,
+      base_upgrade_mode must be safe or full, and
+      base_upgrade_autoremove, base_upgrade_allow_reboot, and
+      base_upgrade_fail_if_reboot_required must be booleans
+    quiet: true

--- a/roles/base_upgrade/tasks/config.yml
+++ b/roles/base_upgrade/tasks/config.yml
@@ -1,0 +1,62 @@
+---
+# roles/base_upgrade/tasks/config.yml
+# Config phase tasks for the `base_upgrade` role.
+# Refreshes APT metadata, applies the requested upgrade mode, optionally removes unused packages, and handles reboot detection.
+
+- name: "Config | Refresh APT package metadata"
+  ansible.builtin.apt:
+    update_cache: true
+    cache_valid_time: "{{ base_upgrade_cache_valid_time }}"
+
+- name: "Config | Apply requested package upgrades"
+  ansible.builtin.apt:
+    upgrade: "{{ base_upgrade_mode }}"
+    force_apt_get: true
+  environment:
+    DEBIAN_FRONTEND: noninteractive
+
+- name: "Config | Remove unused packages after upgrade"
+  ansible.builtin.apt:
+    autoremove: true
+    purge: false
+  environment:
+    DEBIAN_FRONTEND: noninteractive
+  when: base_upgrade_autoremove
+
+- name: "Config | Read reboot-required state after package maintenance"
+  ansible.builtin.stat:
+    path: /var/run/reboot-required
+  register: base_upgrade_reboot_required_file
+
+- name: "Config | Read reboot-required package list state"
+  ansible.builtin.stat:
+    path: /var/run/reboot-required.pkgs
+  register: base_upgrade_reboot_required_packages_file_state
+
+- name: "Config | Read reboot-required package list"
+  ansible.builtin.slurp:
+    path: /var/run/reboot-required.pkgs
+  register: base_upgrade_reboot_required_packages_file
+  when: base_upgrade_reboot_required_packages_file_state.stat.exists
+
+- name: "Config | Expose reboot-required state"
+  ansible.builtin.set_fact:
+    base_upgrade_reboot_required: "{{ base_upgrade_reboot_required_file.stat.exists }}"
+    base_upgrade_reboot_required_packages: >-
+      {{
+        (
+          base_upgrade_reboot_required_packages_file.content
+          | b64decode
+          | regex_findall('(?m)^.+$')
+        )
+        if base_upgrade_reboot_required_packages_file_state.stat.exists
+        else []
+      }}
+  changed_when: false
+
+- name: "Config | Reboot after upgrade when requested"
+  ansible.builtin.reboot:
+    msg: Reboot initiated by the base_upgrade role after package upgrades.
+  when:
+    - base_upgrade_allow_reboot
+    - base_upgrade_reboot_required

--- a/roles/base_upgrade/tasks/main.yml
+++ b/roles/base_upgrade/tasks/main.yml
@@ -1,0 +1,16 @@
+---
+# roles/base_upgrade/tasks/main.yml
+# Task entrypoint for the `base_upgrade` role.
+# Imports the assert, config, and validate phase files in order.
+
+- name: Assert
+  ansible.builtin.import_tasks: assert.yml
+  tags: [assert, base_upgrade, base_upgrade_assert]
+
+- name: Config
+  ansible.builtin.import_tasks: config.yml
+  tags: [config, base_upgrade, base_upgrade_config]
+
+- name: Validate
+  ansible.builtin.import_tasks: validate.yml
+  tags: [validate, base_upgrade, base_upgrade_validate]

--- a/roles/base_upgrade/tasks/validate.yml
+++ b/roles/base_upgrade/tasks/validate.yml
@@ -1,0 +1,109 @@
+---
+# roles/base_upgrade/tasks/validate.yml
+# Validate phase tasks for the `base_upgrade` role.
+# Verifies the requested APT upgrade convergence and the resulting reboot-required state after package maintenance.
+
+- name: "Validate | Simulate safe APT upgrade state"
+  ansible.builtin.command:
+    argv:
+      - apt-get
+      - -s
+      - upgrade
+  register: base_upgrade_safe_simulation
+  changed_when: false
+  environment:
+    DEBIAN_FRONTEND: noninteractive
+    LC_ALL: C
+
+- name: "Validate | Simulate full APT upgrade state"
+  ansible.builtin.command:
+    argv:
+      - apt-get
+      - -s
+      - full-upgrade
+  register: base_upgrade_full_simulation
+  changed_when: false
+  environment:
+    DEBIAN_FRONTEND: noninteractive
+    LC_ALL: C
+
+- name: "Validate | Read reboot-required state"
+  ansible.builtin.stat:
+    path: /var/run/reboot-required
+  register: base_upgrade_validate_reboot_required_file
+
+- name: "Validate | Read reboot-required package list state"
+  ansible.builtin.stat:
+    path: /var/run/reboot-required.pkgs
+  register: base_upgrade_validate_reboot_required_packages_file_state
+
+- name: "Validate | Read reboot-required package list"
+  ansible.builtin.slurp:
+    path: /var/run/reboot-required.pkgs
+  register: base_upgrade_validate_reboot_required_packages_file
+  when: base_upgrade_validate_reboot_required_packages_file_state.stat.exists
+
+- name: "Validate | Expose final reboot-required state"
+  ansible.builtin.set_fact:
+    base_upgrade_reboot_required: "{{ base_upgrade_validate_reboot_required_file.stat.exists }}"
+    base_upgrade_reboot_required_packages: >-
+      {{
+        (
+          base_upgrade_validate_reboot_required_packages_file.content
+          | b64decode
+          | regex_findall('(?m)^.+$')
+        )
+        if base_upgrade_validate_reboot_required_packages_file_state.stat.exists
+        else []
+      }}
+  changed_when: false
+
+- name: "Validate | Report reboot-required state"
+  ansible.builtin.debug:
+    msg: >-
+      Reboot is required after package upgrades.
+      Packages: {{ base_upgrade_reboot_required_packages | join(', ') | default('(none)', true) }}
+  when:
+    - base_upgrade_reboot_required
+    - not base_upgrade_fail_if_reboot_required
+
+- name: "Validate | Assert upgrade state"
+  vars:
+    base_upgrade_expected_safe_summary_pattern: >-
+      0 upgraded, 0 newly installed, 0 to remove(?: and [0-9]+ not upgraded)?\.
+    base_upgrade_expected_full_summary: >-
+      0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
+  ansible.builtin.assert:
+    that:
+      - >-
+        (
+          base_upgrade_mode == 'safe'
+          and
+          (
+            base_upgrade_safe_simulation.stdout
+            | regex_search(base_upgrade_expected_safe_summary_pattern)
+          ) is not none
+        )
+        or
+        (
+          base_upgrade_mode == 'full'
+          and
+          base_upgrade_expected_full_summary in base_upgrade_full_simulation.stdout
+        )
+      - >-
+        (
+          not base_upgrade_allow_reboot
+        ) or (
+          not base_upgrade_reboot_required
+        )
+      - >-
+        (
+          not base_upgrade_fail_if_reboot_required
+        ) or (
+          not base_upgrade_reboot_required
+        )
+    fail_msg: >-
+      Configured upgrade state does not match the requested base_upgrade
+      values. reboot_required={{ base_upgrade_reboot_required | bool }};
+      reboot_required_packages={{ base_upgrade_reboot_required_packages | join(', ') | default('(none)', true) }}
+    quiet: true


### PR DESCRIPTION
- Introduced the `base_upgrade` role for managing APT package upgrades on Debian-family hosts.
- Updated aggregate `base` role to include `base_upgrade` as an optional follow-up role.
- Enhanced documentation across various files to reflect the new role and its usage.
- Added example variables and playbook adjustments for safer reboot-capable runs. base_upgrade: add an explicit role to apply package upgrades safely on Debian-family hosts Fixes #37