### PR TITLE
feat(auditd): Introduce base_auditd role for Linux audit management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,22 @@
 # CHANGELOG.md
 
-Release history for `ansible-roles`.
+Release history for `homelab-roles`.
 Documents notable changes across repository structure, roles, examples, and documentation.
+
+## [v0.24.0]
+### Added
+- Added the `base_auditd` role for Debian-family Linux audit baseline management, including defaults, handlers, full phase tasks, template, role documentation, and example variables.
+
+### Changed
+- Added `base_auditd` to the aggregate `base` role as an explicit opt-in follow-up role gated by `base_include_auditd`.
+- Reworked `base_auditd` configuration handling so audit daemon changes use a compatible `auditctl --signal HUP` reconfigure path instead of unsupported generic service reload or restart behavior.
+- Expanded the `base_auditd` managed log-directory and `auditd.conf` baseline so Debian-family hosts converge more reliably during service startup.
+- Added visible managed-file ownership comments to comment-friendly rendered config templates such as `base_auditd`, `base_dns`, `base_logging`, `base_locale`, `base_ntp`, and `base_sshd`.
+- Updated `base_hosts` to insert a blank line before the managed `/etc/hosts` block for friendlier readability.
+
+### Documentation
+- Updated repository, aggregate-role, and example documentation to describe the new optional audit role, its example variable file, and the current `homelab-roles` repository naming.
+- Added repository guidance for when rendered templates should include visible managed-file comments and when they should not.
 
 ## [v0.23.0]
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # README.md
 
-Repository overview for `ansible-roles`.
+Repository overview for `homelab-roles`.
 Explains the role collection layout, the intended consumption pattern from another repository, and the local example workflow.
 
 ## Overview
@@ -26,7 +26,7 @@ Role implementations, package-management tasks, and example configuration assume
 
 ## Repository Layout
 ```text
-ansible-roles/
+homelab-roles/
 ├── roles/
 │   ├── base/
 │   ├── bootstrap/
@@ -43,8 +43,9 @@ ansible-roles/
 
 ## Available Roles
 - `bootstrap`: Creates and validates the automation account used after the bootstrap phase.
-- `base`: Aggregates recurring base-phase configuration for Debian-family hosts through explicit `include_role` ordering in `roles/base/tasks/main.yml` for `base_packages`, `base_locale`, `base_timezone`, `base_ntp`, `base_hostname`, optional `base_hosts`, optional `base_dns`, `base_sudo`, and `base_sshd`, with optional follow-up inclusion for `base_firewall`, `base_logging`, `base_updates`, `base_apparmor`, and `base_upgrade`.
+- `base`: Aggregates recurring base-phase configuration for Debian-family hosts through explicit `include_role` ordering in `roles/base/tasks/main.yml` for `base_packages`, `base_locale`, `base_timezone`, `base_ntp`, `base_hostname`, optional `base_hosts`, optional `base_dns`, `base_sudo`, and `base_sshd`, with optional follow-up inclusion for `base_firewall`, `base_logging`, `base_updates`, `base_apparmor`, `base_auditd`, and `base_upgrade`.
 - `base_apparmor`: Enforces a minimal AppArmor package and service baseline on Debian-family hosts during the base phase.
+- `base_auditd`: Enforces a minimal Linux audit daemon package, service, and baseline configuration on Debian-family hosts during the base phase.
 - `base_dns`: Enforces a minimal DNS resolver baseline through `systemd-resolved` on Debian-family hosts during the base phase.
 - `base_firewall`: Enforces an additive UFW baseline with managed default policies and requested allow or limit rules on Debian-family hosts during the base phase, with an optional purge mode for exact rebuilds.
 - `base_hosts`: Enforces inventory-driven and optional manual cluster host mappings through a managed `/etc/hosts` block on Debian-family hosts during the base phase.
@@ -61,14 +62,14 @@ ansible-roles/
 - `monitoring_authorized_key`: Installs an SSH authorized key for monitoring-style inter-host access.
 
 ## Consume From Another Repo
-Recommended pattern: add this repository to your infra repository (submodule or vendored checkout), then point `roles_path` to `ansible-roles/roles`.
+Recommended pattern: add this repository to your infra repository (submodule or vendored checkout), then point `roles_path` to `homelab-roles/roles`.
 
 Example infra repo `ansible.cfg`:
 
 ```ini
 [defaults]
 inventory = ./inventory/hosts.ini
-roles_path = ./roles:./vendor/ansible-roles/roles
+roles_path = ./roles:./vendor/homelab-roles/roles
 ```
 
 Example infra playbook:
@@ -112,7 +113,7 @@ ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/site.yml
 Optional `base_sshd` integration check:
 
 ```sh
-ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/test_base_sshd.yml --tags base_sshd
+ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/tests/test_base_sshd.yml --tags base_sshd
 ```
 
 Or from the `examples/` directory:

--- a/docs/01-examples.md
+++ b/docs/01-examples.md
@@ -19,11 +19,11 @@ The example content assumes Debian-family targets such as Debian and Ubuntu.
 
 - `examples/ansible.cfg`: Example Ansible configuration for local test runs that also hides skipped-host output for quieter example runs.
 - `examples/inventory/hosts.ini`: Example hosts and groups.
-- `examples/inventory/group_vars/all/`: Example variables for all hosts, split into role-scoped files such as `bootstrap.yml`, `base_packages.yml`, `base_hostname.yml`, `base_hosts.yml`, `base_dns.yml`, `base_locale.yml`, `base_ntp.yml`, `base_sudo.yml`, `base_sshd.yml`, `base_firewall.yml`, `base_logging.yml`, `base_updates.yml`, `base_apparmor.yml`, `base_upgrade.yml`, `base_timezone.yml`, and `monitoring_authorized_key.yml`.
+- `examples/inventory/group_vars/all/`: Example variables for all hosts, split into role-scoped files such as `bootstrap.yml`, `base_packages.yml`, `base_hostname.yml`, `base_hosts.yml`, `base_dns.yml`, `base_locale.yml`, `base_ntp.yml`, `base_sudo.yml`, `base_sshd.yml`, `base_firewall.yml`, `base_logging.yml`, `base_updates.yml`, `base_apparmor.yml`, `base_auditd.yml`, `base_upgrade.yml`, `base_timezone.yml`, and `monitoring_authorized_key.yml`.
 - `examples/playbooks/bootstrap.yml`: Bootstrap phase playbook that uses initial host credentials and applies the standalone `bootstrap` role.
 - `examples/playbooks/base.yml`: Base phase playbook for post-bootstrap role execution that applies the aggregate base role one host at a time for safer reboot-capable runs.
 - `examples/playbooks/site.yml`: Base-phase entry playbook that imports `base.yml`.
-- `examples/playbooks/test_base_sshd.yml`: Optional integration test playbook for exercising merged `sshd_config.d` fragments plus `Match User` and `Match Address` behavior around the `base_sshd` role.
+- `examples/playbooks/tests/test_base_sshd.yml`: Optional integration test playbook for exercising merged `sshd_config.d` fragments plus `Match User` and `Match Address` behavior around the `base_sshd` role.
 
 ## How to Use the Example
 
@@ -51,24 +51,25 @@ ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/base.yml
 Optional `base_sshd` integration check:
 
 ```bash
-ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/test_base_sshd.yml --tags base_sshd
+ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/tests/test_base_sshd.yml --tags base_sshd
 ```
 
 ## Notes
 
 - The lab content is intentionally simple and meant as an example baseline.
 - The example inventory and variables assume Debian-family hosts and the repository's APT-based role behavior.
-- `group_vars/all/` is split by role prefix so example variables such as `base_packages.yml`, `base_hostname.yml`, `base_hosts.yml`, `base_dns.yml`, `base_locale.yml`, `base_ntp.yml`, `base_sudo.yml`, `base_sshd.yml`, `base_firewall.yml`, `base_logging.yml`, `base_updates.yml`, `base_apparmor.yml`, `base_upgrade.yml`, `base_timezone.yml`, and `monitoring_authorized_key.yml` stay readable as the stack grows.
+- `group_vars/all/` is split by role prefix so example variables such as `base_packages.yml`, `base_hostname.yml`, `base_hosts.yml`, `base_dns.yml`, `base_locale.yml`, `base_ntp.yml`, `base_sudo.yml`, `base_sshd.yml`, `base_firewall.yml`, `base_logging.yml`, `base_updates.yml`, `base_apparmor.yml`, `base_auditd.yml`, `base_upgrade.yml`, `base_timezone.yml`, and `monitoring_authorized_key.yml` stay readable as the stack grows.
 - `base_hosts.yml` sets `base_include_hosts: true`, which opts the example base run into the optional `base_hosts` role so example hosts can resolve inventory peer names through `/etc/hosts`.
 - `base_dns.yml` sets `base_include_dns: true`, which opts the example base run into the optional `base_dns` role with an explicit `systemd-resolved` baseline.
 - `base_firewall.yml` sets `base_include_firewall: true`, which opts the example base run into the optional `base_firewall` role.
 - `base_logging.yml` sets `base_include_logging: true`, which opts the example base run into the optional `base_logging` role with persistent journald storage enabled.
 - `base_updates.yml` sets `base_include_updates: true`, which opts the example base run into the optional `base_updates` role with unattended-upgrades enabled.
 - `base_apparmor.yml` sets `base_include_apparmor: true`, which opts the example base run into the optional `base_apparmor` role with the AppArmor service enabled.
+- `base_auditd.yml` sets `base_include_auditd: true`, which opts the example base run into the optional `base_auditd` role with the audit daemon enabled and a minimal explicit baseline configuration.
 - `base_upgrade.yml` keeps `base_include_upgrade: false` by default, so the example lab documents the role inputs without turning every base run into an immediate package-maintenance operation.
 - `playbooks/base.yml` uses `serial: 1`, which is safer when optional roles such as `base_upgrade` may reboot a host during the run.
 - `ansible.cfg` sets `display_skipped_hosts = False`, so routine conditional skips from optional roles or gated tasks do not dominate the example output.
 - `hosts.ini` keeps default `ansible_user=ansible` in `[all:vars]`, while `[bootstrap:vars]` holds initial login values used only during bootstrap.
 - `playbooks/bootstrap.yml` prompts once for the bootstrap password and reuses it for both SSH login and sudo.
-- `playbooks/test_base_sshd.yml` removes its temporary SSH fixture files in an `always` block after the integration run, so the example host is returned to the normal post-test state.
+- `playbooks/tests/test_base_sshd.yml` removes its temporary SSH fixture files in an `always` block after the integration run, so the example host is returned to the normal post-test state.
 - Extend the inventory, vars, and playbooks to fit your own infrastructure and test scope.

--- a/docs/02-role-workflow.md
+++ b/docs/02-role-workflow.md
@@ -91,7 +91,8 @@ Optional current follow-up:
 2. `base_logging` when `base_include_logging: true`
 3. `base_updates` when `base_include_updates: true`
 4. `base_apparmor` when `base_include_apparmor: true`
-5. `base_upgrade` when `base_include_upgrade: true`
+5. `base_auditd` when `base_include_auditd: true`
+6. `base_upgrade` when `base_include_upgrade: true`
 
 Future optional follow-up roles should also be included explicitly from `roles/base/tasks/main.yml` and gated only by aggregate include flags.
 
@@ -111,3 +112,13 @@ This keeps `--tags validate` working across the aggregate stack and also allows 
 When you add a new aggregate child role or change a child role's tags, update the parent include-task tags to match so targeted execution keeps working as documented.
 
 Run the full workflow by running the playbook with no tag filter.
+
+## Optional Role Toggle Convention
+
+Use a consistent toggle pattern when you add new optional roles to the aggregate `base` stack.
+
+- Use `base_include_<role>` when the whole role is optional in the aggregate `base` role.
+- Use `<role>_enabled` only when the role manages a service and an installed-but-disabled state is a valid supported outcome.
+- Do not add `enabled` flags to roles that only enforce static configuration or one-time state.
+
+This keeps aggregate role selection separate from service state management and helps avoid unnecessary toggle sprawl across narrow configuration roles.

--- a/docs/03-file-consistency.md
+++ b/docs/03-file-consistency.md
@@ -54,6 +54,27 @@ For Jinja templates:
 Avoid a blank line after Jinja header comments when template output is whitespace-sensitive.
 This helps prevent accidental leading newlines in managed files such as `/etc/locale.gen`.
 
+When the rendered file format supports comments and the output is not
+whitespace-sensitive, prefer adding visible managed-file comments near the top
+of the rendered content too.
+
+Example:
+
+```jinja
+{# roles/base_logging/templates/journald.conf.j2 #}
+{# Template for the managed `/etc/systemd/journald.conf` file in the `base_logging` role. #}
+# Managed by Ansible: base_logging
+# Source: roles/base_logging/templates/journald.conf.j2
+[Journal]
+```
+
+Skip visible managed-file comments when:
+
+- the rendered format does not reliably support the repository's comment style
+- the file is intentionally whitespace-sensitive
+- a different visible ownership marker already exists, such as `blockinfile`
+  markers in `/etc/hosts`
+
 For ignore or dotfiles:
 
 ```text

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,11 +10,11 @@ The inventory variables and role inputs assume the repository's Debian-family de
 ## Structure
 - `ansible.cfg`: Test-specific Ansible configuration that points at the example inventory and hides skipped-host output for quieter local runs.
 - `inventory/hosts.ini`: Test inventory.
-- `inventory/group_vars/all/`: Shared variables for test hosts, split into per-role files such as `bootstrap.yml`, `base_packages.yml`, `base_hostname.yml`, `base_hosts.yml`, `base_dns.yml`, `base_locale.yml`, `base_ntp.yml`, `base_sudo.yml`, `base_sshd.yml`, `base_firewall.yml`, `base_logging.yml`, `base_updates.yml`, `base_apparmor.yml`, `base_upgrade.yml`, `base_timezone.yml`, and `monitoring_authorized_key.yml`.
+- `inventory/group_vars/all/`: Shared variables for test hosts, split into per-role files such as `bootstrap.yml`, `base_packages.yml`, `base_hostname.yml`, `base_hosts.yml`, `base_dns.yml`, `base_locale.yml`, `base_ntp.yml`, `base_sudo.yml`, `base_sshd.yml`, `base_firewall.yml`, `base_logging.yml`, `base_updates.yml`, `base_apparmor.yml`, `base_auditd.yml`, `base_upgrade.yml`, `base_timezone.yml`, and `monitoring_authorized_key.yml`.
 - `playbooks/bootstrap.yml`: Bootstrap phase playbook that connects with the initial admin account and applies the standalone `bootstrap` role.
 - `playbooks/base.yml`: Base phase playbook that connects as the automation account, applies the `base` role, and uses `serial: 1` so reboot-capable base runs process one host at a time.
 - `playbooks/site.yml`: Base-phase entry playbook that imports `base.yml`.
-- `playbooks/test_base_sshd.yml`: Integration test playbook that temporarily adds extra SSH daemon fragments, runs `base_sshd`, verifies merged `AllowUsers` plus `Match User` and `Match Address` behavior, and removes the temporary fixtures.
+- `playbooks/tests/test_base_sshd.yml`: Integration test playbook that temporarily adds extra SSH daemon fragments, runs `base_sshd`, verifies merged `AllowUsers` plus `Match User` and `Match Address` behavior, and removes the temporary fixtures.
 
 ## Usage
 Run bootstrap from repository root:
@@ -45,7 +45,7 @@ ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/base.yml
 Optional `base_sshd` integration check:
 
 ```sh
-ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/test_base_sshd.yml --tags base_sshd
+ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/tests/test_base_sshd.yml --tags base_sshd
 ```
 
 The SSH integration test playbook cleans up its temporary `/etc/ssh/sshd_config.d/` fixture files in an `always` block, so you do not need to remove them manually after the run.
@@ -53,6 +53,7 @@ The SSH integration test playbook cleans up its temporary `/etc/ssh/sshd_config.
 `inventory/group_vars/all/base_logging.yml` sets `base_include_logging: true`, which opts the example base run into the optional `base_logging` role with persistent journald storage enabled.
 `inventory/group_vars/all/base_updates.yml` sets `base_include_updates: true`, which opts the example base run into the optional `base_updates` role with unattended-upgrades enabled.
 `inventory/group_vars/all/base_apparmor.yml` sets `base_include_apparmor: true`, which opts the example base run into the optional `base_apparmor` role with the AppArmor service enabled.
+`inventory/group_vars/all/base_auditd.yml` sets `base_include_auditd: true`, which opts the example base run into the optional `base_auditd` role with the audit daemon enabled and a minimal explicit baseline configuration.
 `inventory/group_vars/all/base_hosts.yml` sets `base_include_hosts: true`, which opts the example base run into the optional `base_hosts` role so example hosts can resolve inventory peer names through `/etc/hosts`.
 `inventory/group_vars/all/base_dns.yml` sets `base_include_dns: true`, which opts the example base run into the optional `base_dns` role with an explicit `systemd-resolved` baseline.
 `inventory/group_vars/all/base_upgrade.yml` keeps `base_include_upgrade: false` by default, so the example lab documents the role inputs without making every base run apply immediate package upgrades.

--- a/examples/inventory/group_vars/all/base_auditd.yml
+++ b/examples/inventory/group_vars/all/base_auditd.yml
@@ -1,0 +1,24 @@
+---
+# examples/inventory/group_vars/all/base_auditd.yml
+# Shared audit variables for the example lab.
+# Defines the aggregate-role opt-in plus the audit package, service, and minimal configuration baseline enforced during the base phase.
+
+# Opt in to the optional base_auditd role from the aggregate base role.
+base_include_auditd: true
+
+# Package list installed with APT to provide the Linux audit daemon baseline.
+base_auditd_packages:
+  - auditd
+
+# Audit daemon service name managed and validated during the base phase.
+base_auditd_service_name: auditd
+
+# Keep the audit daemon enabled and running in the example lab.
+base_auditd_enabled: true
+
+# Flush audit records asynchronously for a safer balance between durability
+# and runtime overhead in the example lab.
+base_auditd_flush: incremental_async
+
+# Enrich audit records with additional decoded metadata in the example lab.
+base_auditd_log_format: enriched

--- a/examples/playbooks/tests/test_base_sshd.yml
+++ b/examples/playbooks/tests/test_base_sshd.yml
@@ -1,5 +1,5 @@
 ---
-# examples/playbooks/test_base_sshd.yml
+# examples/playbooks/tests/test_base_sshd.yml
 # Integration test playbook for the `base_sshd` role in the example lab.
 # Exercises merged `sshd_config.d` fragments plus `Match User` and `Match Address` behavior, then removes the temporary fixture files.
 

--- a/roles/base/README.md
+++ b/roles/base/README.md
@@ -14,6 +14,7 @@ Explains how the aggregate base role delegates recurring Debian-family host conf
 - Can include `base_logging` as an explicit opt-in follow-up role when `base_include_logging: true`
 - Can include `base_updates` as an explicit opt-in follow-up role when `base_include_updates: true`
 - Can include `base_apparmor` as an explicit opt-in follow-up role when `base_include_apparmor: true`
+- Can include `base_auditd` as an explicit opt-in follow-up role when `base_include_auditd: true`
 - Can include `base_upgrade` as an explicit opt-in follow-up role when `base_include_upgrade: true`
 
 ## Usage
@@ -29,7 +30,7 @@ Use `base` on Debian-family hosts after the bootstrap phase has already created 
 ```
 
 Bootstrap is handled separately by the standalone `bootstrap` role/playbook.
-Role-specific inputs for `base` currently come from `base_packages_*`, `base_locale_*`, `base_timezone_*`, `base_ntp_*`, `base_hostname_*`, optional `base_include_hosts` plus `base_hosts_*`, optional `base_include_dns` plus `base_dns_*`, `base_sudo_*`, `base_sshd_*`, optional `base_include_firewall` plus `base_firewall_*`, optional `base_include_logging` plus `base_logging_*`, optional `base_include_updates` plus `base_updates_*`, optional `base_include_apparmor` plus `base_apparmor_*`, and optional `base_include_upgrade` plus `base_upgrade_*`.
+Role-specific inputs for `base` currently come from `base_packages_*`, `base_locale_*`, `base_timezone_*`, `base_ntp_*`, `base_hostname_*`, optional `base_include_hosts` plus `base_hosts_*`, optional `base_include_dns` plus `base_dns_*`, `base_sudo_*`, `base_sshd_*`, optional `base_include_firewall` plus `base_firewall_*`, optional `base_include_logging` plus `base_logging_*`, optional `base_include_updates` plus `base_updates_*`, optional `base_include_apparmor` plus `base_apparmor_*`, optional `base_include_auditd` plus `base_auditd_*`, and optional `base_include_upgrade` plus `base_upgrade_*`.
 
 Current include order in `base` is:
 
@@ -55,7 +56,8 @@ Optional follow-up role:
 2. `base_logging` when `base_include_logging: true`
 3. `base_updates` when `base_include_updates: true`
 4. `base_apparmor` when `base_include_apparmor: true`
-5. `base_upgrade` when `base_include_upgrade: true`
+5. `base_auditd` when `base_include_auditd: true`
+6. `base_upgrade` when `base_include_upgrade: true`
 
 ## License
 MIT

--- a/roles/base/defaults/main.yml
+++ b/roles/base/defaults/main.yml
@@ -9,4 +9,5 @@ base_include_updates: false
 base_include_hosts: false
 base_include_dns: false
 base_include_apparmor: false
+base_include_auditd: false
 base_include_upgrade: false

--- a/roles/base/tasks/main.yml
+++ b/roles/base/tasks/main.yml
@@ -100,6 +100,14 @@
   when: base_include_apparmor | default(false)
   tags: [base, base_apparmor, assert, install, config, validate, base_apparmor_assert, base_apparmor_install, base_apparmor_config, base_apparmor_validate]
 
+- name: "Base | Include optional base_auditd role"
+  ansible.builtin.include_role:
+    name: base_auditd
+    apply:
+      tags: [base, base_auditd]
+  when: base_include_auditd | default(false)
+  tags: [base, base_auditd, assert, install, config, validate, base_auditd_assert, base_auditd_install, base_auditd_config, base_auditd_validate]
+
 - name: "Base | Include optional base_upgrade role"
   ansible.builtin.include_role:
     name: base_upgrade

--- a/roles/base_auditd/README.md
+++ b/roles/base_auditd/README.md
@@ -1,0 +1,58 @@
+# roles/base_auditd/README.md
+
+Reference for the `base_auditd` role.
+Explains how the role manages a minimal Linux audit daemon baseline on Debian-family hosts during the base phase.
+
+## Features
+- Validates the requested audit package, service, enabled-state, and minimal configuration inputs
+- Installs the requested audit package baseline with APT before configuration
+- Manages a small explicit `auditd.conf` baseline focused on local logging plus the requested flush and log-format behavior
+- Ensures the audit daemon service is enabled and running when requested
+- Verifies the requested package state, managed configuration file, and service enabled/running state after changes
+- Keeps scope intentionally narrow by not authoring audit rules, remote forwarding, or compliance-profile-specific policy in v1
+
+## Variables
+
+| Variable | Default | Required | Description |
+|----------|---------|----------|-------------|
+| `base_auditd_packages` | `['auditd']` | no | Package list installed with APT to provide the Linux audit daemon baseline |
+| `base_auditd_service_name` | `auditd` | no | Audit daemon service name managed and validated by the role |
+| `base_auditd_enabled` | `true` | no | Whether the role should keep the audit daemon enabled and running during the base phase |
+| `base_auditd_flush` | `incremental_async` | no | Flush mode written to the managed `auditd.conf` baseline; supported values are `none`, `incremental`, `incremental_async`, `data`, and `sync` |
+| `base_auditd_log_format` | `enriched` | no | Audit log format written to the managed `auditd.conf` baseline; supported values are `raw` and `enriched` |
+
+## Usage
+
+The `base` role can include `base_auditd` when `base_include_auditd: true`.
+
+Direct usage:
+
+```yaml
+- hosts: all
+  become: true
+  roles:
+    - base_auditd
+```
+
+Example variables:
+
+```yaml
+base_include_auditd: true
+base_auditd_packages:
+  - auditd
+base_auditd_enabled: true
+base_auditd_flush: incremental_async
+base_auditd_log_format: enriched
+```
+
+Set `base_auditd_enabled: false` only when you intentionally want to keep the package and managed configuration baseline present while stopping and disabling the audit daemon service.
+This role does not manage audit rule files, remote forwarding, or advanced compliance profiles in v1.
+
+## Dependencies
+None
+
+## License
+MIT
+
+## Author
+Tatbyte

--- a/roles/base_auditd/defaults/main.yml
+++ b/roles/base_auditd/defaults/main.yml
@@ -1,0 +1,11 @@
+---
+# roles/base_auditd/defaults/main.yml
+# Default variables for the `base_auditd` role.
+# Defines the audit package list, service, enabled state, and minimal auditd.conf values enforced during the base phase.
+
+base_auditd_packages:
+  - auditd
+base_auditd_service_name: auditd
+base_auditd_enabled: true
+base_auditd_flush: incremental_async
+base_auditd_log_format: enriched

--- a/roles/base_auditd/handlers/main.yml
+++ b/roles/base_auditd/handlers/main.yml
@@ -1,0 +1,10 @@
+---
+# roles/base_auditd/handlers/main.yml
+# Handlers for the `base_auditd` role.
+# Reloads the audit daemon configuration through `auditctl` when the managed
+# configuration changes while the service is enabled.
+
+- name: Reload audit daemon service
+  ansible.builtin.command: auditctl --signal HUP
+  changed_when: true
+  when: base_auditd_enabled

--- a/roles/base_auditd/tasks/assert.yml
+++ b/roles/base_auditd/tasks/assert.yml
@@ -1,0 +1,39 @@
+---
+# roles/base_auditd/tasks/assert.yml
+# Assert phase tasks for the `base_auditd` role.
+# Validates the requested audit package, service, enabled-state, and minimal configuration inputs before installation and configuration run.
+
+- name: "Assert | Validate base_auditd variable structure"
+  vars:
+    base_auditd_allowed_flush_values:
+      - none
+      - incremental
+      - incremental_async
+      - data
+      - sync
+    base_auditd_allowed_log_formats:
+      - raw
+      - enriched
+  ansible.builtin.assert:
+    that:
+      - base_auditd_packages is sequence
+      - base_auditd_packages is not string
+      - base_auditd_service_name is string
+      - base_auditd_service_name | trim | length > 0
+      - base_auditd_enabled is boolean
+      - base_auditd_flush is string
+      - base_auditd_flush | trim | length > 0
+      - (base_auditd_flush | lower) in base_auditd_allowed_flush_values
+      - base_auditd_log_format is string
+      - base_auditd_log_format | trim | length > 0
+      - (base_auditd_log_format | lower) in base_auditd_allowed_log_formats
+      - (base_auditd_packages | map('string') | list | length) == (base_auditd_packages | length)
+      - (base_auditd_packages | map('trim') | reject('equalto', '') | list | length) == (base_auditd_packages | length)
+      - "'auditd' in base_auditd_packages"
+    fail_msg: >-
+      base_auditd_packages must be a list of non-empty package names that
+      includes auditd, base_auditd_service_name must be a non-empty service
+      name, base_auditd_enabled must be a boolean, base_auditd_flush must be
+      one of none, incremental, incremental_async, data, or sync, and
+      base_auditd_log_format must be raw or enriched
+    quiet: true

--- a/roles/base_auditd/tasks/config.yml
+++ b/roles/base_auditd/tasks/config.yml
@@ -1,0 +1,32 @@
+---
+# roles/base_auditd/tasks/config.yml
+# Config phase tasks for the `base_auditd` role.
+# Ensures the audit log directory exists, renders a Debian-aligned
+# auditd configuration baseline, and enforces the requested audit daemon
+# service state during the base phase.
+
+- name: "Config | Ensure audit log directory state"
+  ansible.builtin.file:
+    path: /var/log/audit
+    state: directory
+    owner: root
+    group: adm
+    mode: "0750"
+
+- name: "Config | Render audit daemon configuration"
+  ansible.builtin.template:
+    src: auditd.conf.j2
+    dest: /etc/audit/auditd.conf
+    owner: root
+    group: root
+    mode: "0640"
+  notify: Reload audit daemon service
+
+- name: "Config | Ensure audit daemon service state"
+  ansible.builtin.service:
+    name: "{{ base_auditd_service_name }}"
+    enabled: "{{ base_auditd_enabled }}"
+    state: "{{ 'started' if base_auditd_enabled else 'stopped' }}"
+
+- name: "Config | Flush audit daemon handler"
+  ansible.builtin.meta: flush_handlers

--- a/roles/base_auditd/tasks/install.yml
+++ b/roles/base_auditd/tasks/install.yml
@@ -1,0 +1,11 @@
+---
+# roles/base_auditd/tasks/install.yml
+# Install phase tasks for the `base_auditd` role.
+# Ensures the requested audit packages are present before audit daemon configuration and validation.
+
+- name: "Install | Ensure audit packages are present"
+  ansible.builtin.apt:
+    name: "{{ base_auditd_packages }}"
+    state: present
+    update_cache: true
+    cache_valid_time: 3600

--- a/roles/base_auditd/tasks/main.yml
+++ b/roles/base_auditd/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+# roles/base_auditd/tasks/main.yml
+# Task entrypoint for the `base_auditd` role.
+# Imports the assert, install, config, and validate phase files in order.
+
+- name: Assert
+  ansible.builtin.import_tasks: assert.yml
+  tags: [assert, base_auditd, base_auditd_assert]
+
+- name: Install
+  ansible.builtin.import_tasks: install.yml
+  tags: [install, base_auditd, base_auditd_install]
+
+- name: Config
+  ansible.builtin.import_tasks: config.yml
+  tags: [config, base_auditd, base_auditd_config]
+
+- name: Validate
+  ansible.builtin.import_tasks: validate.yml
+  tags: [validate, base_auditd, base_auditd_validate]

--- a/roles/base_auditd/tasks/validate.yml
+++ b/roles/base_auditd/tasks/validate.yml
@@ -1,0 +1,66 @@
+---
+# roles/base_auditd/tasks/validate.yml
+# Validate phase tasks for the `base_auditd` role.
+# Verifies the requested package state, audit log directory state, managed auditd configuration file, and audit daemon service state after configuration.
+
+- name: "Validate | Gather package facts"
+  ansible.builtin.package_facts:
+    manager: auto
+
+- name: "Validate | Gather service facts"
+  ansible.builtin.service_facts:
+
+- name: "Validate | Read audit daemon configuration"
+  ansible.builtin.slurp:
+    path: /etc/audit/auditd.conf
+  register: base_auditd_config_file
+
+- name: "Validate | Read audit log directory state"
+  ansible.builtin.stat:
+    path: /var/log/audit
+  register: base_auditd_log_directory
+
+- name: "Validate | Assert audit daemon state"
+  vars:
+    base_auditd_expected_config: "{{ lookup('template', 'auditd.conf.j2') }}"
+    base_auditd_service_unit: >-
+      {{
+        base_auditd_service_name
+        if base_auditd_service_name.endswith('.service')
+        else (base_auditd_service_name ~ '.service')
+      }}
+    base_auditd_expected_service_statuses: >-
+      {{
+        ['enabled', 'enabled-runtime']
+        if base_auditd_enabled
+        else ['disabled']
+      }}
+  ansible.builtin.assert:
+    that:
+      - >-
+        (
+          base_auditd_packages
+          | difference(ansible_facts.packages.keys() | list)
+          | length
+        ) == 0
+      - base_auditd_log_directory.stat.exists
+      - base_auditd_log_directory.stat.isdir
+      - base_auditd_log_directory.stat.pw_name == 'root'
+      - base_auditd_log_directory.stat.gr_name == 'adm'
+      - (base_auditd_config_file.content | b64decode) == base_auditd_expected_config
+      - base_auditd_service_unit in ansible_facts.services
+      - ansible_facts.services[base_auditd_service_unit].status in base_auditd_expected_service_statuses
+      - >-
+        (
+          base_auditd_enabled
+          and ansible_facts.services[base_auditd_service_unit].state == 'running'
+        )
+        or
+        (
+          not base_auditd_enabled
+          and ansible_facts.services[base_auditd_service_unit].state != 'running'
+        )
+    fail_msg: >-
+      Configured audit daemon state does not match the requested
+      base_auditd values
+    quiet: true

--- a/roles/base_auditd/templates/auditd.conf.j2
+++ b/roles/base_auditd/templates/auditd.conf.j2
@@ -1,0 +1,35 @@
+{# roles/base_auditd/templates/auditd.conf.j2 #}
+{# Template for the managed `/etc/audit/auditd.conf` file in the `base_auditd` role. #}
+# Managed by Ansible: base_auditd
+# Source: roles/base_auditd/templates/auditd.conf.j2
+local_events = yes
+write_logs = yes
+log_file = /var/log/audit/audit.log
+log_group = adm
+log_format = {{ base_auditd_log_format | lower }}
+flush = {{ base_auditd_flush | lower }}
+freq = 50
+max_log_file = 8
+num_logs = 5
+priority_boost = 4
+name_format = none
+max_log_file_action = rotate
+space_left = 75
+space_left_action = syslog
+verify_email = yes
+action_mail_acct = root
+admin_space_left = 50
+admin_space_left_action = suspend
+disk_full_action = suspend
+disk_error_action = suspend
+use_libwrap = yes
+tcp_listen_queue = 5
+tcp_max_per_addr = 1
+tcp_client_max_idle = 0
+transport = tcp
+krb5_principal = auditd
+distribute_network = no
+q_depth = 400
+overflow_action = syslog
+max_restarts = 10
+plugin_dir = /etc/audit/plugins.d

--- a/roles/base_dns/templates/resolved.conf.j2
+++ b/roles/base_dns/templates/resolved.conf.j2
@@ -3,7 +3,12 @@
 {# Renders the Debian-family DNS baseline for systemd-resolved. #}
 {{
   (
-    ['[Resolve]', 'DNS=' ~ (base_dns_servers | join(' '))]
+    [
+      '# Managed by Ansible: base_dns',
+      '# Source: roles/base_dns/templates/resolved.conf.j2',
+      '[Resolve]',
+      'DNS=' ~ (base_dns_servers | join(' '))
+    ]
     + (
       ['Domains=' ~ (base_dns_search_domains | join(' '))]
       if base_dns_search_domains | length > 0

--- a/roles/base_hosts/tasks/config.yml
+++ b/roles/base_hosts/tasks/config.yml
@@ -7,4 +7,5 @@
   ansible.builtin.blockinfile:
     path: /etc/hosts
     marker: "{{ base_hosts_block_marker }}"
+    prepend_newline: true
     block: "{{ lookup('template', 'hosts_block.j2') | trim }}"

--- a/roles/base_locale/templates/default_locale.j2
+++ b/roles/base_locale/templates/default_locale.j2
@@ -3,7 +3,11 @@
 {#- Renders the Debian-family locale category configuration. -#}
 {{
   (
-    ['LANG=' ~ base_locale_lang]
+    [
+      '# Managed by Ansible: base_locale',
+      '# Source: roles/base_locale/templates/default_locale.j2',
+      'LANG=' ~ base_locale_lang
+    ]
     + (
       ['LC_ALL=' ~ base_locale_lc_all]
       if base_locale_lc_all | trim | length > 0

--- a/roles/base_logging/templates/journald.conf.j2
+++ b/roles/base_logging/templates/journald.conf.j2
@@ -1,5 +1,7 @@
 {# roles/base_logging/templates/journald.conf.j2 #}
 {# Template for the managed `/etc/systemd/journald.conf` file in the `base_logging` role. #}
+# Managed by Ansible: base_logging
+# Source: roles/base_logging/templates/journald.conf.j2
 [Journal]
 Storage={{ base_logging_storage }}
 Compress={{ 'yes' if base_logging_compress else 'no' }}

--- a/roles/base_ntp/templates/timesyncd.conf.j2
+++ b/roles/base_ntp/templates/timesyncd.conf.j2
@@ -3,7 +3,12 @@
 {# Renders the Debian-family NTP server configuration for systemd-timesyncd. #}
 {{
   (
-    ['[Time]', 'NTP=' ~ (base_ntp_servers | join(' '))]
+    [
+      '# Managed by Ansible: base_ntp',
+      '# Source: roles/base_ntp/templates/timesyncd.conf.j2',
+      '[Time]',
+      'NTP=' ~ (base_ntp_servers | join(' '))
+    ]
     + (
       ['FallbackNTP=' ~ (base_ntp_fallback_servers | join(' '))]
       if base_ntp_fallback_servers | length > 0

--- a/roles/base_sshd/templates/sshd_base.conf.j2
+++ b/roles/base_sshd/templates/sshd_base.conf.j2
@@ -1,6 +1,8 @@
 {# roles/base_sshd/templates/sshd_base.conf.j2 #}
 {# Template for the managed `/etc/ssh/sshd_config.d/90-base-sshd.conf` file in the `base_sshd` role. #}
 {# Renders the Debian-family SSH daemon baseline managed during the base phase. #}
+# Managed by Ansible: base_sshd
+# Source: roles/base_sshd/templates/sshd_base.conf.j2
 Port {{ base_sshd_port }}
 PermitRootLogin {{ base_sshd_permit_root_login }}
 PasswordAuthentication {{ 'yes' if base_sshd_password_authentication else 'no' }}


### PR DESCRIPTION
- Added the `base_auditd` role to manage the Linux audit daemon on Debian-family hosts.
- Included configuration for package installation, service management, and log formatting.
- Updated documentation to reflect the new role and its integration into the base role.
- Enhanced existing roles and templates to include managed-file comments for clarity.
- Adjusted playbook paths and variable files to accommodate the new role structure. base_auditd: add an optional audit baseline role for Debian-family hosts Fixes #42