### PR TITLE
base_fail2ban: add an optional intrusion-prevention baseline role for Debian-family hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 Release history for `homelab-roles`.
 Documents notable changes across repository structure, roles, examples, and documentation.
 
+## [v0.25.0]
+### Added
+- Added the `base_fail2ban` role for Debian-family intrusion-prevention baseline management, including defaults, handlers, full phase tasks, template, role documentation, and example variables.
+
+### Changed
+- Added `base_fail2ban` to the aggregate `base` role as an explicit opt-in follow-up role gated by `base_include_fail2ban`.
+
+### Documentation
+- Updated repository, aggregate-role, and example documentation to describe the new optional Fail2ban role and its example variable file.
+
 ## [v0.24.0]
 ### Added
 - Added the `base_auditd` role for Debian-family Linux audit baseline management, including defaults, handlers, full phase tasks, template, role documentation, and example variables.

--- a/README.md
+++ b/README.md
@@ -43,10 +43,11 @@ homelab-roles/
 
 ## Available Roles
 - `bootstrap`: Creates and validates the automation account used after the bootstrap phase.
-- `base`: Aggregates recurring base-phase configuration for Debian-family hosts through explicit `include_role` ordering in `roles/base/tasks/main.yml` for `base_packages`, `base_locale`, `base_timezone`, `base_ntp`, `base_hostname`, optional `base_hosts`, optional `base_dns`, `base_sudo`, and `base_sshd`, with optional follow-up inclusion for `base_firewall`, `base_logging`, `base_updates`, `base_apparmor`, `base_auditd`, and `base_upgrade`.
+- `base`: Aggregates recurring base-phase configuration for Debian-family hosts through explicit `include_role` ordering in `roles/base/tasks/main.yml` for `base_packages`, `base_locale`, `base_timezone`, `base_ntp`, `base_hostname`, optional `base_hosts`, optional `base_dns`, `base_sudo`, and `base_sshd`, with optional follow-up inclusion for `base_firewall`, `base_fail2ban`, `base_logging`, `base_updates`, `base_apparmor`, `base_auditd`, and `base_upgrade`.
 - `base_apparmor`: Enforces a minimal AppArmor package and service baseline on Debian-family hosts during the base phase.
 - `base_auditd`: Enforces a minimal Linux audit daemon package, service, and baseline configuration on Debian-family hosts during the base phase.
 - `base_dns`: Enforces a minimal DNS resolver baseline through `systemd-resolved` on Debian-family hosts during the base phase.
+- `base_fail2ban`: Enforces a minimal Fail2ban package, service, and SSH jail baseline on Debian-family hosts during the base phase.
 - `base_firewall`: Enforces an additive UFW baseline with managed default policies and requested allow or limit rules on Debian-family hosts during the base phase, with an optional purge mode for exact rebuilds.
 - `base_hosts`: Enforces inventory-driven and optional manual cluster host mappings through a managed `/etc/hosts` block on Debian-family hosts during the base phase.
 - `base_logging`: Enforces a persistent local journald baseline on Debian-family hosts during the base phase, with an optional volatile mode for non-persistent logs.

--- a/docs/01-examples.md
+++ b/docs/01-examples.md
@@ -19,7 +19,7 @@ The example content assumes Debian-family targets such as Debian and Ubuntu.
 
 - `examples/ansible.cfg`: Example Ansible configuration for local test runs that also hides skipped-host output for quieter example runs.
 - `examples/inventory/hosts.ini`: Example hosts and groups.
-- `examples/inventory/group_vars/all/`: Example variables for all hosts, split into role-scoped files such as `bootstrap.yml`, `base_packages.yml`, `base_hostname.yml`, `base_hosts.yml`, `base_dns.yml`, `base_locale.yml`, `base_ntp.yml`, `base_sudo.yml`, `base_sshd.yml`, `base_firewall.yml`, `base_logging.yml`, `base_updates.yml`, `base_apparmor.yml`, `base_auditd.yml`, `base_upgrade.yml`, `base_timezone.yml`, and `monitoring_authorized_key.yml`.
+- `examples/inventory/group_vars/all/`: Example variables for all hosts, split into role-scoped files such as `bootstrap.yml`, `base_packages.yml`, `base_hostname.yml`, `base_hosts.yml`, `base_dns.yml`, `base_locale.yml`, `base_ntp.yml`, `base_sudo.yml`, `base_sshd.yml`, `base_firewall.yml`, `base_fail2ban.yml`, `base_logging.yml`, `base_updates.yml`, `base_apparmor.yml`, `base_auditd.yml`, `base_upgrade.yml`, `base_timezone.yml`, and `monitoring_authorized_key.yml`.
 - `examples/playbooks/bootstrap.yml`: Bootstrap phase playbook that uses initial host credentials and applies the standalone `bootstrap` role.
 - `examples/playbooks/base.yml`: Base phase playbook for post-bootstrap role execution that applies the aggregate base role one host at a time for safer reboot-capable runs.
 - `examples/playbooks/site.yml`: Base-phase entry playbook that imports `base.yml`.
@@ -58,10 +58,11 @@ ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/tests/te
 
 - The lab content is intentionally simple and meant as an example baseline.
 - The example inventory and variables assume Debian-family hosts and the repository's APT-based role behavior.
-- `group_vars/all/` is split by role prefix so example variables such as `base_packages.yml`, `base_hostname.yml`, `base_hosts.yml`, `base_dns.yml`, `base_locale.yml`, `base_ntp.yml`, `base_sudo.yml`, `base_sshd.yml`, `base_firewall.yml`, `base_logging.yml`, `base_updates.yml`, `base_apparmor.yml`, `base_auditd.yml`, `base_upgrade.yml`, `base_timezone.yml`, and `monitoring_authorized_key.yml` stay readable as the stack grows.
+- `group_vars/all/` is split by role prefix so example variables such as `base_packages.yml`, `base_hostname.yml`, `base_hosts.yml`, `base_dns.yml`, `base_locale.yml`, `base_ntp.yml`, `base_sudo.yml`, `base_sshd.yml`, `base_firewall.yml`, `base_fail2ban.yml`, `base_logging.yml`, `base_updates.yml`, `base_apparmor.yml`, `base_auditd.yml`, `base_upgrade.yml`, `base_timezone.yml`, and `monitoring_authorized_key.yml` stay readable as the stack grows.
 - `base_hosts.yml` sets `base_include_hosts: true`, which opts the example base run into the optional `base_hosts` role so example hosts can resolve inventory peer names through `/etc/hosts`.
 - `base_dns.yml` sets `base_include_dns: true`, which opts the example base run into the optional `base_dns` role with an explicit `systemd-resolved` baseline.
 - `base_firewall.yml` sets `base_include_firewall: true`, which opts the example base run into the optional `base_firewall` role.
+- `base_fail2ban.yml` sets `base_include_fail2ban: true`, which opts the example base run into the optional `base_fail2ban` role with a managed SSH jail baseline.
 - `base_logging.yml` sets `base_include_logging: true`, which opts the example base run into the optional `base_logging` role with persistent journald storage enabled.
 - `base_updates.yml` sets `base_include_updates: true`, which opts the example base run into the optional `base_updates` role with unattended-upgrades enabled.
 - `base_apparmor.yml` sets `base_include_apparmor: true`, which opts the example base run into the optional `base_apparmor` role with the AppArmor service enabled.

--- a/docs/02-role-workflow.md
+++ b/docs/02-role-workflow.md
@@ -88,11 +88,12 @@ Use this sequence to keep foundational packages and environment settings first, 
 Optional current follow-up:
 
 1. `base_firewall` when `base_include_firewall: true`
-2. `base_logging` when `base_include_logging: true`
-3. `base_updates` when `base_include_updates: true`
-4. `base_apparmor` when `base_include_apparmor: true`
-5. `base_auditd` when `base_include_auditd: true`
-6. `base_upgrade` when `base_include_upgrade: true`
+2. `base_fail2ban` when `base_include_fail2ban: true`
+3. `base_logging` when `base_include_logging: true`
+4. `base_updates` when `base_include_updates: true`
+5. `base_apparmor` when `base_include_apparmor: true`
+6. `base_auditd` when `base_include_auditd: true`
+7. `base_upgrade` when `base_include_upgrade: true`
 
 Future optional follow-up roles should also be included explicitly from `roles/base/tasks/main.yml` and gated only by aggregate include flags.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,7 +10,7 @@ The inventory variables and role inputs assume the repository's Debian-family de
 ## Structure
 - `ansible.cfg`: Test-specific Ansible configuration that points at the example inventory and hides skipped-host output for quieter local runs.
 - `inventory/hosts.ini`: Test inventory.
-- `inventory/group_vars/all/`: Shared variables for test hosts, split into per-role files such as `bootstrap.yml`, `base_packages.yml`, `base_hostname.yml`, `base_hosts.yml`, `base_dns.yml`, `base_locale.yml`, `base_ntp.yml`, `base_sudo.yml`, `base_sshd.yml`, `base_firewall.yml`, `base_logging.yml`, `base_updates.yml`, `base_apparmor.yml`, `base_auditd.yml`, `base_upgrade.yml`, `base_timezone.yml`, and `monitoring_authorized_key.yml`.
+- `inventory/group_vars/all/`: Shared variables for test hosts, split into per-role files such as `bootstrap.yml`, `base_packages.yml`, `base_hostname.yml`, `base_hosts.yml`, `base_dns.yml`, `base_locale.yml`, `base_ntp.yml`, `base_sudo.yml`, `base_sshd.yml`, `base_firewall.yml`, `base_fail2ban.yml`, `base_logging.yml`, `base_updates.yml`, `base_apparmor.yml`, `base_auditd.yml`, `base_upgrade.yml`, `base_timezone.yml`, and `monitoring_authorized_key.yml`.
 - `playbooks/bootstrap.yml`: Bootstrap phase playbook that connects with the initial admin account and applies the standalone `bootstrap` role.
 - `playbooks/base.yml`: Base phase playbook that connects as the automation account, applies the `base` role, and uses `serial: 1` so reboot-capable base runs process one host at a time.
 - `playbooks/site.yml`: Base-phase entry playbook that imports `base.yml`.
@@ -54,6 +54,7 @@ The SSH integration test playbook cleans up its temporary `/etc/ssh/sshd_config.
 `inventory/group_vars/all/base_updates.yml` sets `base_include_updates: true`, which opts the example base run into the optional `base_updates` role with unattended-upgrades enabled.
 `inventory/group_vars/all/base_apparmor.yml` sets `base_include_apparmor: true`, which opts the example base run into the optional `base_apparmor` role with the AppArmor service enabled.
 `inventory/group_vars/all/base_auditd.yml` sets `base_include_auditd: true`, which opts the example base run into the optional `base_auditd` role with the audit daemon enabled and a minimal explicit baseline configuration.
+`inventory/group_vars/all/base_fail2ban.yml` sets `base_include_fail2ban: true`, which opts the example base run into the optional `base_fail2ban` role with a managed SSH jail baseline.
 `inventory/group_vars/all/base_hosts.yml` sets `base_include_hosts: true`, which opts the example base run into the optional `base_hosts` role so example hosts can resolve inventory peer names through `/etc/hosts`.
 `inventory/group_vars/all/base_dns.yml` sets `base_include_dns: true`, which opts the example base run into the optional `base_dns` role with an explicit `systemd-resolved` baseline.
 `inventory/group_vars/all/base_upgrade.yml` keeps `base_include_upgrade: false` by default, so the example lab documents the role inputs without making every base run apply immediate package upgrades.

--- a/examples/inventory/group_vars/all/base_fail2ban.yml
+++ b/examples/inventory/group_vars/all/base_fail2ban.yml
@@ -1,0 +1,27 @@
+---
+# examples/inventory/group_vars/all/base_fail2ban.yml
+# Shared Fail2ban variables for the example lab.
+# Defines the aggregate-role opt-in plus the Fail2ban package, service, and SSH jail baseline enforced during the base phase.
+
+# Opt in to the optional base_fail2ban role from the aggregate base role.
+base_include_fail2ban: true
+
+# Package list installed with APT to provide the Fail2ban baseline.
+base_fail2ban_packages:
+  - fail2ban
+
+# Fail2ban service name managed and validated during the base phase.
+base_fail2ban_service_name: fail2ban
+
+# Use the systemd backend in the example lab so the SSH jail reads the
+# journal directly on modern Debian-family hosts.
+base_fail2ban_backend: systemd
+
+# Ban repeated SSH failures for 10 minutes in the example lab.
+base_fail2ban_bantime: 10m
+
+# Count retries that occur within a 10-minute window.
+base_fail2ban_findtime: 10m
+
+# Ban after 5 failed attempts in the example lab.
+base_fail2ban_maxretry: 5

--- a/roles/base/README.md
+++ b/roles/base/README.md
@@ -11,6 +11,7 @@ Explains how the aggregate base role delegates recurring Debian-family host conf
 - Can insert `base_dns` after `base_hosts` as an explicit opt-in resolver baseline when `base_include_dns: true`
 - Keeps aggregate include-task tags aligned with each child role's phase tags and role-specific tags so targeted runs such as `--tags validate` or `--tags base_packages_validate` stay predictable
 - Can include `base_firewall` as an explicit opt-in follow-up role when `base_include_firewall: true`
+- Can include `base_fail2ban` as an explicit opt-in follow-up role when `base_include_fail2ban: true`
 - Can include `base_logging` as an explicit opt-in follow-up role when `base_include_logging: true`
 - Can include `base_updates` as an explicit opt-in follow-up role when `base_include_updates: true`
 - Can include `base_apparmor` as an explicit opt-in follow-up role when `base_include_apparmor: true`
@@ -30,7 +31,7 @@ Use `base` on Debian-family hosts after the bootstrap phase has already created 
 ```
 
 Bootstrap is handled separately by the standalone `bootstrap` role/playbook.
-Role-specific inputs for `base` currently come from `base_packages_*`, `base_locale_*`, `base_timezone_*`, `base_ntp_*`, `base_hostname_*`, optional `base_include_hosts` plus `base_hosts_*`, optional `base_include_dns` plus `base_dns_*`, `base_sudo_*`, `base_sshd_*`, optional `base_include_firewall` plus `base_firewall_*`, optional `base_include_logging` plus `base_logging_*`, optional `base_include_updates` plus `base_updates_*`, optional `base_include_apparmor` plus `base_apparmor_*`, optional `base_include_auditd` plus `base_auditd_*`, and optional `base_include_upgrade` plus `base_upgrade_*`.
+Role-specific inputs for `base` currently come from `base_packages_*`, `base_locale_*`, `base_timezone_*`, `base_ntp_*`, `base_hostname_*`, optional `base_include_hosts` plus `base_hosts_*`, optional `base_include_dns` plus `base_dns_*`, `base_sudo_*`, `base_sshd_*`, optional `base_include_firewall` plus `base_firewall_*`, optional `base_include_fail2ban` plus `base_fail2ban_*`, optional `base_include_logging` plus `base_logging_*`, optional `base_include_updates` plus `base_updates_*`, optional `base_include_apparmor` plus `base_apparmor_*`, optional `base_include_auditd` plus `base_auditd_*`, and optional `base_include_upgrade` plus `base_upgrade_*`.
 
 Current include order in `base` is:
 
@@ -53,11 +54,12 @@ This keeps broad phase runs such as `--tags validate` working across the full ba
 Optional follow-up role:
 
 1. `base_firewall` when `base_include_firewall: true`
-2. `base_logging` when `base_include_logging: true`
-3. `base_updates` when `base_include_updates: true`
-4. `base_apparmor` when `base_include_apparmor: true`
-5. `base_auditd` when `base_include_auditd: true`
-6. `base_upgrade` when `base_include_upgrade: true`
+2. `base_fail2ban` when `base_include_fail2ban: true`
+3. `base_logging` when `base_include_logging: true`
+4. `base_updates` when `base_include_updates: true`
+5. `base_apparmor` when `base_include_apparmor: true`
+6. `base_auditd` when `base_include_auditd: true`
+7. `base_upgrade` when `base_include_upgrade: true`
 
 ## License
 MIT

--- a/roles/base/defaults/main.yml
+++ b/roles/base/defaults/main.yml
@@ -10,4 +10,5 @@ base_include_hosts: false
 base_include_dns: false
 base_include_apparmor: false
 base_include_auditd: false
+base_include_fail2ban: false
 base_include_upgrade: false

--- a/roles/base/tasks/main.yml
+++ b/roles/base/tasks/main.yml
@@ -76,6 +76,14 @@
   when: base_include_firewall | default(false)
   tags: [base, base_firewall, assert, install, config, validate, base_firewall_assert, base_firewall_install, base_firewall_config, base_firewall_validate]
 
+- name: "Base | Include optional base_fail2ban role"
+  ansible.builtin.include_role:
+    name: base_fail2ban
+    apply:
+      tags: [base, base_fail2ban]
+  when: base_include_fail2ban | default(false)
+  tags: [base, base_fail2ban, assert, install, config, validate, base_fail2ban_assert, base_fail2ban_install, base_fail2ban_config, base_fail2ban_validate]
+
 - name: "Base | Include optional base_logging role"
   ansible.builtin.include_role:
     name: base_logging

--- a/roles/base_fail2ban/README.md
+++ b/roles/base_fail2ban/README.md
@@ -1,0 +1,60 @@
+# roles/base_fail2ban/README.md
+
+Reference for the `base_fail2ban` role.
+Explains how the role manages a minimal Fail2ban SSH jail baseline on Debian-family hosts during the base phase.
+
+## Features
+- Validates the requested Fail2ban package, service, backend, and SSH jail inputs
+- Installs the requested Fail2ban package baseline with APT before configuration
+- Fully manages `/etc/fail2ban/jail.local` as a minimal SSH-focused baseline
+- Ensures the Fail2ban service is enabled and running
+- Verifies the requested package state, managed jail configuration file, running service state, and active SSH jail after changes
+- Keeps v1 intentionally narrow by managing only one SSH jail without custom actions or multi-service jail matrices
+
+## Variables
+
+| Variable | Default | Required | Description |
+|----------|---------|----------|-------------|
+| `base_fail2ban_packages` | `['fail2ban']` | no | Package list installed with APT to provide the Fail2ban baseline; must include `fail2ban` |
+| `base_fail2ban_service_name` | `fail2ban` | no | Fail2ban service name enabled, restarted, and validated by the role |
+| `base_fail2ban_backend` | `systemd` | no | Backend written to the managed SSH jail baseline; supported values are `auto`, `polling`, `pyinotify`, and `systemd` |
+| `base_fail2ban_bantime` | `10m` | no | Ban duration written to the managed SSH jail baseline; may be a Fail2ban time string such as `10m` or an integer number of seconds |
+| `base_fail2ban_findtime` | `10m` | no | Failure counting window written to the managed SSH jail baseline; may be a Fail2ban time string such as `10m` or an integer number of seconds |
+| `base_fail2ban_maxretry` | `5` | no | Number of failed SSH attempts allowed before the managed jail bans an address |
+
+## Usage
+
+The `base` role can include `base_fail2ban` when `base_include_fail2ban: true`.
+
+Direct usage:
+
+```yaml
+- hosts: all
+  become: true
+  roles:
+    - base_fail2ban
+```
+
+Example variables:
+
+```yaml
+base_include_fail2ban: true
+base_fail2ban_packages:
+  - fail2ban
+base_fail2ban_backend: systemd
+base_fail2ban_bantime: 10m
+base_fail2ban_findtime: 10m
+base_fail2ban_maxretry: 5
+```
+
+This role intentionally manages only one SSH jail in v1.
+It does not yet manage custom actions, per-service jail matrices, or non-SSH policy expansion.
+
+## Dependencies
+None
+
+## License
+MIT
+
+## Author
+Tatbyte

--- a/roles/base_fail2ban/defaults/main.yml
+++ b/roles/base_fail2ban/defaults/main.yml
@@ -1,0 +1,12 @@
+---
+# roles/base_fail2ban/defaults/main.yml
+# Default variables for the `base_fail2ban` role.
+# Defines the Fail2ban package list, service, backend, and SSH jail values enforced during the base phase.
+
+base_fail2ban_packages:
+  - fail2ban
+base_fail2ban_service_name: fail2ban
+base_fail2ban_backend: systemd
+base_fail2ban_bantime: 10m
+base_fail2ban_findtime: 10m
+base_fail2ban_maxretry: 5

--- a/roles/base_fail2ban/handlers/main.yml
+++ b/roles/base_fail2ban/handlers/main.yml
@@ -1,0 +1,9 @@
+---
+# roles/base_fail2ban/handlers/main.yml
+# Handlers for the `base_fail2ban` role.
+# Restarts the Fail2ban service when the managed jail configuration changes.
+
+- name: Restart Fail2ban service
+  ansible.builtin.service:
+    name: "{{ base_fail2ban_service_name }}"
+    state: restarted

--- a/roles/base_fail2ban/tasks/assert.yml
+++ b/roles/base_fail2ban/tasks/assert.yml
@@ -1,0 +1,38 @@
+---
+# roles/base_fail2ban/tasks/assert.yml
+# Assert phase tasks for the `base_fail2ban` role.
+# Validates the requested Fail2ban package, service, backend, and SSH jail inputs before installation and configuration run.
+
+- name: "Assert | Validate base_fail2ban variable structure"
+  vars:
+    base_fail2ban_allowed_backends:
+      - auto
+      - polling
+      - pyinotify
+      - systemd
+  ansible.builtin.assert:
+    that:
+      - base_fail2ban_packages is sequence
+      - base_fail2ban_packages is not string
+      - base_fail2ban_service_name is string
+      - base_fail2ban_service_name | trim | length > 0
+      - base_fail2ban_backend is string
+      - base_fail2ban_backend | trim | length > 0
+      - (base_fail2ban_backend | lower) in base_fail2ban_allowed_backends
+      - (base_fail2ban_bantime is string) or (base_fail2ban_bantime is integer)
+      - (base_fail2ban_bantime | string | trim | length) > 0
+      - (base_fail2ban_findtime is string) or (base_fail2ban_findtime is integer)
+      - (base_fail2ban_findtime | string | trim | length) > 0
+      - base_fail2ban_maxretry is integer
+      - (base_fail2ban_maxretry | int) > 0
+      - (base_fail2ban_packages | map('string') | list | length) == (base_fail2ban_packages | length)
+      - (base_fail2ban_packages | map('trim') | reject('equalto', '') | list | length) == (base_fail2ban_packages | length)
+      - "'fail2ban' in base_fail2ban_packages"
+    fail_msg: >-
+      base_fail2ban_packages must be a list of non-empty package names that
+      includes fail2ban, base_fail2ban_service_name must be a non-empty
+      service name, base_fail2ban_backend must be auto, polling,
+      pyinotify, or systemd, base_fail2ban_bantime and
+      base_fail2ban_findtime must be non-empty strings or integers, and
+      base_fail2ban_maxretry must be a positive integer
+    quiet: true

--- a/roles/base_fail2ban/tasks/config.yml
+++ b/roles/base_fail2ban/tasks/config.yml
@@ -1,0 +1,22 @@
+---
+# roles/base_fail2ban/tasks/config.yml
+# Config phase tasks for the `base_fail2ban` role.
+# Renders the managed Fail2ban jail baseline and enforces the requested service state during the base phase.
+
+- name: "Config | Render Fail2ban SSH jail configuration"
+  ansible.builtin.template:
+    src: jail.local.j2
+    dest: /etc/fail2ban/jail.local
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart Fail2ban service
+
+- name: "Config | Ensure Fail2ban service is enabled and running"
+  ansible.builtin.service:
+    name: "{{ base_fail2ban_service_name }}"
+    enabled: true
+    state: started
+
+- name: "Config | Flush Fail2ban handler"
+  ansible.builtin.meta: flush_handlers

--- a/roles/base_fail2ban/tasks/install.yml
+++ b/roles/base_fail2ban/tasks/install.yml
@@ -1,0 +1,11 @@
+---
+# roles/base_fail2ban/tasks/install.yml
+# Install phase tasks for the `base_fail2ban` role.
+# Ensures the requested Fail2ban packages are present before jail configuration and validation.
+
+- name: "Install | Ensure Fail2ban packages are present"
+  ansible.builtin.apt:
+    name: "{{ base_fail2ban_packages }}"
+    state: present
+    update_cache: true
+    cache_valid_time: 3600

--- a/roles/base_fail2ban/tasks/main.yml
+++ b/roles/base_fail2ban/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+# roles/base_fail2ban/tasks/main.yml
+# Task entrypoint for the `base_fail2ban` role.
+# Imports the assert, install, config, and validate phase files in order.
+
+- name: Assert
+  ansible.builtin.import_tasks: assert.yml
+  tags: [assert, base_fail2ban, base_fail2ban_assert]
+
+- name: Install
+  ansible.builtin.import_tasks: install.yml
+  tags: [install, base_fail2ban, base_fail2ban_install]
+
+- name: Config
+  ansible.builtin.import_tasks: config.yml
+  tags: [config, base_fail2ban, base_fail2ban_config]
+
+- name: Validate
+  ansible.builtin.import_tasks: validate.yml
+  tags: [validate, base_fail2ban, base_fail2ban_validate]

--- a/roles/base_fail2ban/tasks/validate.yml
+++ b/roles/base_fail2ban/tasks/validate.yml
@@ -1,0 +1,54 @@
+---
+# roles/base_fail2ban/tasks/validate.yml
+# Validate phase tasks for the `base_fail2ban` role.
+# Verifies the requested package state, managed jail configuration file, running service state, and active SSH jail after configuration.
+
+- name: "Validate | Gather package facts"
+  ansible.builtin.package_facts:
+    manager: auto
+
+- name: "Validate | Gather service facts"
+  ansible.builtin.service_facts:
+
+- name: "Validate | Read managed Fail2ban jail configuration"
+  ansible.builtin.slurp:
+    path: /etc/fail2ban/jail.local
+  register: base_fail2ban_jail_file
+
+- name: "Validate | Read active Fail2ban server state"
+  ansible.builtin.command: fail2ban-client ping
+  register: base_fail2ban_ping
+  changed_when: false
+
+- name: "Validate | Read active Fail2ban jail list"
+  ansible.builtin.command: fail2ban-client status
+  register: base_fail2ban_status
+  changed_when: false
+
+- name: "Validate | Assert Fail2ban state"
+  vars:
+    base_fail2ban_expected_config: "{{ lookup('template', 'jail.local.j2') }}"
+    base_fail2ban_service_unit: >-
+      {{
+        base_fail2ban_service_name
+        if base_fail2ban_service_name.endswith('.service')
+        else (base_fail2ban_service_name ~ '.service')
+      }}
+  ansible.builtin.assert:
+    that:
+      - >-
+        (
+          base_fail2ban_packages
+          | difference(ansible_facts.packages.keys() | list)
+          | length
+        ) == 0
+      - (base_fail2ban_jail_file.content | b64decode) == base_fail2ban_expected_config
+      - base_fail2ban_service_unit in ansible_facts.services
+      - ansible_facts.services[base_fail2ban_service_unit].status in ['enabled', 'enabled-runtime']
+      - ansible_facts.services[base_fail2ban_service_unit].state == 'running'
+      - base_fail2ban_ping.stdout is search('Server replied:\\s+pong')
+      - base_fail2ban_status.stdout is search('Jail list:\\s+.*\\bsshd\\b')
+    fail_msg: >-
+      Configured Fail2ban state does not match the requested
+      base_fail2ban values
+    quiet: true

--- a/roles/base_fail2ban/templates/jail.local.j2
+++ b/roles/base_fail2ban/templates/jail.local.j2
@@ -1,0 +1,13 @@
+{# roles/base_fail2ban/templates/jail.local.j2 #}
+{# Template for the managed `/etc/fail2ban/jail.local` file in the `base_fail2ban` role. #}
+# Managed by Ansible: base_fail2ban
+# Source: roles/base_fail2ban/templates/jail.local.j2
+[DEFAULT]
+backend = {{ base_fail2ban_backend | lower }}
+bantime = {{ base_fail2ban_bantime }}
+findtime = {{ base_fail2ban_findtime }}
+maxretry = {{ base_fail2ban_maxretry }}
+
+[sshd]
+enabled = true
+port = ssh


### PR DESCRIPTION
Introduce the `base_fail2ban` role to provide a minimal, explicit Fail2ban baseline for Debian-family hosts. This role installs Fail2ban, manages an SSH-focused jail configuration, and validates the resulting state. It enhances SSH protection by automating responses to repeated login failures and integrates seamlessly with existing base roles. Documentation has been updated to reflect this new role and its configuration options.

Fixes #43