### PR TITLE
Add base_hosts role for inventory-driven /etc/hosts management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 Release history for `ansible-roles`.
 Documents notable changes across repository structure, roles, examples, and documentation.
 
+## [v0.22.0]
+### Added
+- Added the `base_hosts` role for inventory-driven `/etc/hosts` management on Debian-family hosts, including defaults, compact phase tasks, template, role documentation, and example variables.
+
+### Changed
+- Added `base_hosts` to the aggregate `base` role as an explicit opt-in identity-and-resolution step gated by `base_include_hosts`.
+- Extended `base_hosts` to support optional manual host mappings in addition to inventory-driven entries.
+
+### Documentation
+- Updated repository, aggregate-role, and example documentation to describe the new optional hosts role and its example variable file.
+
 ## [v0.21.0]
 ### Added
 - Added the `base_upgrade` role for explicit Debian-family package upgrades, including defaults, full phase tasks, role documentation, and example variables.

--- a/README.md
+++ b/README.md
@@ -43,9 +43,10 @@ ansible-roles/
 
 ## Available Roles
 - `bootstrap`: Creates and validates the automation account used after the bootstrap phase.
-- `base`: Aggregates recurring base-phase configuration for Debian-family hosts through explicit `include_role` ordering in `roles/base/tasks/main.yml` for `base_packages`, `base_locale`, `base_timezone`, `base_ntp`, `base_hostname`, `base_sudo`, and `base_sshd`, with optional follow-up inclusion for `base_firewall`, `base_logging`, `base_updates`, `base_apparmor`, and `base_upgrade`.
+- `base`: Aggregates recurring base-phase configuration for Debian-family hosts through explicit `include_role` ordering in `roles/base/tasks/main.yml` for `base_packages`, `base_locale`, `base_timezone`, `base_ntp`, `base_hostname`, optional `base_hosts`, `base_sudo`, and `base_sshd`, with optional follow-up inclusion for `base_firewall`, `base_logging`, `base_updates`, `base_apparmor`, and `base_upgrade`.
 - `base_apparmor`: Enforces a minimal AppArmor package and service baseline on Debian-family hosts during the base phase.
 - `base_firewall`: Enforces an additive UFW baseline with managed default policies and requested allow or limit rules on Debian-family hosts during the base phase, with an optional purge mode for exact rebuilds.
+- `base_hosts`: Enforces inventory-driven and optional manual cluster host mappings through a managed `/etc/hosts` block on Debian-family hosts during the base phase.
 - `base_logging`: Enforces a persistent local journald baseline on Debian-family hosts during the base phase, with an optional volatile mode for non-persistent logs.
 - `base_upgrade`: Applies an explicit APT upgrade pass with optional autoremove and reboot handling on Debian-family hosts during the base phase.
 - `base_updates`: Enforces a minimal unattended-upgrades baseline on Debian-family hosts during the base phase through managed APT periodic policy files.

--- a/docs/01-examples.md
+++ b/docs/01-examples.md
@@ -58,7 +58,8 @@ ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/test_bas
 
 - The lab content is intentionally simple and meant as an example baseline.
 - The example inventory and variables assume Debian-family hosts and the repository's APT-based role behavior.
-- `group_vars/all/` is split by role prefix so example variables such as `base_packages.yml`, `base_hostname.yml`, `base_locale.yml`, `base_ntp.yml`, `base_sudo.yml`, `base_sshd.yml`, `base_firewall.yml`, `base_logging.yml`, `base_updates.yml`, `base_apparmor.yml`, `base_upgrade.yml`, `base_timezone.yml`, and `monitoring_authorized_key.yml` stay readable as the stack grows.
+- `group_vars/all/` is split by role prefix so example variables such as `base_packages.yml`, `base_hostname.yml`, `base_hosts.yml`, `base_locale.yml`, `base_ntp.yml`, `base_sudo.yml`, `base_sshd.yml`, `base_firewall.yml`, `base_logging.yml`, `base_updates.yml`, `base_apparmor.yml`, `base_upgrade.yml`, `base_timezone.yml`, and `monitoring_authorized_key.yml` stay readable as the stack grows.
+- `base_hosts.yml` sets `base_include_hosts: true`, which opts the example base run into the optional `base_hosts` role so example hosts can resolve inventory peer names through `/etc/hosts`.
 - `base_firewall.yml` sets `base_include_firewall: true`, which opts the example base run into the optional `base_firewall` role.
 - `base_logging.yml` sets `base_include_logging: true`, which opts the example base run into the optional `base_logging` role with persistent journald storage enabled.
 - `base_updates.yml` sets `base_include_updates: true`, which opts the example base run into the optional `base_updates` role with unattended-upgrades enabled.

--- a/docs/02-role-workflow.md
+++ b/docs/02-role-workflow.md
@@ -78,10 +78,11 @@ Current order:
 3. `base_timezone`
 4. `base_ntp`
 5. `base_hostname`
-6. `base_sudo`
-7. `base_sshd`
+6. `base_hosts` when `base_include_hosts: true`
+7. `base_sudo`
+8. `base_sshd`
 
-Use this sequence to keep foundational packages and environment settings first, then time synchronization, then final host identity, sudo policy, and SSH daemon policy.
+Use this sequence to keep foundational packages and environment settings first, then time synchronization, then final host identity and optional peer host mappings, then sudo policy and SSH daemon policy.
 
 Optional current follow-up:
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,7 +10,7 @@ The inventory variables and role inputs assume the repository's Debian-family de
 ## Structure
 - `ansible.cfg`: Test-specific Ansible configuration that points at the example inventory and hides skipped-host output for quieter local runs.
 - `inventory/hosts.ini`: Test inventory.
-- `inventory/group_vars/all/`: Shared variables for test hosts, split into per-role files such as `bootstrap.yml`, `base_packages.yml`, `base_hostname.yml`, `base_locale.yml`, `base_ntp.yml`, `base_sudo.yml`, `base_sshd.yml`, `base_firewall.yml`, `base_logging.yml`, `base_updates.yml`, `base_apparmor.yml`, `base_upgrade.yml`, `base_timezone.yml`, and `monitoring_authorized_key.yml`.
+- `inventory/group_vars/all/`: Shared variables for test hosts, split into per-role files such as `bootstrap.yml`, `base_packages.yml`, `base_hostname.yml`, `base_hosts.yml`, `base_locale.yml`, `base_ntp.yml`, `base_sudo.yml`, `base_sshd.yml`, `base_firewall.yml`, `base_logging.yml`, `base_updates.yml`, `base_apparmor.yml`, `base_upgrade.yml`, `base_timezone.yml`, and `monitoring_authorized_key.yml`.
 - `playbooks/bootstrap.yml`: Bootstrap phase playbook that connects with the initial admin account and applies the standalone `bootstrap` role.
 - `playbooks/base.yml`: Base phase playbook that connects as the automation account, applies the `base` role, and uses `serial: 1` so reboot-capable base runs process one host at a time.
 - `playbooks/site.yml`: Base-phase entry playbook that imports `base.yml`.
@@ -53,6 +53,7 @@ The SSH integration test playbook cleans up its temporary `/etc/ssh/sshd_config.
 `inventory/group_vars/all/base_logging.yml` sets `base_include_logging: true`, which opts the example base run into the optional `base_logging` role with persistent journald storage enabled.
 `inventory/group_vars/all/base_updates.yml` sets `base_include_updates: true`, which opts the example base run into the optional `base_updates` role with unattended-upgrades enabled.
 `inventory/group_vars/all/base_apparmor.yml` sets `base_include_apparmor: true`, which opts the example base run into the optional `base_apparmor` role with the AppArmor service enabled.
+`inventory/group_vars/all/base_hosts.yml` sets `base_include_hosts: true`, which opts the example base run into the optional `base_hosts` role so example hosts can resolve inventory peer names through `/etc/hosts`.
 `inventory/group_vars/all/base_upgrade.yml` keeps `base_include_upgrade: false` by default, so the example lab documents the role inputs without making every base run apply immediate package upgrades.
 `playbooks/base.yml` uses `serial: 1`, which is safer when optional roles such as `base_upgrade` may reboot a host during the run.
 `ansible.cfg` sets `display_skipped_hosts = False`, so optional-role and conditional-task skips are hidden during normal example runs.

--- a/examples/inventory/group_vars/all/base_hosts.yml
+++ b/examples/inventory/group_vars/all/base_hosts.yml
@@ -1,0 +1,41 @@
+---
+# examples/inventory/group_vars/all/base_hosts.yml
+# Shared hosts-file variables for the example lab.
+# Defines the aggregate-role opt-in plus the inventory-driven `/etc/hosts` block settings used during the base phase.
+
+# Opt in to the optional base_hosts role from the aggregate base role.
+# This keeps inventory-driven host mappings available on every example host
+# without depending on external DNS for internal lab name resolution.
+base_include_hosts: true
+
+# Inventory group used to build the managed `/etc/hosts` block.
+# Keep `all` here so every host in the example lab learns the inventory
+# hostname-to-address mappings for every other managed host.
+base_hosts_inventory_group: all
+# Example group-specific override:
+# Use this when only one inventory group should appear in the managed
+# `/etc/hosts` block instead of every host from `all`.
+# base_hosts_inventory_group: cluster_nodes
+#
+# Example inventory layout:
+# [cluster_nodes]
+# node1 ansible_host=192.168.0.101
+# node2 ansible_host=192.168.0.102
+
+# Optional extra host mappings for devices that are not managed as Ansible
+# inventory hosts. Keep this empty unless you want additional static entries
+# such as NAS, router, printer, or switch names in the managed hosts block.
+base_hosts_manual_entries: []
+# base_hosts_manual_entries:
+#   - ip: 192.168.0.10
+#     names:
+#       - nas
+#   - ip: 192.168.0.20
+#     names:
+#       - router
+#       - gateway
+
+# Marker used around the managed hosts block.
+# Keep the default marker unless you need a host-specific format for an
+# existing `/etc/hosts` management workflow.
+base_hosts_block_marker: "# {mark} ANSIBLE HOSTS"

--- a/roles/base/README.md
+++ b/roles/base/README.md
@@ -7,6 +7,7 @@ Explains how the aggregate base role delegates recurring Debian-family host conf
 - Runs the recurring base configuration on every `base` execution
 - Keeps the aggregate base-role execution order in `roles/base/tasks/main.yml`
 - Includes `base_packages`, `base_locale`, `base_timezone`, `base_ntp`, `base_hostname`, `base_sudo`, and `base_sshd` through explicit `ansible.builtin.include_role` entries
+- Can insert `base_hosts` after `base_hostname` as an explicit opt-in identity-and-resolution step when `base_include_hosts: true`
 - Keeps aggregate include-task tags aligned with each child role's phase tags and role-specific tags so targeted runs such as `--tags validate` or `--tags base_packages_validate` stay predictable
 - Can include `base_firewall` as an explicit opt-in follow-up role when `base_include_firewall: true`
 - Can include `base_logging` as an explicit opt-in follow-up role when `base_include_logging: true`
@@ -27,7 +28,7 @@ Use `base` on Debian-family hosts after the bootstrap phase has already created 
 ```
 
 Bootstrap is handled separately by the standalone `bootstrap` role/playbook.
-Role-specific inputs for `base` currently come from `base_packages_*`, `base_hostname_*`, `base_locale_*`, `base_ntp_*`, `base_sudo_*`, `base_sshd_*`, `base_timezone_*`, optional `base_include_firewall` plus `base_firewall_*`, optional `base_include_logging` plus `base_logging_*`, optional `base_include_updates` plus `base_updates_*`, optional `base_include_apparmor` plus `base_apparmor_*`, and optional `base_include_upgrade` plus `base_upgrade_*`.
+Role-specific inputs for `base` currently come from `base_packages_*`, `base_hostname_*`, optional `base_include_hosts` plus `base_hosts_*`, `base_locale_*`, `base_ntp_*`, `base_sudo_*`, `base_sshd_*`, `base_timezone_*`, optional `base_include_firewall` plus `base_firewall_*`, optional `base_include_logging` plus `base_logging_*`, optional `base_include_updates` plus `base_updates_*`, optional `base_include_apparmor` plus `base_apparmor_*`, and optional `base_include_upgrade` plus `base_upgrade_*`.
 
 Current include order in `base` is:
 
@@ -36,8 +37,9 @@ Current include order in `base` is:
 3. `base_timezone`
 4. `base_ntp`
 5. `base_hostname`
-6. `base_sudo`
-7. `base_sshd`
+6. `base_hosts` when `base_include_hosts: true`
+7. `base_sudo`
+8. `base_sshd`
 
 `roles/base/tasks/main.yml` is the single source of truth for this sequence.
 This keeps foundational packages and system environment first, then time synchronization, then final host identity, sudo policy, and SSH daemon policy.

--- a/roles/base/defaults/main.yml
+++ b/roles/base/defaults/main.yml
@@ -6,5 +6,6 @@
 base_include_firewall: false
 base_include_logging: false
 base_include_updates: false
+base_include_hosts: false
 base_include_apparmor: false
 base_include_upgrade: false

--- a/roles/base/tasks/main.yml
+++ b/roles/base/tasks/main.yml
@@ -38,6 +38,14 @@
       tags: [base, base_hostname]
   tags: [base, base_hostname, assert, config, validate, base_hostname_assert, base_hostname_config, base_hostname_validate]
 
+- name: "Base | Include optional base_hosts role"
+  ansible.builtin.include_role:
+    name: base_hosts
+    apply:
+      tags: [base, base_hosts]
+  when: base_include_hosts | default(false)
+  tags: [base, base_hosts, assert, config, validate, base_hosts_assert, base_hosts_config, base_hosts_validate]
+
 - name: "Base | Include base_sudo role"
   ansible.builtin.include_role:
     name: base_sudo

--- a/roles/base_hosts/README.md
+++ b/roles/base_hosts/README.md
@@ -1,0 +1,58 @@
+# roles/base_hosts/README.md
+
+Reference for the `base_hosts` role.
+Explains how the role manages inventory-driven and optional manual cluster host mappings in `/etc/hosts` on Debian-family hosts during the base phase.
+
+## Features
+- Validates the requested inventory group, optional manual entries, marker format, and host mapping inputs
+- Uses inventory hostnames and `ansible_host` values to build cluster host mappings
+- Supports extra manual host mappings for devices that are not managed as Ansible inventory hosts
+- Manages entries through an Ansible-managed block instead of overwriting the full `/etc/hosts` file
+- Verifies the managed `/etc/hosts` block after changes
+- Keeps scope narrow by not managing DNS resolver configuration or network interfaces
+
+## Variables
+
+| Variable | Default | Required | Description |
+|----------|---------|----------|-------------|
+| `base_hosts_inventory_group` | `all` | no | Inventory group used to build the managed `/etc/hosts` block from inventory hostnames and `ansible_host` values |
+| `base_hosts_manual_entries` | `[]` | no | Optional extra host mappings added after inventory entries; each item must define `ip` and a non-empty `names` list |
+| `base_hosts_block_marker` | `# {mark} ANSIBLE HOSTS` | no | Marker string used by `blockinfile`; must contain `{mark}` |
+
+## Usage
+
+The `base` role can include `base_hosts` when `base_include_hosts: true`.
+
+Direct usage:
+
+```yaml
+- hosts: all
+  become: true
+  roles:
+    - base_hosts
+```
+
+Example variables:
+
+```yaml
+base_include_hosts: true
+base_hosts_inventory_group: all
+base_hosts_manual_entries:
+  - ip: 192.168.0.10
+    names:
+      - nas
+      - files
+base_hosts_block_marker: "# {mark} ANSIBLE HOSTS"
+```
+
+This role is intentionally separate from `base_hostname` and any future `base_dns` role.
+Use `base_hostname` to manage the local system hostname, and use `base_hosts` when you want inventory-driven peer mappings plus optional manual entries in `/etc/hosts`.
+
+## Dependencies
+None
+
+## License
+MIT
+
+## Author
+Tatbyte

--- a/roles/base_hosts/defaults/main.yml
+++ b/roles/base_hosts/defaults/main.yml
@@ -1,0 +1,8 @@
+---
+# roles/base_hosts/defaults/main.yml
+# Default variables for the `base_hosts` role.
+# Defines the inventory source group, optional manual entries, and managed marker used for cluster host mappings during the base phase.
+
+base_hosts_inventory_group: all
+base_hosts_manual_entries: []
+base_hosts_block_marker: "# {mark} ANSIBLE HOSTS"

--- a/roles/base_hosts/tasks/assert.yml
+++ b/roles/base_hosts/tasks/assert.yml
@@ -1,0 +1,77 @@
+---
+# roles/base_hosts/tasks/assert.yml
+# Assert phase tasks for the `base_hosts` role.
+# Validates the requested inventory group, optional manual entries, marker format, and host mapping inputs before `/etc/hosts` management runs.
+
+- name: "Assert | Validate base_hosts variable structure"
+  ansible.builtin.assert:
+    that:
+      - base_hosts_inventory_group is string
+      - base_hosts_inventory_group | trim | length > 0
+      - base_hosts_inventory_group in groups
+      - (groups[base_hosts_inventory_group] | length) > 0
+      - base_hosts_manual_entries is sequence
+      - base_hosts_manual_entries is not string
+      - base_hosts_block_marker is string
+      - base_hosts_block_marker | trim | length > 0
+      - "'{mark}' in base_hosts_block_marker"
+    fail_msg: >-
+      base_hosts_inventory_group must be a non-empty inventory group that
+      exists and contains at least one host, base_hosts_manual_entries
+      must be a list, and base_hosts_block_marker must be a non-empty
+      marker string containing {mark}
+    quiet: true
+
+- name: "Assert | Validate inventory host mappings"
+  ansible.builtin.assert:
+    that:
+      - item is string
+      - item | trim | length > 0
+      - item == (item | trim)
+      - item is not match('.*\\s+.*')
+      - hostvars[item].ansible_host is defined
+      - hostvars[item].ansible_host is string
+      - hostvars[item].ansible_host | trim | length > 0
+      - hostvars[item].ansible_host == (hostvars[item].ansible_host | trim)
+      - hostvars[item].ansible_host is not match('.*\\s+.*')
+    fail_msg: >-
+      Every host in the requested base_hosts_inventory_group must have a
+      non-empty inventory hostname without whitespace and a non-empty
+      ansible_host value without whitespace
+    quiet: true
+  loop: "{{ groups[base_hosts_inventory_group] }}"
+  loop_control:
+    label: "{{ item }}"
+
+- name: "Assert | Validate manual host mappings"
+  ansible.builtin.assert:
+    that:
+      - item is mapping
+      - (item.keys() | difference(['ip', 'names']) | length) == 0
+      - item.ip is defined
+      - item.ip is string
+      - item.ip | trim | length > 0
+      - item.ip == (item.ip | trim)
+      - item.ip is not match('.*\\s+.*')
+      - item.names is defined
+      - item.names is sequence
+      - item.names is not string
+      - (item.names | length) > 0
+      - (item.names | map('string') | list | length) == (item.names | length)
+      - (item.names | map('trim') | reject('equalto', '') | list | length) == (item.names | length)
+      - >-
+        (
+          item.names
+          | select('match', '.*\\s+.*')
+          | list
+          | length
+        ) == 0
+    fail_msg: >-
+      Each base_hosts_manual_entries item must be a mapping with only ip and
+      names keys. ip must be a non-empty string without whitespace, and
+      names must be a non-empty list of non-empty hostnames without
+      whitespace
+    quiet: true
+  loop: "{{ base_hosts_manual_entries }}"
+  loop_control:
+    label: "{{ item.ip | default('manual-entry') }}"

--- a/roles/base_hosts/tasks/config.yml
+++ b/roles/base_hosts/tasks/config.yml
@@ -1,0 +1,10 @@
+---
+# roles/base_hosts/tasks/config.yml
+# Config phase tasks for the `base_hosts` role.
+# Manages the inventory-driven and optional manual cluster host mappings through an Ansible-managed block in `/etc/hosts`.
+
+- name: "Config | Manage cluster hosts in /etc/hosts"
+  ansible.builtin.blockinfile:
+    path: /etc/hosts
+    marker: "{{ base_hosts_block_marker }}"
+    block: "{{ lookup('template', 'hosts_block.j2') | trim }}"

--- a/roles/base_hosts/tasks/main.yml
+++ b/roles/base_hosts/tasks/main.yml
@@ -1,0 +1,16 @@
+---
+# roles/base_hosts/tasks/main.yml
+# Task entrypoint for the `base_hosts` role.
+# Imports the assert, config, and validate phase files in order.
+
+- name: Assert
+  ansible.builtin.import_tasks: assert.yml
+  tags: [assert, base_hosts, base_hosts_assert]
+
+- name: Config
+  ansible.builtin.import_tasks: config.yml
+  tags: [config, base_hosts, base_hosts_config]
+
+- name: Validate
+  ansible.builtin.import_tasks: validate.yml
+  tags: [validate, base_hosts, base_hosts_validate]

--- a/roles/base_hosts/tasks/validate.yml
+++ b/roles/base_hosts/tasks/validate.yml
@@ -1,0 +1,55 @@
+---
+# roles/base_hosts/tasks/validate.yml
+# Validate phase tasks for the `base_hosts` role.
+# Verifies the managed `/etc/hosts` block contains the requested inventory-driven and manual host mappings after configuration.
+
+- name: "Validate | Read /etc/hosts"
+  ansible.builtin.slurp:
+    path: /etc/hosts
+  register: base_hosts_file
+
+- name: "Validate | Assert managed marker state"
+  vars:
+    base_hosts_file_content: "{{ base_hosts_file.content | b64decode }}"
+  ansible.builtin.assert:
+    that:
+      - (base_hosts_block_marker | replace('{mark}', 'BEGIN')) in base_hosts_file_content
+      - (base_hosts_block_marker | replace('{mark}', 'END')) in base_hosts_file_content
+    fail_msg: >-
+      Configured /etc/hosts state is missing the requested base_hosts block
+      markers
+    quiet: true
+
+- name: "Validate | Assert /etc/hosts state"
+  ansible.builtin.assert:
+    that:
+      - >-
+        (
+          hostvars[item].ansible_host
+          ~ ' '
+          ~ item
+        ) in (base_hosts_file.content | b64decode)
+    fail_msg: >-
+      Configured /etc/hosts state does not match the requested base_hosts
+      values
+    quiet: true
+  loop: "{{ groups[base_hosts_inventory_group] }}"
+  loop_control:
+    label: "{{ item }}"
+
+- name: "Validate | Assert manual /etc/hosts state"
+  ansible.builtin.assert:
+    that:
+      - >-
+        (
+          item.ip
+          ~ ' '
+          ~ (item.names | join(' '))
+        ) in (base_hosts_file.content | b64decode)
+    fail_msg: >-
+      Configured /etc/hosts state does not match the requested
+      base_hosts_manual_entries values
+    quiet: true
+  loop: "{{ base_hosts_manual_entries }}"
+  loop_control:
+    label: "{{ item.ip }}"

--- a/roles/base_hosts/templates/hosts_block.j2
+++ b/roles/base_hosts/templates/hosts_block.j2
@@ -1,0 +1,8 @@
+{# roles/base_hosts/templates/hosts_block.j2 #}
+{# Template for the managed `/etc/hosts` block in the `base_hosts` role. #}
+{% for host in groups[base_hosts_inventory_group] -%}
+{{ hostvars[host]['ansible_host'] }} {{ host }}
+{% endfor -%}
+{% for entry in base_hosts_manual_entries -%}
+{{ entry.ip }} {{ entry.names | join(' ') }}
+{% endfor -%}


### PR DESCRIPTION
- Introduced the `base_hosts` role to manage host mappings on Debian-family hosts.
- Updated documentation to reflect the new role and its integration into the base role.
- Enhanced example configurations to demonstrate usage of the new role. Add `base_hosts` Role for Cluster `/etc/hosts` Management Fixes #49