### PR TITLE
feat: Add user and user_account roles for human admin management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@
 Release history for `homelab-roles`.
 Documents notable changes across repository structure, roles, examples, and documentation.
 
+## [v1.1.0]
+### Added
+- Added the aggregate `user` role for the post-base human-admin user layer, including explicit aggregate ordering, metadata, documentation, and example playbook wiring.
+- Added the standalone `user_account` role for creating, adopting, and validating one human admin account with explicit primary-group, home-directory, baseline shell, and optional password-lock management.
+- Added example inventory files for the new user layer, including `user.yml` and `user_account.yml`, plus a dedicated `examples/playbooks/user.yml` entrypoint.
+
+### Changed
+- Updated the example `site.yml` flow so the full post-bootstrap stack now runs `base` and then `user`.
+- Shifted the bootstrap-role default automation UID/GID to `1100` and kept the new human-admin `user_account` role defaults at `1050` to preserve a clearer ID separation between automation and human accounts.
+- Updated the example SSH allow-list so the example human admin account created by the user layer is permitted by the managed `base_sshd` policy.
+- Hardened `user_account` input validation and final-state validation so missing users or groups fail cleanly instead of crashing through unsafe fact lookups, and so unmanaged primary groups are asserted explicitly before config runs.
+- Added explicit `user_account_move_home` handling so adopting an existing user now fails early on unexpected home-directory changes unless the move is intentionally allowed.
+- Made `user_account` password-lock management opt-in by treating `null` as "leave current password-lock state unchanged", reducing repeated change noise on reruns.
+
+### Documentation
+- Updated repository, workflow, role, and example documentation to describe the new `user` aggregate role, the `user_account` role, the expanded example lab flow, and the bootstrap-versus-user UID/GID defaults.
+
 ## [v1.0.0]
 ### Changed
 - Declared the recurring Debian-family `base` stack complete at `v1.0.0`, covering the aggregate base workflow plus the current optional follow-up roles for firewall, fail2ban, logging, updates, AppArmor, auditd, upgrade, and needrestart.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The current role set is centered on:
 
 - bootstrap access for the automation account
 - recurring base host configuration and hardening
+- recurring human admin account management
 - monitoring-related access primitives
 
 This is a roles repository, not the full infrastructure repository.
@@ -31,7 +32,9 @@ homelab-roles/
 │   ├── base/
 │   ├── bootstrap/
 │   ├── monitoring/
-│   └── monitoring_authorized_key/
+│   ├── monitoring_authorized_key/
+│   ├── user/
+│   └── user_account/
 ├── examples/
 │   ├── ansible.cfg
 │   ├── inventory/
@@ -62,6 +65,8 @@ homelab-roles/
 - `base_timezone`: Enforces the system timezone on Debian-family hosts during the base phase.
 - `monitoring`: Aggregates monitoring-related configuration through dependency roles such as `monitoring_authorized_key`.
 - `monitoring_authorized_key`: Installs an SSH authorized key for monitoring-style inter-host access.
+- `user`: Aggregates recurring human admin user configuration through explicit `include_role` ordering in `roles/user/tasks/main.yml` for `user_account`.
+- `user_account`: Creates and validates one human admin account with explicit primary-group, shell, home-directory, and basic account-state enforcement after the base phase.
 
 ## Consume From Another Repo
 Recommended pattern: add this repository to your infra repository (submodule or vendored checkout), then point `roles_path` to `homelab-roles/roles`.
@@ -90,6 +95,12 @@ Example infra playbook:
   roles:
     - role: base
 
+- name: Apply human admin user setup
+  hosts: all
+  become: true
+  roles:
+    - role: user
+
 - name: Apply monitoring access
   hosts: monitoring_targets
   become: true
@@ -106,10 +117,16 @@ Run bootstrap first from repo root:
 ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/bootstrap.yml
 ```
 
-Then run the base phase:
+Then run the full post-bootstrap stack:
 
 ```sh
 ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/site.yml
+```
+
+Equivalent direct user-phase command:
+
+```sh
+ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/user.yml
 ```
 
 Optional `base_sshd` integration check:
@@ -151,7 +168,7 @@ See [docs/00-pre-commit.mb](docs/00-pre-commit.mb) for full setup details.
 Core repository docs:
 
 - [docs/01-examples.md](docs/01-examples.md): Example lab layout and execution flow
-- [docs/02-role-workflow.md](docs/02-role-workflow.md): Shared role phase structure and aggregate base-role ordering
+- [docs/02-role-workflow.md](docs/02-role-workflow.md): Shared role phase structure and aggregate base-role plus user-role ordering
 - [docs/03-file-consistency.md](docs/03-file-consistency.md): File header and wording consistency rules
 - [docs/04-firewall-role-integration.md](docs/04-firewall-role-integration.md): How future roles should register firewall rules for `base_firewall`
 

--- a/docs/01-examples.md
+++ b/docs/01-examples.md
@@ -1,7 +1,7 @@
 # docs/01-examples.md
 
 Reference document for the example lab in `examples/`.
-Explains how the example inventory, variables, and playbooks fit together for the bootstrap phase and the base phase on Debian-family hosts.
+Explains how the example inventory, variables, and playbooks fit together for the bootstrap phase and the follow-up base plus user phases on Debian-family hosts.
 
 ## Purpose
 
@@ -19,10 +19,11 @@ The example content assumes Debian-family targets such as Debian and Ubuntu.
 
 - `examples/ansible.cfg`: Example Ansible configuration for local test runs that also hides skipped-host output for quieter example runs.
 - `examples/inventory/hosts.ini`: Example hosts and groups.
-- `examples/inventory/group_vars/all/`: Example variables for all hosts, split into role-scoped files such as `bootstrap.yml`, `base_packages.yml`, `base_hostname.yml`, `base_hosts.yml`, `base_dns.yml`, `base_locale.yml`, `base_ntp.yml`, `base_sudo.yml`, `base_sshd.yml`, `base_firewall.yml`, `base_fail2ban.yml`, `base_logging.yml`, `base_updates.yml`, `base_apparmor.yml`, `base_auditd.yml`, `base_upgrade.yml`, `base_needrestart.yml`, `base_timezone.yml`, and `monitoring_authorized_key.yml`.
+- `examples/inventory/group_vars/all/`: Example variables for all hosts, split into role-scoped files such as `bootstrap.yml`, `base_packages.yml`, `base_hostname.yml`, `base_hosts.yml`, `base_dns.yml`, `base_locale.yml`, `base_ntp.yml`, `base_sudo.yml`, `base_sshd.yml`, `base_firewall.yml`, `base_fail2ban.yml`, `base_logging.yml`, `base_updates.yml`, `base_apparmor.yml`, `base_auditd.yml`, `base_upgrade.yml`, `base_needrestart.yml`, `base_timezone.yml`, `user.yml`, `user_account.yml`, and `monitoring_authorized_key.yml`.
 - `examples/playbooks/bootstrap.yml`: Bootstrap phase playbook that uses initial host credentials and applies the standalone `bootstrap` role.
 - `examples/playbooks/base.yml`: Base phase playbook for post-bootstrap role execution that applies the aggregate base role one host at a time for safer reboot-capable runs.
-- `examples/playbooks/site.yml`: Base-phase entry playbook that imports `base.yml`.
+- `examples/playbooks/user.yml`: User phase playbook for post-base role execution that applies the aggregate `user` role for human admin account enforcement.
+- `examples/playbooks/site.yml`: Post-bootstrap entry playbook that imports `base.yml` and then `user.yml`.
 - `examples/playbooks/tests/test_base_sshd.yml`: Optional integration test playbook for exercising merged `sshd_config.d` fragments plus `Match User` and `Match Address` behavior around the `base_sshd` role.
 
 ## How to Use the Example
@@ -36,7 +37,7 @@ The example content assumes Debian-family targets such as Debian and Ubuntu.
 ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/bootstrap.yml
 ```
 
-5. Then run the base phase:
+5. Then run the full post-bootstrap stack:
 
 ```bash
 ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/site.yml
@@ -46,6 +47,12 @@ Equivalent direct base-phase command:
 
 ```bash
 ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/base.yml
+```
+
+Equivalent direct user-phase command:
+
+```bash
+ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/user.yml
 ```
 
 Optional `base_sshd` integration check:
@@ -58,7 +65,7 @@ ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/tests/te
 
 - The lab content is intentionally simple and meant as an example baseline.
 - The example inventory and variables assume Debian-family hosts and the repository's APT-based role behavior.
-- `group_vars/all/` is split by role prefix so example variables such as `base_packages.yml`, `base_hostname.yml`, `base_hosts.yml`, `base_dns.yml`, `base_locale.yml`, `base_ntp.yml`, `base_sudo.yml`, `base_sshd.yml`, `base_firewall.yml`, `base_fail2ban.yml`, `base_logging.yml`, `base_updates.yml`, `base_apparmor.yml`, `base_auditd.yml`, `base_upgrade.yml`, `base_needrestart.yml`, `base_timezone.yml`, and `monitoring_authorized_key.yml` stay readable as the stack grows.
+- `group_vars/all/` is split by role prefix so example variables such as `base_packages.yml`, `base_hostname.yml`, `base_hosts.yml`, `base_dns.yml`, `base_locale.yml`, `base_ntp.yml`, `base_sudo.yml`, `base_sshd.yml`, `base_firewall.yml`, `base_fail2ban.yml`, `base_logging.yml`, `base_updates.yml`, `base_apparmor.yml`, `base_auditd.yml`, `base_upgrade.yml`, `base_needrestart.yml`, `base_timezone.yml`, `user.yml`, `user_account.yml`, and `monitoring_authorized_key.yml` stay readable as the stack grows.
 - `base_hosts.yml` sets `base_include_hosts: true`, which opts the example base run into the optional `base_hosts` role so example hosts can resolve inventory peer names through `/etc/hosts`.
 - `base_dns.yml` sets `base_include_dns: true`, which opts the example base run into the optional `base_dns` role with an explicit `systemd-resolved` baseline.
 - `base_firewall.yml` sets `base_include_firewall: true`, which opts the example base run into the optional `base_firewall` role and documents the shared baseline, role-declared accumulator, and `managed:` comment convention used for stale rule cleanup.
@@ -72,6 +79,7 @@ ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/tests/te
 - This means the example base run may fail intentionally after package maintenance when restart follow-up is still pending; set the `base_needrestart_fail_if_*` values back to `false` for report-only example runs.
 - When the example run's `base_upgrade` role makes no package-maintenance changes and leaves no reboot-required follow-up, `base_needrestart` now skips the batch check automatically to reduce no-change noise.
 - `playbooks/base.yml` uses `serial: 1`, which is safer when optional roles such as `base_upgrade` may reboot a host during the run.
+- `user_account.yml` defines the example human admin account enforced after the base phase through the aggregate `user` role.
 - `ansible.cfg` sets `display_skipped_hosts = False`, so routine conditional skips from optional roles or gated tasks do not dominate the example output.
 - `hosts.ini` keeps default `ansible_user=ansible` in `[all:vars]`, while `[bootstrap:vars]` holds initial login values used only during bootstrap.
 - `playbooks/bootstrap.yml` prompts once for the bootstrap password and reuses it for both SSH login and sudo.

--- a/docs/02-role-workflow.md
+++ b/docs/02-role-workflow.md
@@ -98,6 +98,18 @@ Optional current follow-up:
 
 Future optional follow-up roles should also be included explicitly from `roles/base/tasks/main.yml` and gated only by aggregate include flags.
 
+## Aggregate User Order
+
+The aggregate `user` role in this repository applies its human-admin user roles in a stable order.
+`roles/user/tasks/main.yml` is the single source of truth and uses explicit `ansible.builtin.include_role` entries for the aggregate sequence.
+Its include-task tags should mirror the generic phase tags plus the child role's role-specific tags so both broad and narrow tagged runs behave predictably.
+
+Current order:
+
+1. `user_account`
+
+Use this sequence to keep human-admin account creation and adoption explicit after the `base_*` layer and before any future user-environment roles such as SSH, shell, or profile management.
+
 ## Tag Usage
 
 Run specific phases during development or troubleshooting:

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,7 +1,7 @@
 # examples/README.md
 
 Guide for the local example lab in `examples/`.
-Explains the example file layout, the explicit bootstrap phase, and the follow-up base phase for Debian-family hosts.
+Explains the example file layout, the explicit bootstrap phase, and the follow-up base plus user phases for Debian-family hosts.
 
 ## Scope
 This example lab targets Debian-family hosts such as Debian and Ubuntu.
@@ -10,10 +10,11 @@ The inventory variables and role inputs assume the repository's Debian-family de
 ## Structure
 - `ansible.cfg`: Test-specific Ansible configuration that points at the example inventory and hides skipped-host output for quieter local runs.
 - `inventory/hosts.ini`: Test inventory.
-- `inventory/group_vars/all/`: Shared variables for test hosts, split into per-role files such as `bootstrap.yml`, `base_packages.yml`, `base_hostname.yml`, `base_hosts.yml`, `base_dns.yml`, `base_locale.yml`, `base_ntp.yml`, `base_sudo.yml`, `base_sshd.yml`, `base_firewall.yml`, `base_fail2ban.yml`, `base_logging.yml`, `base_updates.yml`, `base_apparmor.yml`, `base_auditd.yml`, `base_upgrade.yml`, `base_needrestart.yml`, `base_timezone.yml`, and `monitoring_authorized_key.yml`.
+- `inventory/group_vars/all/`: Shared variables for test hosts, split into per-role files such as `bootstrap.yml`, `base_packages.yml`, `base_hostname.yml`, `base_hosts.yml`, `base_dns.yml`, `base_locale.yml`, `base_ntp.yml`, `base_sudo.yml`, `base_sshd.yml`, `base_firewall.yml`, `base_fail2ban.yml`, `base_logging.yml`, `base_updates.yml`, `base_apparmor.yml`, `base_auditd.yml`, `base_upgrade.yml`, `base_needrestart.yml`, `base_timezone.yml`, `user.yml`, `user_account.yml`, and `monitoring_authorized_key.yml`.
 - `playbooks/bootstrap.yml`: Bootstrap phase playbook that connects with the initial admin account and applies the standalone `bootstrap` role.
 - `playbooks/base.yml`: Base phase playbook that connects as the automation account, applies the `base` role, and uses `serial: 1` so reboot-capable base runs process one host at a time.
-- `playbooks/site.yml`: Base-phase entry playbook that imports `base.yml`.
+- `playbooks/user.yml`: User phase playbook that connects as the automation account after the base phase and applies the aggregate `user` role.
+- `playbooks/site.yml`: Post-bootstrap entry playbook that imports `base.yml` and then `user.yml`.
 - `playbooks/tests/test_base_sshd.yml`: Integration test playbook that temporarily adds extra SSH daemon fragments, runs `base_sshd`, verifies merged `AllowUsers` plus `Match User` and `Match Address` behavior, and removes the temporary fixtures.
 
 ## Usage
@@ -23,7 +24,7 @@ Run bootstrap from repository root:
 ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/bootstrap.yml
 ```
 
-Then run the base phase:
+Then run the full post-bootstrap stack:
 
 ```sh
 ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/site.yml
@@ -40,6 +41,12 @@ Equivalent direct base-phase command:
 
 ```sh
 ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/base.yml
+```
+
+Equivalent direct user-phase command:
+
+```sh
+ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/user.yml
 ```
 
 Optional `base_sshd` integration check:
@@ -62,6 +69,7 @@ The SSH integration test playbook cleans up its temporary `/etc/ssh/sshd_config.
 This means the example base run may fail intentionally after package maintenance when restart follow-up is still pending; set the `base_needrestart_fail_if_*` values back to `false` for report-only example runs.
 When the example run's `base_upgrade` role makes no package-maintenance changes and leaves no reboot-required follow-up, `base_needrestart` now skips the batch check automatically to reduce no-change noise.
 `playbooks/base.yml` uses `serial: 1`, which is safer when optional roles such as `base_upgrade` may reboot a host during the run.
+`inventory/group_vars/all/user_account.yml` defines the example human admin account enforced after the base phase through the aggregate `user` role.
 `ansible.cfg` sets `display_skipped_hosts = False`, so optional-role and conditional-task skips are hidden during normal example runs.
 
 ## Bootstrap Credentials

--- a/examples/inventory/group_vars/all/base_sshd.yml
+++ b/examples/inventory/group_vars/all/base_sshd.yml
@@ -29,3 +29,4 @@ base_sshd_allow_users:
   - vagrant      # Used by Vagrant for VM lifecycle (halt/up) and testing automation
   - ansible
   - admin
+  - human-user    # Example human admin account managed by the user layer

--- a/examples/inventory/group_vars/all/user.yml
+++ b/examples/inventory/group_vars/all/user.yml
@@ -1,0 +1,4 @@
+---
+# examples/inventory/group_vars/all/user.yml
+# Shared aggregate user-role variables for the example lab.
+# Intentionally empty because the aggregate `user` role currently delegates work through `user_account_*` variables only.

--- a/examples/inventory/group_vars/all/user_account.yml
+++ b/examples/inventory/group_vars/all/user_account.yml
@@ -1,0 +1,47 @@
+---
+# examples/inventory/group_vars/all/user_account.yml
+# Shared human admin account variables for the example lab.
+# Defines the example account state enforced after the base phase through the aggregate `user` role.
+
+# Human admin account managed by the example user layer.
+# Keep this separate from the automation account created during bootstrap.
+user_account_name: human-user
+
+# Fixed UID/GID help keep ownership predictable if the example admin account
+# already exists and you want the role to adopt it into a stable baseline.
+user_account_uid: 1050
+user_account_gid: 1050
+
+# Primary group for the example human admin account.
+user_account_primary_group: human-user
+
+# Keep the example account present after the base phase.
+user_account_state: present
+
+# Baseline login shell enforced for the example admin account.
+# Keep this minimal here so a future `user_shell` role can own broader shell policy.
+user_account_shell: /bin/bash
+
+# Home directory enforced for the example admin account.
+user_account_home: "/home/{{ user_account_name }}"
+
+# Keep home moves disabled in the example lab unless you intentionally need to
+# relocate an existing account's home directory to a new managed path.
+user_account_move_home: false
+
+# Ensure the example admin primary group exists before the account is managed.
+user_account_manage_primary_group: true
+
+# Create the example admin home directory if it does not already exist.
+user_account_create_home: true
+
+# Keep the home directory if you ever switch the example account to absent.
+user_account_remove: false
+
+# Descriptive GECOS/comment field for the example human admin account.
+user_account_comment: Example human admin account managed by Ansible
+
+# Leave password-lock state unmanaged in the example lab so the role avoids
+# unnecessary unlock operations and repeated change noise on hosts where the
+# current password state is already acceptable.
+user_account_password_lock: null

--- a/examples/playbooks/site.yml
+++ b/examples/playbooks/site.yml
@@ -1,7 +1,10 @@
 ---
 # examples/playbooks/site.yml
-# Base-phase entry playbook for the example lab.
-# Imports `base.yml` so the base phase can be run through a stable entrypoint.
+# Post-bootstrap entry playbook for the example lab.
+# Imports `base.yml` and `user.yml` so the recurring host baseline and human-admin user layer can be run through a stable entrypoint.
 
 - name: Include base playbook
   ansible.builtin.import_playbook: base.yml
+
+- name: Include user playbook
+  ansible.builtin.import_playbook: user.yml

--- a/examples/playbooks/user.yml
+++ b/examples/playbooks/user.yml
@@ -1,0 +1,10 @@
+---
+# examples/playbooks/user.yml
+# User phase playbook for the example lab.
+# Connects as the automation account after the base phase and applies the aggregate `user` role.
+
+- name: Apply user role after base
+  hosts: all
+  become: true
+  roles:
+    - role: user

--- a/roles/bootstrap/README.md
+++ b/roles/bootstrap/README.md
@@ -15,8 +15,8 @@ Explains how the role creates and validates the automation account used after th
 | Variable                     | Default     | Required | Description                                 |
 |-----------------------------|-------------|----------|---------------------------------------------|
 | `bootstrap_user`            | `admin`     | yes      | Automation username to create/manage        |
-| `bootstrap_puid`            | `1000`      | yes      | UID for automation user (>= 1000)           |
-| `bootstrap_pgid`            | `1000`      | yes      | GID for automation user (>= 1000)           |
+| `bootstrap_puid`            | `1100`      | yes      | UID for automation user (>= 1000)           |
+| `bootstrap_pgid`            | `1100`      | yes      | GID for automation user (>= 1000)           |
 | `bootstrap_sudo_group`      | `sudo`      | yes      | Sudo-capable group that must include user   |
 | `bootstrap_passwordless_sudo` | `false`   | no       | If true, write `/etc/sudoers.d/90-<user>` with `NOPASSWD` |
 | `bootstrap_user_shell`      | `/bin/bash` | yes      | Shell for automation user (absolute path)   |

--- a/roles/bootstrap/defaults/main.yml
+++ b/roles/bootstrap/defaults/main.yml
@@ -7,8 +7,8 @@
 bootstrap_user: admin
 
 # Fixed UID/GID keep ownership predictable across hosts and restores.
-bootstrap_puid: 1000
-bootstrap_pgid: 1000
+bootstrap_puid: 1100
+bootstrap_pgid: 1100
 
 # Sudo-capable group to attach the automation account to.
 bootstrap_sudo_group: sudo

--- a/roles/user/README.md
+++ b/roles/user/README.md
@@ -1,0 +1,42 @@
+# roles/user/README.md
+
+Reference for the `user` role.
+Explains how the aggregate user role delegates recurring human admin account configuration after the base phase through explicit role includes.
+
+## Features
+- Runs the recurring human-admin user configuration on every `user` execution
+- Keeps the aggregate user-role execution order in `roles/user/tasks/main.yml`
+- Includes `user_account` through an explicit `ansible.builtin.include_role` entry
+- Keeps aggregate include-task tags aligned with the child role's phase tags and role-specific tags so targeted runs such as `--tags validate` or `--tags user_account_validate` stay predictable
+
+## Usage
+Use `user` on Debian-family hosts after the `base` role has already applied the base host baseline:
+
+```yaml
+- hosts: all
+  become: true
+  roles:
+    - role: base
+    - role: user
+```
+
+Role-specific inputs for `user` currently come from `user_account_*`.
+
+Current include order in `user` is:
+
+1. `user_account`
+
+`roles/user/tasks/main.yml` is the single source of truth for this sequence.
+This keeps the human-admin account layer explicit and leaves future `user_*` roles room to be added in a stable order.
+
+Aggregate include-task tags in `roles/user/tasks/main.yml` intentionally mirror the child role phase tags and role-specific tags.
+This keeps broad phase runs such as `--tags validate` working across the user stack while also allowing narrow runs such as `--tags user_account` or `--tags user_account_validate` without unrelated role execution.
+
+## Dependencies
+None
+
+## License
+MIT
+
+## Author
+Tatbyte

--- a/roles/user/defaults/main.yml
+++ b/roles/user/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+# roles/user/defaults/main.yml
+# Default variables for the `user` role.
+# Intentionally empty because this aggregate role currently delegates work through explicit child-role includes only.

--- a/roles/user/meta/main.yml
+++ b/roles/user/meta/main.yml
@@ -1,0 +1,6 @@
+---
+# roles/user/meta/main.yml
+# Role metadata for `user`.
+# Leaves dependencies empty because aggregate user-role ordering is defined in `roles/user/tasks/main.yml`.
+
+dependencies: []

--- a/roles/user/tasks/main.yml
+++ b/roles/user/tasks/main.yml
@@ -1,0 +1,11 @@
+---
+# roles/user/tasks/main.yml
+# Task entrypoint for the `user` role.
+# Defines the aggregate user-role execution order through explicit role includes.
+
+- name: "User | Include user_account role"
+  ansible.builtin.include_role:
+    name: user_account
+    apply:
+      tags: [user, user_account]
+  tags: [user, user_account, assert, config, validate, user_account_assert, user_account_config, user_account_validate]

--- a/roles/user_account/README.md
+++ b/roles/user_account/README.md
@@ -1,0 +1,67 @@
+# roles/user_account/README.md
+
+Reference for the `user_account` role.
+Explains how the role creates and validates one human admin account after the base phase on Debian-family hosts in this repository.
+
+## Features
+- Ensures the primary group exists for the human admin account when enabled
+- Ensures the human admin user exists with the expected UID, GID, baseline login shell, home directory, and basic account settings
+- Supports enforcing an existing human admin account instead of assuming fresh creation, while requiring explicit opt-in before moving an existing home directory
+- Can optionally manage password-lock state for SSH-oriented admin access
+- Validates resulting passwd, group, and home-directory state
+
+## Variables
+
+| Variable | Default | Required | Description |
+|----------|---------|----------|-------------|
+| `user_account_name` | `admin` | yes | Human admin username to create/manage |
+| `user_account_uid` | `1050` | yes when `user_account_state: present` | UID for the human admin account (>= 1000) |
+| `user_account_gid` | `1050` | yes when `user_account_state: present` and `user_account_manage_primary_group: true` | GID for the primary group (>= 1000) |
+| `user_account_primary_group` | `{{ user_account_name }}` | yes | Primary group name for the human admin account |
+| `user_account_state` | `present` | yes | Desired account state: `present` or `absent` |
+| `user_account_shell` | `/bin/bash` | yes when `user_account_state: present` | Baseline login shell for the human admin account until a future `user_shell` role owns shell policy |
+| `user_account_home` | `/home/{{ user_account_name }}` | yes when `user_account_state: present` | Home directory for the human admin account |
+| `user_account_move_home` | `false` | no | If true, allow the role to move an existing home directory when `user_account_home` differs from the current passwd entry |
+| `user_account_manage_primary_group` | `true` | no | If true, ensure the primary group exists before the user is managed |
+| `user_account_create_home` | `true` | no | If true, create the home directory for present accounts |
+| `user_account_remove` | `false` | no | If true and the account is absent, remove the home directory and mail spool |
+| `user_account_comment` | `Human admin account managed by Ansible` | no | Optional GECOS/comment field |
+| `user_account_password_lock` | `null` | no | Optional password-lock state: `true` locks, `false` unlocks, `null` leaves password-lock state unmanaged |
+
+## Usage
+
+Direct usage:
+
+```yaml
+- hosts: all
+  become: true
+  roles:
+    - role: user_account
+      vars:
+        user_account_name: alice
+        user_account_uid: 1051
+        user_account_gid: 1051
+```
+
+Example role ordering with the planned `user_*` layer:
+
+```yaml
+- hosts: all
+  become: true
+  roles:
+    - role: base
+    - role: user_account
+```
+
+`user_account` intentionally keeps shell handling narrow.
+Use `user_account_shell` for the account's baseline login shell, and let a future `user_shell` role manage dotfiles, aliases, environment variables, PATH changes, and any richer shell-policy decisions.
+When adopting an existing user, the role fails early if the current home path differs from `user_account_home` unless `user_account_move_home: true` is set explicitly.
+
+## Dependencies
+None
+
+## Author
+tatbyte
+
+## License
+MIT

--- a/roles/user_account/defaults/main.yml
+++ b/roles/user_account/defaults/main.yml
@@ -1,0 +1,43 @@
+---
+# roles/user_account/defaults/main.yml
+# Default variables for the `user_account` role.
+# Defines the human admin account state enforced by this role after the base phase.
+
+# Human admin username to create and manage.
+user_account_name: admin
+
+# Fixed UID/GID keep ownership predictable across hosts and restores.
+user_account_uid: 1050
+user_account_gid: 1050
+
+# Primary group for the managed human admin account.
+user_account_primary_group: "{{ user_account_name }}"
+
+# Desired account state for the human admin account.
+user_account_state: present
+
+# Baseline login shell for the human admin account.
+# Keep this minimal here so a future `user_shell` role can own richer shell policy.
+user_account_shell: /bin/bash
+
+# Home directory for the human admin account.
+user_account_home: "/home/{{ user_account_name }}"
+
+# If true, move an existing home directory when the requested home path changes.
+user_account_move_home: false
+
+# If true, ensure the primary group exists before managing the user account.
+user_account_manage_primary_group: true
+
+# If true, create the home directory while ensuring a present account.
+user_account_create_home: true
+
+# If true, remove the home directory and mail spool when ensuring an absent account.
+user_account_remove: false
+
+# Optional GECOS/comment field for the human admin account.
+user_account_comment: Human admin account managed by Ansible
+
+# Optional password-lock state for the account.
+# Set to true to lock the password, false to unlock it, or null to leave password-lock state unmanaged.
+user_account_password_lock: null

--- a/roles/user_account/tasks/assert.yml
+++ b/roles/user_account/tasks/assert.yml
@@ -1,0 +1,84 @@
+---
+# roles/user_account/tasks/assert.yml
+# Assert phase tasks for the `user_account` role.
+# Validates the human admin account variables before account management starts.
+
+- name: "Assert | Validate required user_account variables"
+  ansible.builtin.assert:
+    that:
+      - user_account_name is defined
+      - user_account_name | length > 0
+      - user_account_primary_group is defined
+      - user_account_primary_group | length > 0
+      - user_account_state in ['present', 'absent']
+      - user_account_move_home is boolean
+      - user_account_manage_primary_group is boolean
+      - user_account_create_home is boolean
+      - user_account_remove is boolean
+      - user_account_password_lock is none or user_account_password_lock is boolean
+      - user_account_state != 'present' or (
+          user_account_uid is number
+          and user_account_uid | int >= 1000
+        )
+      - user_account_state != 'present' or not user_account_manage_primary_group or (
+          user_account_gid is number
+          and user_account_gid | int >= 1000
+        )
+      - user_account_state != 'present' or (
+          user_account_shell is defined
+          and user_account_shell | length > 0
+          and user_account_shell.startswith('/')
+        )
+      - user_account_state != 'present' or (
+          user_account_home is defined
+          and user_account_home | length > 0
+          and user_account_home.startswith('/')
+        )
+    fail_msg: >-
+      user_account_name/state/group and present-state uid/gid/home/shell values must be defined and valid
+    quiet: true
+
+- name: "Assert | Collect Existing Human Admin Account Entry"
+  ansible.builtin.getent:
+    database: passwd
+    key: "{{ user_account_name }}"
+  register: user_account_assert_passwd_lookup
+  changed_when: false
+  failed_when: false
+  when: user_account_state == 'present'
+
+- name: "Assert | Validate Home-Move Intent For Existing Human Admin Account"
+  ansible.builtin.assert:
+    that:
+      - >-
+        user_account_name not in (user_account_assert_passwd_lookup.ansible_facts.getent_passwd | default({}))
+        or
+        (user_account_assert_passwd_lookup.ansible_facts.getent_passwd | default({}))[user_account_name][4] == user_account_home
+        or
+        user_account_move_home | bool
+    fail_msg: >-
+      Existing user_account home does not match user_account_home. Set user_account_move_home to true to move the home directory explicitly.
+    quiet: true
+  when: user_account_state == 'present'
+
+- name: "Assert | Collect Primary Group Entry When Group Management Is Disabled"
+  ansible.builtin.getent:
+    database: group
+    key: "{{ user_account_primary_group }}"
+  register: user_account_assert_group_lookup
+  changed_when: false
+  failed_when: false
+  when:
+    - user_account_state == 'present'
+    - not user_account_manage_primary_group | bool
+
+- name: "Assert | Validate Existing Primary Group When Group Management Is Disabled"
+  ansible.builtin.assert:
+    that:
+      - user_account_primary_group in (user_account_assert_group_lookup.ansible_facts.getent_group | default({}))
+    fail_msg: >-
+      user_account_primary_group must already exist when user_account_manage_primary_group is false
+    quiet: true
+  when:
+    - user_account_state == 'present'
+    - not user_account_manage_primary_group | bool

--- a/roles/user_account/tasks/config.yml
+++ b/roles/user_account/tasks/config.yml
@@ -1,0 +1,32 @@
+---
+# roles/user_account/tasks/config.yml
+# Config phase tasks for the `user_account` role.
+# Creates and configures the human admin account and its primary group.
+
+- name: "Config | Ensure Human Admin Primary Group Exists"
+  ansible.builtin.group:
+    name: "{{ user_account_primary_group }}"
+    gid: "{{ user_account_gid }}"
+    state: present
+  when:
+    - user_account_state == 'present'
+    - user_account_manage_primary_group | bool
+
+- name: "Config | Ensure Human Admin Account State"
+  ansible.builtin.user:
+    name: "{{ user_account_name }}"
+    state: "{{ user_account_state }}"
+    uid: "{{ user_account_uid if user_account_state == 'present' else omit }}"
+    group: "{{ user_account_primary_group if user_account_state == 'present' else omit }}"
+    shell: "{{ user_account_shell if user_account_state == 'present' else omit }}"
+    home: "{{ user_account_home if user_account_state == 'present' else omit }}"
+    move_home: "{{ user_account_move_home if user_account_state == 'present' else omit }}"
+    create_home: "{{ user_account_create_home if user_account_state == 'present' else omit }}"
+    comment: "{{ user_account_comment if user_account_state == 'present' else omit }}"
+    password_lock: >-
+      {{
+        user_account_password_lock
+        if user_account_state == 'present' and user_account_password_lock is not none
+        else omit
+      }}
+    remove: "{{ user_account_remove if user_account_state == 'absent' else omit }}"

--- a/roles/user_account/tasks/main.yml
+++ b/roles/user_account/tasks/main.yml
@@ -1,0 +1,16 @@
+---
+# roles/user_account/tasks/main.yml
+# Task entrypoint for the `user_account` role.
+# Imports the assert, config, and validate phase files in order.
+
+- name: Assert
+  ansible.builtin.import_tasks: assert.yml
+  tags: [user_account, assert, user_account_assert]
+
+- name: Config
+  ansible.builtin.import_tasks: config.yml
+  tags: [user_account, config, user_account_config]
+
+- name: Validate
+  ansible.builtin.import_tasks: validate.yml
+  tags: [user_account, validate, user_account_validate]

--- a/roles/user_account/tasks/validate.yml
+++ b/roles/user_account/tasks/validate.yml
@@ -1,0 +1,87 @@
+---
+# roles/user_account/tasks/validate.yml
+# Validate phase tasks for the `user_account` role.
+# Verifies the resulting passwd, group, and home-directory state after configuration.
+
+- name: "Validate | Collect Human Admin Passwd Entry"
+  ansible.builtin.getent:
+    database: passwd
+    key: "{{ user_account_name }}"
+  register: user_account_passwd_lookup
+  changed_when: false
+  failed_when: false
+
+- name: "Validate | Collect Human Admin Primary Group Entry"
+  ansible.builtin.getent:
+    database: group
+    key: "{{ user_account_primary_group }}"
+  register: user_account_group_lookup
+  changed_when: false
+  failed_when: false
+  when:
+    - user_account_state == 'present'
+    - user_account_manage_primary_group | bool
+
+- name: "Validate | Stat Human Admin Home Directory"
+  ansible.builtin.stat:
+    path: "{{ user_account_home }}"
+  register: user_account_home_stat
+  changed_when: false
+  when:
+    - user_account_state == 'present'
+    - user_account_create_home | bool
+
+- name: "Validate | Derive Human Admin Validation Facts"
+  ansible.builtin.set_fact:
+    user_account_passwd_entries: "{{ user_account_passwd_lookup.ansible_facts.getent_passwd | default({}) }}"
+    user_account_group_entries: "{{ user_account_group_lookup.ansible_facts.getent_group | default({}) }}"
+    user_account_present_entry: >-
+      {{
+        (user_account_passwd_lookup.ansible_facts.getent_passwd | default({})).get(user_account_name)
+        if user_account_state == 'present'
+        else none
+      }}
+    user_account_present_group_entry: >-
+      {{
+        (user_account_group_lookup.ansible_facts.getent_group | default({})).get(user_account_primary_group)
+        if user_account_state == 'present' and user_account_manage_primary_group | bool
+        else none
+      }}
+  changed_when: false
+
+- name: "Validate | Verify Human Admin Account Matches Configured State"
+  ansible.builtin.assert:
+    that:
+      - user_account_state != 'present' or (
+          user_account_name in user_account_passwd_entries
+        )
+      - user_account_state != 'absent' or (
+          user_account_name not in user_account_passwd_entries
+        )
+      - user_account_state != 'present' or (
+          user_account_present_entry is not none
+          and user_account_present_entry[1] | int == user_account_uid
+        )
+      - user_account_state != 'present' or (
+          user_account_present_entry is not none
+          and user_account_present_entry[4] == user_account_home
+        )
+      - user_account_state != 'present' or (
+          user_account_present_entry is not none
+          and user_account_present_entry[5] == user_account_shell
+        )
+      - user_account_state != 'present' or not user_account_manage_primary_group or (
+          user_account_present_group_entry is not none
+          and user_account_present_group_entry[1] | int == user_account_gid
+          and user_account_present_entry is not none
+          and user_account_present_entry[2] | int == user_account_gid
+        )
+      - user_account_state != 'present' or not user_account_create_home or (
+          user_account_home_stat.stat.exists
+          and user_account_home_stat.stat.isdir
+          and user_account_home_stat.stat.pw_name == user_account_name
+          and user_account_home_stat.stat.gr_name == user_account_primary_group
+        )
+    fail_msg: >-
+      Validate | Human admin account is not in the expected final state (passwd/group/home directory)
+    quiet: true


### PR DESCRIPTION
- Introduced aggregate `user` role to manage human admin accounts post-bootstrap.
- Created `user_account` role for creating, adopting, and validating a single human admin account.
- Updated example playbooks and inventory files to include new user management features.
- Enhanced documentation to reflect changes in user role management and usage.
- Adjusted UID/GID defaults for better separation between automation and human accounts.
- Implemented input validation and error handling for user account management tasks.  `user_accounts` role Fixes #60