### PR TITLE
Enhance user and password management roles with Vault integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ Documents notable changes across repository structure, roles, examples, and docu
 ## [v1.1.0]
 ### Added
 - Added the aggregate `user` role for the post-base human-admin user layer, including explicit aggregate ordering, metadata, documentation, and example playbook wiring.
-- Added the standalone `user_account` role for creating, adopting, and validating one human admin account with explicit primary-group, home-directory, baseline shell, and optional password-lock management.
-- Added example inventory files for the new user layer, including `user.yml` and `user_account.yml`, plus a dedicated `examples/playbooks/user.yml` entrypoint.
+- Added the standalone `user_account` role for creating, adopting, and validating one human admin account with explicit primary-group, home-directory, and baseline shell management.
+- Added the standalone `user_password` role for managing Vault-friendly hashed local password state and optional password locking for one existing human admin account.
+- Added example inventory files for the new user layer, including `user.yml`, `user_account.yml`, and `user_password.yml`, plus a dedicated `examples/playbooks/user.yml` entrypoint.
 
 ### Changed
 - Updated the example `site.yml` flow so the full post-bootstrap stack now runs `base` and then `user`.
@@ -15,10 +16,12 @@ Documents notable changes across repository structure, roles, examples, and docu
 - Updated the example SSH allow-list so the example human admin account created by the user layer is permitted by the managed `base_sshd` policy.
 - Hardened `user_account` input validation and final-state validation so missing users or groups fail cleanly instead of crashing through unsafe fact lookups, and so unmanaged primary groups are asserted explicitly before config runs.
 - Added explicit `user_account_move_home` handling so adopting an existing user now fails early on unexpected home-directory changes unless the move is intentionally allowed.
-- Made `user_account` password-lock management opt-in by treating `null` as "leave current password-lock state unchanged", reducing repeated change noise on reruns.
+- Moved password-state ownership out of `user_account` and into `user_password` so hashed local passwords and password locking are managed in one dedicated secret-aware role.
 
 ### Documentation
-- Updated repository, workflow, role, and example documentation to describe the new `user` aggregate role, the `user_account` role, the expanded example lab flow, and the bootstrap-versus-user UID/GID defaults.
+- Updated repository, workflow, role, and example documentation to describe the new `user` aggregate role, the `user_account` and `user_password` roles, the expanded example lab flow, and the bootstrap-versus-user UID/GID defaults.
+- Documented that the local example lab enables `user_password` with a demo SHA-512 hash for the plaintext test password `password` so local account-login testing is straightforward.
+- Documented and aligned the example aggregate-toggle layout so `base_include_*` values now live in `examples/inventory/group_vars/all/base.yml`, matching the newer `user.yml` aggregate-toggle pattern.
 
 ## [v1.0.0]
 ### Changed

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ homelab-roles/
 │   ├── monitoring/
 │   ├── monitoring_authorized_key/
 │   ├── user/
-│   └── user_account/
+│   ├── user_account/
+│   └── user_password/
 ├── examples/
 │   ├── ansible.cfg
 │   ├── inventory/
@@ -65,8 +66,9 @@ homelab-roles/
 - `base_timezone`: Enforces the system timezone on Debian-family hosts during the base phase.
 - `monitoring`: Aggregates monitoring-related configuration through dependency roles such as `monitoring_authorized_key`.
 - `monitoring_authorized_key`: Installs an SSH authorized key for monitoring-style inter-host access.
-- `user`: Aggregates recurring human admin user configuration through explicit `include_role` ordering in `roles/user/tasks/main.yml` for `user_account`.
+- `user`: Aggregates recurring human admin user configuration through explicit `include_role` ordering in `roles/user/tasks/main.yml` for `user_account` plus optional `user_password`.
 - `user_account`: Creates and validates one human admin account with explicit primary-group, shell, home-directory, and basic account-state enforcement after the base phase.
+- `user_password`: Manages Vault-friendly hashed local password state and optional password locking for one existing human admin account after the base phase.
 
 ## Consume From Another Repo
 Recommended pattern: add this repository to your infra repository (submodule or vendored checkout), then point `roles_path` to `homelab-roles/roles`.
@@ -144,6 +146,7 @@ ansible-playbook playbooks/site.yml
 
 See [examples/README.md](examples/README.md) and [docs/01-examples.md](docs/01-examples.md) for lab details.
 The current example lab intentionally keeps `base_upgrade` and strict `base_needrestart` follow-up enabled, so a base run may fail when pending reboot or service-restart work is detected after upgrades.
+The current example lab also enables `user_password` with a documented demo hash for the plaintext test password `password`, so replace that example value before copying the pattern to a real host.
 
 ## Linting
 Pre-commit and linting are configured in this repository.
@@ -171,6 +174,7 @@ Core repository docs:
 - [docs/02-role-workflow.md](docs/02-role-workflow.md): Shared role phase structure and aggregate base-role plus user-role ordering
 - [docs/03-file-consistency.md](docs/03-file-consistency.md): File header and wording consistency rules
 - [docs/04-firewall-role-integration.md](docs/04-firewall-role-integration.md): How future roles should register firewall rules for `base_firewall`
+- [docs/05-vault.md](docs/05-vault.md): Short Vault guidance for secret-bearing inventory values such as `user_password`
 
 ## License
 MIT

--- a/docs/01-examples.md
+++ b/docs/01-examples.md
@@ -19,7 +19,7 @@ The example content assumes Debian-family targets such as Debian and Ubuntu.
 
 - `examples/ansible.cfg`: Example Ansible configuration for local test runs that also hides skipped-host output for quieter example runs.
 - `examples/inventory/hosts.ini`: Example hosts and groups.
-- `examples/inventory/group_vars/all/`: Example variables for all hosts, split into role-scoped files such as `bootstrap.yml`, `base_packages.yml`, `base_hostname.yml`, `base_hosts.yml`, `base_dns.yml`, `base_locale.yml`, `base_ntp.yml`, `base_sudo.yml`, `base_sshd.yml`, `base_firewall.yml`, `base_fail2ban.yml`, `base_logging.yml`, `base_updates.yml`, `base_apparmor.yml`, `base_auditd.yml`, `base_upgrade.yml`, `base_needrestart.yml`, `base_timezone.yml`, `user.yml`, `user_account.yml`, and `monitoring_authorized_key.yml`.
+- `examples/inventory/group_vars/all/`: Example variables for all hosts, split into aggregate-scoped files such as `base.yml` and `user.yml`, plus role-scoped files such as `bootstrap.yml`, `base_packages.yml`, `base_hostname.yml`, `base_hosts.yml`, `base_dns.yml`, `base_locale.yml`, `base_ntp.yml`, `base_sudo.yml`, `base_sshd.yml`, `base_firewall.yml`, `base_fail2ban.yml`, `base_logging.yml`, `base_updates.yml`, `base_apparmor.yml`, `base_auditd.yml`, `base_upgrade.yml`, `base_needrestart.yml`, `base_timezone.yml`, `user_account.yml`, `user_password.yml`, and `monitoring_authorized_key.yml`.
 - `examples/playbooks/bootstrap.yml`: Bootstrap phase playbook that uses initial host credentials and applies the standalone `bootstrap` role.
 - `examples/playbooks/base.yml`: Base phase playbook for post-bootstrap role execution that applies the aggregate base role one host at a time for safer reboot-capable runs.
 - `examples/playbooks/user.yml`: User phase playbook for post-base role execution that applies the aggregate `user` role for human admin account enforcement.
@@ -30,7 +30,7 @@ The example content assumes Debian-family targets such as Debian and Ubuntu.
 
 1. Copy or adapt the files in `examples/` to your own lab.
 2. Replace inventory hosts and credentials with your environment values.
-3. Update the role-scoped files in `group_vars/all/` for your role inputs.
+3. Update the aggregate-scoped and role-scoped files in `group_vars/all/` for your role inputs.
 4. Run bootstrap first:
 
 ```bash
@@ -65,21 +65,23 @@ ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/tests/te
 
 - The lab content is intentionally simple and meant as an example baseline.
 - The example inventory and variables assume Debian-family hosts and the repository's APT-based role behavior.
-- `group_vars/all/` is split by role prefix so example variables such as `base_packages.yml`, `base_hostname.yml`, `base_hosts.yml`, `base_dns.yml`, `base_locale.yml`, `base_ntp.yml`, `base_sudo.yml`, `base_sshd.yml`, `base_firewall.yml`, `base_fail2ban.yml`, `base_logging.yml`, `base_updates.yml`, `base_apparmor.yml`, `base_auditd.yml`, `base_upgrade.yml`, `base_needrestart.yml`, `base_timezone.yml`, `user.yml`, `user_account.yml`, and `monitoring_authorized_key.yml` stay readable as the stack grows.
-- `base_hosts.yml` sets `base_include_hosts: true`, which opts the example base run into the optional `base_hosts` role so example hosts can resolve inventory peer names through `/etc/hosts`.
-- `base_dns.yml` sets `base_include_dns: true`, which opts the example base run into the optional `base_dns` role with an explicit `systemd-resolved` baseline.
-- `base_firewall.yml` sets `base_include_firewall: true`, which opts the example base run into the optional `base_firewall` role and documents the shared baseline, role-declared accumulator, and `managed:` comment convention used for stale rule cleanup.
-- `base_fail2ban.yml` sets `base_include_fail2ban: true`, which opts the example base run into the optional `base_fail2ban` role with a managed SSH jail baseline.
-- `base_logging.yml` sets `base_include_logging: true`, which opts the example base run into the optional `base_logging` role with persistent journald storage enabled.
-- `base_updates.yml` sets `base_include_updates: true`, which opts the example base run into the optional `base_updates` role with unattended-upgrades enabled.
-- `base_apparmor.yml` sets `base_include_apparmor: true`, which opts the example base run into the optional `base_apparmor` role with the AppArmor service enabled.
-- `base_auditd.yml` sets `base_include_auditd: true`, which opts the example base run into the optional `base_auditd` role with the audit daemon enabled and a minimal explicit baseline configuration.
-- `base_upgrade.yml` sets `base_include_upgrade: true`, which keeps the example base run exercising immediate package maintenance so post-upgrade follow-up such as `base_needrestart` reflects the current host state.
-- `base_needrestart.yml` sets `base_include_needrestart: true`, which opts the example base run into the optional `base_needrestart` role and enables strict failure flags so pending restart or reboot follow-up is surfaced immediately without restarting services automatically.
+- `group_vars/all/` is split between aggregate-scoped files such as `base.yml` and `user.yml`, plus child-role files such as `base_firewall.yml` and `user_password.yml`, so aggregate toggles stay separate from child-role inputs as the stack grows.
+- `base.yml` keeps the aggregate `base_include_*` toggles in one place so enabled optional base roles are easy to scan.
+- `base_hosts.yml` defines the inventory-driven `/etc/hosts` baseline used when `base.yml` enables `base_hosts`.
+- `base_dns.yml` defines the explicit `systemd-resolved` baseline used when `base.yml` enables `base_dns`.
+- `base_firewall.yml` defines the shared firewall baseline, role-declared accumulator, and `managed:` comment convention used when `base.yml` enables `base_firewall`.
+- `base_fail2ban.yml` defines the managed SSH jail baseline used when `base.yml` enables `base_fail2ban`.
+- `base_logging.yml` defines the persistent journald baseline used when `base.yml` enables `base_logging`.
+- `base_updates.yml` defines the unattended-upgrades baseline used when `base.yml` enables `base_updates`.
+- `base_apparmor.yml` defines the AppArmor service baseline used when `base.yml` enables `base_apparmor`.
+- `base_auditd.yml` defines the audit-daemon baseline used when `base.yml` enables `base_auditd`.
+- `base_upgrade.yml` defines the immediate package-maintenance behavior used when `base.yml` enables `base_upgrade`.
+- `base_needrestart.yml` defines the restart-check behavior used when `base.yml` enables `base_needrestart`.
 - This means the example base run may fail intentionally after package maintenance when restart follow-up is still pending; set the `base_needrestart_fail_if_*` values back to `false` for report-only example runs.
 - When the example run's `base_upgrade` role makes no package-maintenance changes and leaves no reboot-required follow-up, `base_needrestart` now skips the batch check automatically to reduce no-change noise.
 - `playbooks/base.yml` uses `serial: 1`, which is safer when optional roles such as `base_upgrade` may reboot a host during the run.
 - `user_account.yml` defines the example human admin account enforced after the base phase through the aggregate `user` role.
+- `user.yml` enables the optional password role in the example lab, while `user_password.yml` sets a demo SHA-512 password hash for the example human admin account using the plaintext test password `password` and documents that a real host should use a Vault-managed hash instead.
 - `ansible.cfg` sets `display_skipped_hosts = False`, so routine conditional skips from optional roles or gated tasks do not dominate the example output.
 - `hosts.ini` keeps default `ansible_user=ansible` in `[all:vars]`, while `[bootstrap:vars]` holds initial login values used only during bootstrap.
 - `playbooks/bootstrap.yml` prompts once for the bootstrap password and reuses it for both SSH login and sudo.

--- a/docs/02-role-workflow.md
+++ b/docs/02-role-workflow.md
@@ -107,8 +107,9 @@ Its include-task tags should mirror the generic phase tags plus the child role's
 Current order:
 
 1. `user_account`
+2. `user_password` when `user_include_password: true`
 
-Use this sequence to keep human-admin account creation and adoption explicit after the `base_*` layer and before any future user-environment roles such as SSH, shell, or profile management.
+Use this sequence to keep human-admin account creation and adoption explicit first, then optional secret-backed local password management, before any future user-environment roles such as SSH, shell, or profile management.
 
 ## Tag Usage
 
@@ -129,9 +130,12 @@ Run the full workflow by running the playbook with no tag filter.
 
 ## Optional Role Toggle Convention
 
-Use a consistent toggle pattern when you add new optional roles to the aggregate `base` stack.
+Use a consistent toggle pattern when you add new optional roles to an aggregate stack.
 
+- Keep aggregate include toggles in aggregate-scoped variables such as `base.yml` or `user.yml`.
+- Keep child-role inputs in the matching child-role file such as `base_firewall.yml` or `user_password.yml`.
 - Use `base_include_<role>` when the whole role is optional in the aggregate `base` role.
+- Use `user_include_<role>` when the whole role is optional in the aggregate `user` role.
 - Use `<role>_enabled` only when the role manages a service and an installed-but-disabled state is a valid supported outcome.
 - Do not add `enabled` flags to roles that only enforce static configuration or one-time state.
 

--- a/docs/05-vault.md
+++ b/docs/05-vault.md
@@ -1,0 +1,67 @@
+# docs/05-vault.md
+
+Short Vault guidance for this repository.
+Explains where to keep a local Vault password file, how to point Ansible at it, and which current role inputs are the right fit for Vault.
+
+## Recommended Local Path
+
+Keep your personal Ansible config and Vault password file under:
+
+- `~/.config/ansible/ansible.cfg`
+- `~/.config/ansible/vault/password.txt`
+
+Suggested permissions:
+
+- `~/.config/ansible/`: `0700`
+- `~/.config/ansible/vault/password.txt`: `0600`
+
+Example:
+
+```sh
+mkdir -p ~/.config/ansible/vault
+chmod 700 ~/.config/ansible ~/.config/ansible/vault
+printf '%s\n' 'your-vault-password' > ~/.config/ansible/vault/password.txt
+chmod 600 ~/.config/ansible/vault/password.txt
+```
+
+## Ansible Config
+
+Point Ansible at that file from `~/.config/ansible/ansible.cfg`:
+
+```ini
+[defaults]
+vault_password_file = ~/.config/ansible/vault/password.txt
+```
+
+## How To Use It
+
+Create or edit an encrypted vars file:
+
+```sh
+ansible-vault create inventory/group_vars/all/vault.yml
+ansible-vault edit inventory/group_vars/all/vault.yml
+```
+
+Then store secret values there and reference them from normal vars files:
+
+```yaml
+# inventory/group_vars/all/vault.yml
+vault_user_password_hash: "$6$..."
+```
+
+```yaml
+# inventory/group_vars/all/user_password.yml
+user_password_password_hash: "{{ vault_user_password_hash }}"
+```
+
+## Which Roles Use Vault Well
+
+- `user_password`: best current fit, because it manages `user_password_password_hash`, which is secret-bearing and should not live in plain inventory.
+
+Today, `user_account`, `base_*`, and `monitoring_authorized_key` do not need Vault for their normal role inputs.
+The example `bootstrap` flow also prompts for the initial password instead of storing it in inventory.
+
+## Why
+
+Use Vault when a variable is secret-bearing, reusable, and should stay out of normal tracked YAML.
+For this repository today, that mainly means local password hashes managed by `user_password`.

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,7 +10,7 @@ The inventory variables and role inputs assume the repository's Debian-family de
 ## Structure
 - `ansible.cfg`: Test-specific Ansible configuration that points at the example inventory and hides skipped-host output for quieter local runs.
 - `inventory/hosts.ini`: Test inventory.
-- `inventory/group_vars/all/`: Shared variables for test hosts, split into per-role files such as `bootstrap.yml`, `base_packages.yml`, `base_hostname.yml`, `base_hosts.yml`, `base_dns.yml`, `base_locale.yml`, `base_ntp.yml`, `base_sudo.yml`, `base_sshd.yml`, `base_firewall.yml`, `base_fail2ban.yml`, `base_logging.yml`, `base_updates.yml`, `base_apparmor.yml`, `base_auditd.yml`, `base_upgrade.yml`, `base_needrestart.yml`, `base_timezone.yml`, `user.yml`, `user_account.yml`, and `monitoring_authorized_key.yml`.
+- `inventory/group_vars/all/`: Shared variables for test hosts, split into aggregate-scoped files such as `base.yml` and `user.yml`, plus role-scoped files such as `bootstrap.yml`, `base_packages.yml`, `base_hostname.yml`, `base_hosts.yml`, `base_dns.yml`, `base_locale.yml`, `base_ntp.yml`, `base_sudo.yml`, `base_sshd.yml`, `base_firewall.yml`, `base_fail2ban.yml`, `base_logging.yml`, `base_updates.yml`, `base_apparmor.yml`, `base_auditd.yml`, `base_upgrade.yml`, `base_needrestart.yml`, `base_timezone.yml`, `user_account.yml`, `user_password.yml`, and `monitoring_authorized_key.yml`.
 - `playbooks/bootstrap.yml`: Bootstrap phase playbook that connects with the initial admin account and applies the standalone `bootstrap` role.
 - `playbooks/base.yml`: Base phase playbook that connects as the automation account, applies the `base` role, and uses `serial: 1` so reboot-capable base runs process one host at a time.
 - `playbooks/user.yml`: User phase playbook that connects as the automation account after the base phase and applies the aggregate `user` role.
@@ -56,20 +56,22 @@ ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/tests/te
 ```
 
 The SSH integration test playbook cleans up its temporary `/etc/ssh/sshd_config.d/` fixture files in an `always` block, so you do not need to remove them manually after the run.
-`inventory/group_vars/all/base_firewall.yml` sets `base_include_firewall: true`, which opts the example base run into the optional `base_firewall` role and documents the role-declared rule accumulator plus the `managed:` comment convention used for stale-rule cleanup.
-`inventory/group_vars/all/base_logging.yml` sets `base_include_logging: true`, which opts the example base run into the optional `base_logging` role with persistent journald storage enabled.
-`inventory/group_vars/all/base_updates.yml` sets `base_include_updates: true`, which opts the example base run into the optional `base_updates` role with unattended-upgrades enabled.
-`inventory/group_vars/all/base_apparmor.yml` sets `base_include_apparmor: true`, which opts the example base run into the optional `base_apparmor` role with the AppArmor service enabled.
-`inventory/group_vars/all/base_auditd.yml` sets `base_include_auditd: true`, which opts the example base run into the optional `base_auditd` role with the audit daemon enabled and a minimal explicit baseline configuration.
-`inventory/group_vars/all/base_fail2ban.yml` sets `base_include_fail2ban: true`, which opts the example base run into the optional `base_fail2ban` role with a managed SSH jail baseline.
-`inventory/group_vars/all/base_hosts.yml` sets `base_include_hosts: true`, which opts the example base run into the optional `base_hosts` role so example hosts can resolve inventory peer names through `/etc/hosts`.
-`inventory/group_vars/all/base_dns.yml` sets `base_include_dns: true`, which opts the example base run into the optional `base_dns` role with an explicit `systemd-resolved` baseline.
-`inventory/group_vars/all/base_upgrade.yml` sets `base_include_upgrade: true`, which keeps the example base run applying immediate package upgrades so post-upgrade follow-up such as `base_needrestart` reflects the current host state.
-`inventory/group_vars/all/base_needrestart.yml` sets `base_include_needrestart: true`, which opts the example base run into the optional `base_needrestart` role and enables strict failure flags so pending restart or reboot follow-up is surfaced immediately without restarting services automatically.
+`inventory/group_vars/all/base.yml` keeps the aggregate `base_include_*` toggles in one place so enabled optional base roles are easy to scan.
+`inventory/group_vars/all/base_firewall.yml` documents the shared firewall baseline, the role-declared rule accumulator, and the `managed:` comment convention used for stale-rule cleanup when `base.yml` enables `base_firewall`.
+`inventory/group_vars/all/base_logging.yml` defines the persistent journald baseline used when `base.yml` enables `base_logging`.
+`inventory/group_vars/all/base_updates.yml` defines the unattended-upgrades baseline used when `base.yml` enables `base_updates`.
+`inventory/group_vars/all/base_apparmor.yml` defines the AppArmor service baseline used when `base.yml` enables `base_apparmor`.
+`inventory/group_vars/all/base_auditd.yml` defines the audit-daemon baseline used when `base.yml` enables `base_auditd`.
+`inventory/group_vars/all/base_fail2ban.yml` defines the managed SSH jail baseline used when `base.yml` enables `base_fail2ban`.
+`inventory/group_vars/all/base_hosts.yml` defines the inventory-driven hosts-file baseline used when `base.yml` enables `base_hosts`.
+`inventory/group_vars/all/base_dns.yml` defines the explicit `systemd-resolved` baseline used when `base.yml` enables `base_dns`.
+`inventory/group_vars/all/base_upgrade.yml` defines the immediate package-maintenance behavior used when `base.yml` enables `base_upgrade`.
+`inventory/group_vars/all/base_needrestart.yml` defines the restart-check behavior used when `base.yml` enables `base_needrestart`.
 This means the example base run may fail intentionally after package maintenance when restart follow-up is still pending; set the `base_needrestart_fail_if_*` values back to `false` for report-only example runs.
 When the example run's `base_upgrade` role makes no package-maintenance changes and leaves no reboot-required follow-up, `base_needrestart` now skips the batch check automatically to reduce no-change noise.
 `playbooks/base.yml` uses `serial: 1`, which is safer when optional roles such as `base_upgrade` may reboot a host during the run.
 `inventory/group_vars/all/user_account.yml` defines the example human admin account enforced after the base phase through the aggregate `user` role.
+`inventory/group_vars/all/user.yml` enables the optional password role in the example lab, while `inventory/group_vars/all/user_password.yml` sets a demo SHA-512 password hash for the example human admin account using the plaintext test password `password` and documents that a real host should use a Vault-managed hash instead.
 `ansible.cfg` sets `display_skipped_hosts = False`, so optional-role and conditional-task skips are hidden during normal example runs.
 
 ## Bootstrap Credentials
@@ -81,5 +83,5 @@ The example inventory stores only the bootstrap login user:
 
 ## Extending
 - Add playbooks under `examples/playbooks/`.
-- Update `examples/inventory/hosts.ini` and the role-scoped files under `examples/inventory/group_vars/all/` as needed.
+- Update `examples/inventory/hosts.ini` and the aggregate-scoped plus role-scoped files under `examples/inventory/group_vars/all/` as needed.
 - Keep this README aligned with any new test scenarios.

--- a/examples/inventory/group_vars/all/base.yml
+++ b/examples/inventory/group_vars/all/base.yml
@@ -1,0 +1,35 @@
+---
+# examples/inventory/group_vars/all/base.yml
+# Shared aggregate base-role variables for the example lab.
+# Defines the optional aggregate-role toggles for the example base layer.
+
+# Keep inventory-driven hosts-file management enabled in the example lab so
+# hosts can resolve one another without depending on external DNS.
+base_include_hosts: true
+
+# Keep the explicit DNS resolver baseline enabled in the example lab.
+base_include_dns: true
+
+# Keep the additive firewall baseline enabled in the example lab.
+base_include_firewall: true
+
+# Keep the managed SSH jail baseline enabled in the example lab.
+base_include_fail2ban: true
+
+# Keep persistent local journald storage enabled in the example lab.
+base_include_logging: true
+
+# Keep unattended-upgrades enabled in the example lab.
+base_include_updates: true
+
+# Keep AppArmor enabled in the example lab.
+base_include_apparmor: true
+
+# Keep the audit daemon enabled in the example lab.
+base_include_auditd: true
+
+# Keep the explicit immediate-upgrade pass enabled in the example lab.
+base_include_upgrade: true
+
+# Keep restart-check reporting enabled after the example upgrade run.
+base_include_needrestart: true

--- a/examples/inventory/group_vars/all/base_apparmor.yml
+++ b/examples/inventory/group_vars/all/base_apparmor.yml
@@ -1,10 +1,7 @@
 ---
 # examples/inventory/group_vars/all/base_apparmor.yml
 # Shared AppArmor variables for the example lab.
-# Defines the aggregate-role opt-in plus the AppArmor package, service, and enabled-state baseline enforced during the base phase.
-
-# Opt in to the optional base_apparmor role from the aggregate base role.
-base_include_apparmor: true
+# Defines the AppArmor package, service, and enabled-state baseline enforced during the base phase.
 
 # Package list installed with APT to provide the AppArmor baseline and
 # validation tooling used by the role.

--- a/examples/inventory/group_vars/all/base_auditd.yml
+++ b/examples/inventory/group_vars/all/base_auditd.yml
@@ -1,10 +1,7 @@
 ---
 # examples/inventory/group_vars/all/base_auditd.yml
 # Shared audit variables for the example lab.
-# Defines the aggregate-role opt-in plus the audit package, service, and minimal configuration baseline enforced during the base phase.
-
-# Opt in to the optional base_auditd role from the aggregate base role.
-base_include_auditd: true
+# Defines the audit package, service, and minimal configuration baseline enforced during the base phase.
 
 # Package list installed with APT to provide the Linux audit daemon baseline.
 base_auditd_packages:

--- a/examples/inventory/group_vars/all/base_dns.yml
+++ b/examples/inventory/group_vars/all/base_dns.yml
@@ -1,10 +1,7 @@
 ---
 # examples/inventory/group_vars/all/base_dns.yml
 # Shared DNS variables for the example lab.
-# Defines the aggregate-role opt-in plus the resolver mode, DNS servers, and optional search domains enforced during the base phase.
-
-# Opt in to the optional base_dns role from the aggregate base role.
-base_include_dns: true
+# Defines the resolver mode, DNS servers, and optional search domains enforced during the base phase.
 
 # Resolver backend managed during the base phase.
 # Keep the default `systemd_resolved` mode in the example lab so DNS state

--- a/examples/inventory/group_vars/all/base_fail2ban.yml
+++ b/examples/inventory/group_vars/all/base_fail2ban.yml
@@ -1,10 +1,7 @@
 ---
 # examples/inventory/group_vars/all/base_fail2ban.yml
 # Shared Fail2ban variables for the example lab.
-# Defines the aggregate-role opt-in plus the Fail2ban package, service, and SSH jail baseline enforced during the base phase.
-
-# Opt in to the optional base_fail2ban role from the aggregate base role.
-base_include_fail2ban: true
+# Defines the Fail2ban package, service, and SSH jail baseline enforced during the base phase.
 
 # Package list installed with APT to provide the Fail2ban baseline.
 base_fail2ban_packages:

--- a/examples/inventory/group_vars/all/base_firewall.yml
+++ b/examples/inventory/group_vars/all/base_firewall.yml
@@ -1,10 +1,7 @@
 ---
 # examples/inventory/group_vars/all/base_firewall.yml
 # Shared firewall variables for the example lab.
-# Defines the aggregate-role opt-in, UFW package, enabled state, default policies, baseline rules, and optional host additions enforced during the base phase.
-
-# Opt in to the optional base_firewall role from the aggregate base role.
-base_include_firewall: true
+# Defines the UFW package, enabled state, default policies, baseline rules, and optional host additions enforced during the base phase.
 
 # Package list installed with APT to provide the firewall on the host.
 base_firewall_packages:

--- a/examples/inventory/group_vars/all/base_hosts.yml
+++ b/examples/inventory/group_vars/all/base_hosts.yml
@@ -1,12 +1,7 @@
 ---
 # examples/inventory/group_vars/all/base_hosts.yml
 # Shared hosts-file variables for the example lab.
-# Defines the aggregate-role opt-in plus the inventory-driven `/etc/hosts` block settings used during the base phase.
-
-# Opt in to the optional base_hosts role from the aggregate base role.
-# This keeps inventory-driven host mappings available on every example host
-# without depending on external DNS for internal lab name resolution.
-base_include_hosts: true
+# Defines the inventory-driven `/etc/hosts` block settings used during the base phase.
 
 # Inventory group used to build the managed `/etc/hosts` block.
 # Keep `all` here so every host in the example lab learns the inventory

--- a/examples/inventory/group_vars/all/base_logging.yml
+++ b/examples/inventory/group_vars/all/base_logging.yml
@@ -1,10 +1,7 @@
 ---
 # examples/inventory/group_vars/all/base_logging.yml
 # Shared logging variables for the example lab.
-# Defines the aggregate-role opt-in plus the journald package, service, storage, and retention values used during the base phase.
-
-# Opt in to the optional base_logging role from the aggregate base role.
-base_include_logging: true
+# Defines the journald package, service, storage, and retention values used during the base phase.
 
 # Package list installed with APT before journald configuration.
 # Keep `systemd` here in the example lab so the journald package baseline is

--- a/examples/inventory/group_vars/all/base_needrestart.yml
+++ b/examples/inventory/group_vars/all/base_needrestart.yml
@@ -1,10 +1,7 @@
 ---
 # examples/inventory/group_vars/all/base_needrestart.yml
 # Shared needrestart variables for the example lab.
-# Defines the aggregate-role opt-in plus the non-interactive restart-check behavior exposed during the base phase.
-
-# Opt in to the optional base_needrestart role from the aggregate base role.
-base_include_needrestart: true
+# Defines the non-interactive restart-check behavior exposed during the base phase.
 
 # Package list installed with APT to provide the needrestart restart-check
 # command used by the example lab.

--- a/examples/inventory/group_vars/all/base_updates.yml
+++ b/examples/inventory/group_vars/all/base_updates.yml
@@ -1,10 +1,7 @@
 ---
 # examples/inventory/group_vars/all/base_updates.yml
 # Shared update variables for the example lab.
-# Defines the aggregate-role opt-in plus the unattended-upgrades package and automatic-update policy used during the base phase.
-
-# Opt in to the optional base_updates role from the aggregate base role.
-base_include_updates: true
+# Defines the unattended-upgrades package and automatic-update policy used during the base phase.
 
 # Package list installed with APT to provide unattended-upgrades support.
 # Keep `unattended-upgrades` in this list whenever automatic upgrades stay

--- a/examples/inventory/group_vars/all/base_upgrade.yml
+++ b/examples/inventory/group_vars/all/base_upgrade.yml
@@ -1,16 +1,7 @@
 ---
 # examples/inventory/group_vars/all/base_upgrade.yml
 # Shared upgrade variables for the example lab.
-# Defines the aggregate-role opt-in plus the immediate APT upgrade behavior available during the base phase.
-
-# Keep the optional base_upgrade role enabled by default in the example lab.
-# This makes the example base run exercise immediate package maintenance as a
-# normal part of the full stack so post-upgrade follow-up such as
-# `base_needrestart` reflects current package state.
-# The example base playbook uses `serial: 1` so reboot-capable runs can
-# process one host at a time instead of upgrading and rebooting everything
-# in parallel.
-base_include_upgrade: true
+# Defines the immediate APT upgrade behavior available during the base phase.
 
 # Refresh package metadata on every explicit upgrade run in the example lab.
 base_upgrade_cache_valid_time: 0

--- a/examples/inventory/group_vars/all/user.yml
+++ b/examples/inventory/group_vars/all/user.yml
@@ -1,4 +1,11 @@
 ---
 # examples/inventory/group_vars/all/user.yml
 # Shared aggregate user-role variables for the example lab.
-# Intentionally empty because the aggregate `user` role currently delegates work through `user_account_*` variables only.
+# Defines the optional aggregate-role toggles for the example user layer.
+
+# Keep password management enabled in the example lab so the example human
+# admin account has a usable local password in addition to any SSH access.
+# The companion `user_password.yml` file uses the plaintext test password
+# `password` as a documented local-lab example, so replace that demo hash
+# before using this pattern on a real host.
+user_include_password: true

--- a/examples/inventory/group_vars/all/user_account.yml
+++ b/examples/inventory/group_vars/all/user_account.yml
@@ -40,8 +40,3 @@ user_account_remove: false
 
 # Descriptive GECOS/comment field for the example human admin account.
 user_account_comment: Example human admin account managed by Ansible
-
-# Leave password-lock state unmanaged in the example lab so the role avoids
-# unnecessary unlock operations and repeated change noise on hosts where the
-# current password state is already acceptable.
-user_account_password_lock: null

--- a/examples/inventory/group_vars/all/user_password.yml
+++ b/examples/inventory/group_vars/all/user_password.yml
@@ -1,0 +1,17 @@
+---
+# examples/inventory/group_vars/all/user_password.yml
+# Shared human admin password variables for the example lab.
+# Defines the optional hashed-password and password-lock inputs available through the aggregate `user` role.
+
+# Target user whose local password state would be managed when the role is enabled.
+user_password_user: "{{ user_account_name }}"
+
+# Demo password hash for the example human admin account.
+# Plaintext for this demo hash: password
+# Replace this with a real Vault-managed hash before using the pattern on a
+# real host.
+user_password_password_hash: "$6$AwekCdzHA8gKBdu1$wCVo6U4a7yY6E4noNCiJEVWCaLTzhw/3qNcs.LINRQdpU7qv/iV7pbdcplAHPV6wekBvJbChplgWTzSaw2oGq/"
+
+# Keep the example password explicitly unlocked so the demo hash remains
+# usable for local password-based login or sudo flows if needed.
+user_password_password_lock: false

--- a/roles/base/README.md
+++ b/roles/base/README.md
@@ -33,6 +33,7 @@ Use `base` on Debian-family hosts after the bootstrap phase has already created 
 
 Bootstrap is handled separately by the standalone `bootstrap` role/playbook.
 Role-specific inputs for `base` currently come from `base_packages_*`, `base_locale_*`, `base_timezone_*`, `base_ntp_*`, `base_hostname_*`, optional `base_include_hosts` plus `base_hosts_*`, optional `base_include_dns` plus `base_dns_*`, `base_sudo_*`, `base_sshd_*`, optional `base_include_firewall` plus `base_firewall_*`, optional `base_include_fail2ban` plus `base_fail2ban_*`, optional `base_include_logging` plus `base_logging_*`, optional `base_include_updates` plus `base_updates_*`, optional `base_include_apparmor` plus `base_apparmor_*`, optional `base_include_auditd` plus `base_auditd_*`, optional `base_include_upgrade` plus `base_upgrade_*`, and optional `base_include_needrestart` plus `base_needrestart_*`.
+Keep aggregate role toggles such as `base_include_firewall` in aggregate-scoped variables such as `base.yml`, and keep child-role inputs such as `base_firewall_*` in the matching child-role file such as `base_firewall.yml`.
 If you want `base_firewall` to consume `base_firewall_role_declared_rules` registered by roles outside this aggregate stack, run those roles before `base_firewall` in the same play or run `base_firewall` again in a later play after they have registered their rules.
 
 Current include order in `base` is:

--- a/roles/user/README.md
+++ b/roles/user/README.md
@@ -7,6 +7,7 @@ Explains how the aggregate user role delegates recurring human admin account con
 - Runs the recurring human-admin user configuration on every `user` execution
 - Keeps the aggregate user-role execution order in `roles/user/tasks/main.yml`
 - Includes `user_account` through an explicit `ansible.builtin.include_role` entry
+- Can include `user_password` as an explicit opt-in follow-up role when `user_include_password: true`
 - Keeps aggregate include-task tags aligned with the child role's phase tags and role-specific tags so targeted runs such as `--tags validate` or `--tags user_account_validate` stay predictable
 
 ## Usage
@@ -20,17 +21,18 @@ Use `user` on Debian-family hosts after the `base` role has already applied the 
     - role: user
 ```
 
-Role-specific inputs for `user` currently come from `user_account_*`.
+Role-specific inputs for `user` currently come from `user_account_*`, plus optional `user_include_password` and `user_password_*`.
 
 Current include order in `user` is:
 
 1. `user_account`
+2. `user_password` when `user_include_password: true`
 
 `roles/user/tasks/main.yml` is the single source of truth for this sequence.
 This keeps the human-admin account layer explicit and leaves future `user_*` roles room to be added in a stable order.
 
 Aggregate include-task tags in `roles/user/tasks/main.yml` intentionally mirror the child role phase tags and role-specific tags.
-This keeps broad phase runs such as `--tags validate` working across the user stack while also allowing narrow runs such as `--tags user_account` or `--tags user_account_validate` without unrelated role execution.
+This keeps broad phase runs such as `--tags validate` working across the user stack while also allowing narrow runs such as `--tags user_account`, `--tags user_password`, `--tags user_account_validate`, or `--tags user_password_validate` without unrelated role execution.
 
 ## Dependencies
 None

--- a/roles/user/defaults/main.yml
+++ b/roles/user/defaults/main.yml
@@ -1,4 +1,6 @@
 ---
 # roles/user/defaults/main.yml
 # Default variables for the `user` role.
-# Intentionally empty because this aggregate role currently delegates work through explicit child-role includes only.
+# Defines optional aggregate-role toggles that extend the human-admin user layer without changing existing consumers by default.
+
+user_include_password: false

--- a/roles/user/tasks/main.yml
+++ b/roles/user/tasks/main.yml
@@ -9,3 +9,11 @@
     apply:
       tags: [user, user_account]
   tags: [user, user_account, assert, config, validate, user_account_assert, user_account_config, user_account_validate]
+
+- name: "User | Include optional user_password role"
+  ansible.builtin.include_role:
+    name: user_password
+    apply:
+      tags: [user, user_password]
+  when: user_include_password | default(false)
+  tags: [user, user_password, assert, config, validate, user_password_assert, user_password_config, user_password_validate]

--- a/roles/user_account/README.md
+++ b/roles/user_account/README.md
@@ -7,7 +7,6 @@ Explains how the role creates and validates one human admin account after the ba
 - Ensures the primary group exists for the human admin account when enabled
 - Ensures the human admin user exists with the expected UID, GID, baseline login shell, home directory, and basic account settings
 - Supports enforcing an existing human admin account instead of assuming fresh creation, while requiring explicit opt-in before moving an existing home directory
-- Can optionally manage password-lock state for SSH-oriented admin access
 - Validates resulting passwd, group, and home-directory state
 
 ## Variables
@@ -26,7 +25,6 @@ Explains how the role creates and validates one human admin account after the ba
 | `user_account_create_home` | `true` | no | If true, create the home directory for present accounts |
 | `user_account_remove` | `false` | no | If true and the account is absent, remove the home directory and mail spool |
 | `user_account_comment` | `Human admin account managed by Ansible` | no | Optional GECOS/comment field |
-| `user_account_password_lock` | `null` | no | Optional password-lock state: `true` locks, `false` unlocks, `null` leaves password-lock state unmanaged |
 
 ## Usage
 
@@ -56,6 +54,7 @@ Example role ordering with the planned `user_*` layer:
 `user_account` intentionally keeps shell handling narrow.
 Use `user_account_shell` for the account's baseline login shell, and let a future `user_shell` role manage dotfiles, aliases, environment variables, PATH changes, and any richer shell-policy decisions.
 When adopting an existing user, the role fails early if the current home path differs from `user_account_home` unless `user_account_move_home: true` is set explicitly.
+Use `user_password` when you want to manage a hashed local password or password-lock state for the same human admin account.
 
 ## Dependencies
 None

--- a/roles/user_account/defaults/main.yml
+++ b/roles/user_account/defaults/main.yml
@@ -37,7 +37,3 @@ user_account_remove: false
 
 # Optional GECOS/comment field for the human admin account.
 user_account_comment: Human admin account managed by Ansible
-
-# Optional password-lock state for the account.
-# Set to true to lock the password, false to unlock it, or null to leave password-lock state unmanaged.
-user_account_password_lock: null

--- a/roles/user_account/tasks/assert.yml
+++ b/roles/user_account/tasks/assert.yml
@@ -15,7 +15,6 @@
       - user_account_manage_primary_group is boolean
       - user_account_create_home is boolean
       - user_account_remove is boolean
-      - user_account_password_lock is none or user_account_password_lock is boolean
       - user_account_state != 'present' or (
           user_account_uid is number
           and user_account_uid | int >= 1000

--- a/roles/user_account/tasks/config.yml
+++ b/roles/user_account/tasks/config.yml
@@ -23,10 +23,4 @@
     move_home: "{{ user_account_move_home if user_account_state == 'present' else omit }}"
     create_home: "{{ user_account_create_home if user_account_state == 'present' else omit }}"
     comment: "{{ user_account_comment if user_account_state == 'present' else omit }}"
-    password_lock: >-
-      {{
-        user_account_password_lock
-        if user_account_state == 'present' and user_account_password_lock is not none
-        else omit
-      }}
     remove: "{{ user_account_remove if user_account_state == 'absent' else omit }}"

--- a/roles/user_password/README.md
+++ b/roles/user_password/README.md
@@ -1,0 +1,61 @@
+# roles/user_password/README.md
+
+Reference for the `user_password` role.
+Explains how the role manages Vault-friendly local password state for one human admin account after the base phase on Debian-family hosts in this repository.
+
+## Features
+- Validates that the target human admin account already exists before password management starts
+- Supports hashed password management without accepting plaintext passwords
+- Supports optional password lock or unlock management separately from the password hash
+- Keeps secret-bearing password behavior separate from the broader identity and filesystem scope of `user_account`
+- Validates the resulting shadow-password state after configuration
+
+## Variables
+
+| Variable | Default | Required | Description |
+|----------|---------|----------|-------------|
+| `user_password_user` | `{{ user_account_name | default('admin') }}` | yes | Human admin username whose password state is managed |
+| `user_password_password_hash` | `null` | no | Vault-managed hashed password value; must begin with `$` when set |
+| `user_password_password_lock` | `null` | no | Optional password-lock state: `true` locks, `false` unlocks, `null` leaves lock state unchanged |
+
+At least one of `user_password_password_hash` or `user_password_password_lock` must be set when this role is enabled.
+
+## Usage
+
+Use `user_password` after `user_account` has already ensured the user exists:
+
+```yaml
+- hosts: all
+  become: true
+  vars:
+    user_password_user: alice
+    user_password_password_hash: "{{ vault_user_password_hash }}"
+  roles:
+    - role: user_account
+    - role: user_password
+```
+
+Example aggregate-role usage:
+
+```yaml
+- hosts: all
+  become: true
+  vars:
+    user_include_password: true
+    user_password_password_hash: "{{ vault_user_password_hash }}"
+  roles:
+    - role: user
+```
+
+Store real password hashes in Ansible Vault or another secret backend.
+Do not place plaintext passwords or real password hashes in repository defaults or non-secret inventory files.
+The local `examples/` lab is the one exception in this repository: it uses a documented demo hash for the plaintext test password `password` so the user layer can be validated end to end.
+
+## Dependencies
+None
+
+## Author
+tatbyte
+
+## License
+MIT

--- a/roles/user_password/defaults/main.yml
+++ b/roles/user_password/defaults/main.yml
@@ -1,0 +1,15 @@
+---
+# roles/user_password/defaults/main.yml
+# Default variables for the `user_password` role.
+# Defines the Vault-friendly password state enforced for one human admin account after the account already exists.
+
+# Human admin username whose local password state is managed.
+user_password_user: "{{ user_account_name | default('admin') }}"
+
+# Vault-managed hashed password for the human admin account.
+# Keep this null unless you are supplying a real password hash from a secret backend.
+user_password_password_hash: null
+
+# Optional password-lock state for the human admin account.
+# Set to true to lock, false to unlock, or null to leave lock state unchanged.
+user_password_password_lock: null

--- a/roles/user_password/tasks/assert.yml
+++ b/roles/user_password/tasks/assert.yml
@@ -1,0 +1,36 @@
+---
+# roles/user_password/tasks/assert.yml
+# Assert phase tasks for the `user_password` role.
+# Validates the human admin password variables before password management starts.
+
+- name: "Assert | Validate required user_password variables"
+  ansible.builtin.assert:
+    that:
+      - user_password_user is defined
+      - user_password_user | length > 0
+      - user_password_password_hash is none or (
+          user_password_password_hash is string
+          and user_password_password_hash | length > 0
+          and user_password_password_hash.startswith('$')
+        )
+      - user_password_password_lock is none or user_password_password_lock is boolean
+      - user_password_password_hash is not none or user_password_password_lock is not none
+    fail_msg: >-
+      user_password_user must be defined and at least one valid user_password password or lock input must be set
+    quiet: true
+
+- name: "Assert | Collect Human Admin Account Entry For Password Management"
+  ansible.builtin.getent:
+    database: passwd
+    key: "{{ user_password_user }}"
+  register: user_password_assert_passwd_lookup
+  changed_when: false
+  failed_when: false
+
+- name: "Assert | Validate Human Admin Account Exists Before Password Management"
+  ansible.builtin.assert:
+    that:
+      - user_password_user in (user_password_assert_passwd_lookup.ansible_facts.getent_passwd | default({}))
+    fail_msg: >-
+      user_password_user must already exist before the user_password role manages local password state
+    quiet: true

--- a/roles/user_password/tasks/config.yml
+++ b/roles/user_password/tasks/config.yml
@@ -1,0 +1,11 @@
+---
+# roles/user_password/tasks/config.yml
+# Config phase tasks for the `user_password` role.
+# Applies the requested hashed password and optional password-lock state to the existing human admin account.
+
+- name: "Config | Ensure Human Admin Password State"
+  ansible.builtin.user:
+    name: "{{ user_password_user }}"
+    state: present
+    password: "{{ user_password_password_hash if user_password_password_hash is not none else omit }}"
+    password_lock: "{{ user_password_password_lock if user_password_password_lock is not none else omit }}"

--- a/roles/user_password/tasks/main.yml
+++ b/roles/user_password/tasks/main.yml
@@ -1,0 +1,16 @@
+---
+# roles/user_password/tasks/main.yml
+# Task entrypoint for the `user_password` role.
+# Imports the assert, config, and validate phase files in order.
+
+- name: Assert
+  ansible.builtin.import_tasks: assert.yml
+  tags: [user_password, assert, user_password_assert]
+
+- name: Config
+  ansible.builtin.import_tasks: config.yml
+  tags: [user_password, config, user_password_config]
+
+- name: Validate
+  ansible.builtin.import_tasks: validate.yml
+  tags: [user_password, validate, user_password_validate]

--- a/roles/user_password/tasks/validate.yml
+++ b/roles/user_password/tasks/validate.yml
@@ -1,0 +1,81 @@
+---
+# roles/user_password/tasks/validate.yml
+# Validate phase tasks for the `user_password` role.
+# Verifies the resulting passwd and shadow-password state after configuration.
+
+- name: "Validate | Collect Human Admin Passwd Entry For Password Management"
+  ansible.builtin.getent:
+    database: passwd
+    key: "{{ user_password_user }}"
+  register: user_password_passwd_lookup
+  changed_when: false
+  failed_when: false
+
+- name: "Validate | Collect Human Admin Shadow Entry"
+  ansible.builtin.getent:
+    database: shadow
+    key: "{{ user_password_user }}"
+  register: user_password_shadow_lookup
+  changed_when: false
+  failed_when: false
+
+- name: "Validate | Derive Human Admin Password Validation Facts"
+  ansible.builtin.set_fact:
+    user_password_passwd_entries: "{{ user_password_passwd_lookup.ansible_facts.getent_passwd | default({}) }}"
+    user_password_shadow_entries: "{{ user_password_shadow_lookup.ansible_facts.getent_shadow | default({}) }}"
+    user_password_shadow_entry: >-
+      {{
+        (user_password_shadow_lookup.ansible_facts.getent_shadow | default({})).get(user_password_user)
+      }}
+    user_password_shadow_password_field: >-
+      {{
+        (
+          (user_password_shadow_lookup.ansible_facts.getent_shadow | default({})).get(user_password_user)[0]
+        )
+        if (
+          (user_password_shadow_lookup.ansible_facts.getent_shadow | default({})).get(user_password_user)
+          is not none
+        )
+        else ''
+      }}
+    user_password_expected_shadow_password_field: >-
+      {{
+        (
+          '!' ~ (user_password_password_hash | regex_replace('^!+', ''))
+        )
+        if user_password_password_hash is not none and user_password_password_lock is sameas true
+        else (
+          user_password_password_hash | regex_replace('^!+', '')
+        )
+        if user_password_password_hash is not none
+        else none
+      }}
+  changed_when: false
+
+- name: "Validate | Verify Human Admin Password State"
+  ansible.builtin.assert:
+    that:
+      - user_password_user in user_password_passwd_entries
+      - user_password_user in user_password_shadow_entries
+      - >-
+        (
+          user_password_expected_shadow_password_field is none
+        ) or (
+          user_password_shadow_password_field == user_password_expected_shadow_password_field
+        )
+      - >-
+        (
+          user_password_expected_shadow_password_field is not none
+        ) or (
+          user_password_password_lock is none
+        ) or (
+          user_password_password_lock is sameas true
+          and user_password_shadow_password_field.startswith('!')
+        ) or (
+          user_password_password_lock is sameas false
+          and not user_password_shadow_password_field.startswith('!')
+        )
+    fail_msg: >-
+      Validate | Human admin password state is not in the expected final state
+      (passwd/shadow/password hash/password lock)
+    quiet: true


### PR DESCRIPTION
- Updated role workflow documentation to clarify the sequence of user account and password management.
- Added a new Vault guidance document detailing local Vault password file management and usage with Ansible.
- Refactored example inventory structure to consolidate aggregate role toggles into a single base.yml file.
- Introduced user_password role to manage hashed passwords and password-lock states for human admin accounts.
- Updated user and user_account roles to support optional password management through user_include_password toggle.
- Improved variable documentation across roles to clarify usage and requirements for password management.
- Added validation tasks to ensure proper password state management in user_password role. `user_password` role Fixes #70