### PR TITLE
feat: Introduce user_groups role for managing supplementary group memberships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 Release history for `homelab-roles`.
 Documents notable changes across repository structure, roles, examples, and documentation.
 
+## [v1.3.0]
+### Added
+- Added the standalone `user_groups` role for managing supplementary group membership for existing human admin accounts with per-user append-versus-explicit behavior.
+- Added the example `user_groups.yml` inventory file plus the aggregate `user_include_groups` toggle used to exercise the new role in the local lab.
+
+### Changed
+- Updated the aggregate `user` role so `user_groups` is an explicit opt-in follow-up role that runs after `user_account` and before optional `user_password`.
+- Added optional managed-group creation support to `user_groups` through `user_groups_manage_groups`, while keeping the safer default behavior that requires requested groups to already exist.
+- Extended `user_groups` so it now aggregates `user_groups_base_memberships`, `user_groups_role_declared_memberships`, and `user_groups_additional_memberships` into the effective managed per-user group policy.
+
+### Documentation
+- Updated repository, workflow, role, example, and Vault documentation to describe the new `user_groups` role, its aggregate ordering, and the new example supplementary-group variable file.
+- Added supplementary-group integration guidance for future roles in `docs/06-user-groups-role-integration.md`, including the registration pattern, merge behavior, ordering requirement, and inventory-versus-role split.
+
 ## [v1.2.0]
 ### Added
 - Added the standalone `user_password` role for managing Vault-friendly hashed local password state and optional password locking for one existing human admin account.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ homelab-roles/
 │   ├── monitoring_authorized_key/
 │   ├── user/
 │   ├── user_account/
+│   ├── user_groups/
 │   └── user_password/
 ├── examples/
 │   ├── ansible.cfg
@@ -66,8 +67,9 @@ homelab-roles/
 - `base_timezone`: Enforces the system timezone on Debian-family hosts during the base phase.
 - `monitoring`: Aggregates monitoring-related configuration through dependency roles such as `monitoring_authorized_key`.
 - `monitoring_authorized_key`: Installs an SSH authorized key for monitoring-style inter-host access.
-- `user`: Aggregates recurring human admin user configuration through explicit `include_role` ordering in `roles/user/tasks/main.yml` for `user_account` plus optional `user_password`.
+- `user`: Aggregates recurring human admin user configuration through explicit `include_role` ordering in `roles/user/tasks/main.yml` for `user_account` plus optional `user_groups` and optional `user_password`.
 - `user_account`: Creates and validates one human admin account with explicit primary-group, shell, home-directory, and basic account-state enforcement after the base phase.
+- `user_groups`: Enforces supplementary group membership for one or more existing human admin accounts after account creation, with aggregated base plus role-declared plus explicit inventory inputs and per-user append-versus-explicit behavior.
 - `user_password`: Manages Vault-friendly hashed local password state and optional password locking for one existing human admin account after the base phase.
 
 ## Consume From Another Repo
@@ -146,7 +148,7 @@ ansible-playbook playbooks/site.yml
 
 See [examples/README.md](examples/README.md) and [docs/01-examples.md](docs/01-examples.md) for lab details.
 The current example lab intentionally keeps `base_upgrade` and strict `base_needrestart` follow-up enabled, so a base run may fail when pending reboot or service-restart work is detected after upgrades.
-The current example lab also enables `user_password` with a documented demo hash for the plaintext test password `password`, so replace that example value before copying the pattern to a real host.
+The current example lab also enables `user_groups` for a documented supplementary admin-group baseline and `user_password` with a demo hash for the plaintext test password `password`, so replace that example password value before copying the pattern to a real host.
 
 ## Linting
 Pre-commit and linting are configured in this repository.
@@ -175,6 +177,7 @@ Core repository docs:
 - [docs/03-file-consistency.md](docs/03-file-consistency.md): File header and wording consistency rules
 - [docs/04-firewall-role-integration.md](docs/04-firewall-role-integration.md): How future roles should register firewall rules for `base_firewall`
 - [docs/05-vault.md](docs/05-vault.md): Short Vault guidance for secret-bearing inventory values such as `user_password`
+- [docs/06-user-groups-role-integration.md](docs/06-user-groups-role-integration.md): How future roles should register human admin supplementary-group needs for `user_groups`
 
 ## License
 MIT

--- a/docs/01-examples.md
+++ b/docs/01-examples.md
@@ -19,7 +19,7 @@ The example content assumes Debian-family targets such as Debian and Ubuntu.
 
 - `examples/ansible.cfg`: Example Ansible configuration for local test runs that also hides skipped-host output for quieter example runs.
 - `examples/inventory/hosts.ini`: Example hosts and groups.
-- `examples/inventory/group_vars/all/`: Example variables for all hosts, split into aggregate-scoped files such as `base.yml` and `user.yml`, plus role-scoped files such as `bootstrap.yml`, `base_packages.yml`, `base_hostname.yml`, `base_hosts.yml`, `base_dns.yml`, `base_locale.yml`, `base_ntp.yml`, `base_sudo.yml`, `base_sshd.yml`, `base_firewall.yml`, `base_fail2ban.yml`, `base_logging.yml`, `base_updates.yml`, `base_apparmor.yml`, `base_auditd.yml`, `base_upgrade.yml`, `base_needrestart.yml`, `base_timezone.yml`, `user_account.yml`, `user_password.yml`, and `monitoring_authorized_key.yml`.
+- `examples/inventory/group_vars/all/`: Example variables for all hosts, split into aggregate-scoped files such as `base.yml` and `user.yml`, plus role-scoped files such as `bootstrap.yml`, `base_packages.yml`, `base_hostname.yml`, `base_hosts.yml`, `base_dns.yml`, `base_locale.yml`, `base_ntp.yml`, `base_sudo.yml`, `base_sshd.yml`, `base_firewall.yml`, `base_fail2ban.yml`, `base_logging.yml`, `base_updates.yml`, `base_apparmor.yml`, `base_auditd.yml`, `base_upgrade.yml`, `base_needrestart.yml`, `base_timezone.yml`, `user_account.yml`, `user_groups.yml`, `user_password.yml`, and `monitoring_authorized_key.yml`.
 - `examples/playbooks/bootstrap.yml`: Bootstrap phase playbook that uses initial host credentials and applies the standalone `bootstrap` role.
 - `examples/playbooks/base.yml`: Base phase playbook for post-bootstrap role execution that applies the aggregate base role one host at a time for safer reboot-capable runs.
 - `examples/playbooks/user.yml`: User phase playbook for post-base role execution that applies the aggregate `user` role for human admin account enforcement.
@@ -81,7 +81,8 @@ ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/tests/te
 - When the example run's `base_upgrade` role makes no package-maintenance changes and leaves no reboot-required follow-up, `base_needrestart` now skips the batch check automatically to reduce no-change noise.
 - `playbooks/base.yml` uses `serial: 1`, which is safer when optional roles such as `base_upgrade` may reboot a host during the run.
 - `user_account.yml` defines the example human admin account enforced after the base phase through the aggregate `user` role.
-- `user.yml` enables the optional password role in the example lab, while `user_password.yml` sets a demo SHA-512 password hash for the example human admin account using the plaintext test password `password` and documents that a real host should use a Vault-managed hash instead.
+- `user_groups.yml` defines the example supplementary admin-group baseline, the future role-declared accumulator, and the inventory-specific follow-up layer used when `user.yml` enables `user_groups`.
+- `user.yml` enables the optional supplementary-group and password roles in the example lab, while `user_password.yml` sets a demo SHA-512 password hash for the example human admin account using the plaintext test password `password` and documents that a real host should use a Vault-managed hash instead.
 - `ansible.cfg` sets `display_skipped_hosts = False`, so routine conditional skips from optional roles or gated tasks do not dominate the example output.
 - `hosts.ini` keeps default `ansible_user=ansible` in `[all:vars]`, while `[bootstrap:vars]` holds initial login values used only during bootstrap.
 - `playbooks/bootstrap.yml` prompts once for the bootstrap password and reuses it for both SSH login and sudo.

--- a/docs/02-role-workflow.md
+++ b/docs/02-role-workflow.md
@@ -107,9 +107,10 @@ Its include-task tags should mirror the generic phase tags plus the child role's
 Current order:
 
 1. `user_account`
-2. `user_password` when `user_include_password: true`
+2. `user_groups` when `user_include_groups: true`
+3. `user_password` when `user_include_password: true`
 
-Use this sequence to keep human-admin account creation and adoption explicit first, then optional secret-backed local password management, before any future user-environment roles such as SSH, shell, or profile management.
+Use this sequence to keep human-admin account creation and adoption explicit first, then optional supplementary-group policy, then optional secret-backed local password management, before any future user-environment roles such as SSH, shell, or profile management.
 
 ## Tag Usage
 

--- a/docs/05-vault.md
+++ b/docs/05-vault.md
@@ -58,7 +58,7 @@ user_password_password_hash: "{{ vault_user_password_hash }}"
 
 - `user_password`: best current fit, because it manages `user_password_password_hash`, which is secret-bearing and should not live in plain inventory.
 
-Today, `user_account`, `base_*`, and `monitoring_authorized_key` do not need Vault for their normal role inputs.
+Today, `user_account`, `user_groups`, `base_*`, and `monitoring_authorized_key` do not need Vault for their normal role inputs.
 The example `bootstrap` flow also prompts for the initial password instead of storing it in inventory.
 
 ## Why

--- a/docs/06-user-groups-role-integration.md
+++ b/docs/06-user-groups-role-integration.md
@@ -1,0 +1,113 @@
+# docs/06-user-groups-role-integration.md
+
+Reference for supplementary-group integration from future application or service roles.
+Explains how roles should register human admin supplementary-group needs for `user_groups` to aggregate and enforce centrally.
+
+## Purpose
+
+This repository keeps human admin supplementary-group enforcement centralized in
+`user_groups`.
+Application or service roles should declare their group needs and append them to
+`user_groups_role_declared_memberships` instead of editing
+`user_groups_additional_memberships` manually in inventory.
+
+That gives you:
+
+- automatic user-to-group access when a role is enabled
+- one place where effective supplementary-group state is enforced
+- inventory-specific overrides that can still be appended separately
+
+## Aggregation Order
+
+`user_groups` builds its effective pre-normalized membership list from:
+
+1. `user_groups_base_memberships`
+2. `user_groups_role_declared_memberships`
+3. `user_groups_additional_memberships`
+
+Then it merges entries for the same user into one effective membership
+definition.
+
+This means:
+
+- shared baseline memberships stay first
+- memberships from enabled roles are added next
+- explicit inventory overrides or one-off additions can still be appended last
+
+## Merge Behavior
+
+When multiple entries target the same user, `user_groups`:
+
+1. adds requested `groups` uniquely while entries stay additive
+2. resets the effective user entry to exactly that entry's `groups` when a
+   later entry sets `append: false`
+3. continues from that reset point for any later entries for the same user
+
+This keeps additive role declarations simple while still allowing inventory to
+take explicit ownership when needed.
+
+Unlike `base_firewall`, `user_groups` does not keep a separate live-state
+registry for automatic stale-membership cleanup.
+If a future role stops declaring an additive membership, that group is only
+removed when some later effective input for the same user takes explicit
+ownership with `append: false`.
+
+## How A Role Registers Group Memberships
+
+Keep role-specific supplementary-group needs in that role's defaults or vars.
+Then append them with `set_fact` only when the role is enabled.
+
+Example defaults:
+
+```yaml
+docker_engine_user_group_memberships:
+  - user: "{{ user_account_name }}"
+    groups:
+      - docker
+    append: true
+```
+
+Example task:
+
+```yaml
+- name: "Config | Register user supplementary groups"
+  ansible.builtin.set_fact:
+    user_groups_role_declared_memberships: >-
+      {{
+        (user_groups_role_declared_memberships | default([]))
+        + (docker_engine_user_group_memberships | default([]))
+      }}
+  when: docker_engine_enabled | default(false)
+```
+
+## Ordering Requirement
+
+The registration task must run before `user_groups` enforces supplementary-group
+state.
+
+Inside the aggregate `user` role, `user_groups` runs after:
+
+1. `user_account`
+
+and before:
+
+1. optional `user_password`
+
+If a future application role lives outside that aggregate order, either:
+
+- run that role earlier in the same play before `user_groups`
+- or run `user_groups` in a later play after the role has registered its
+  memberships
+
+## When To Use Additional Memberships Instead
+
+Use `user_groups_additional_memberships` when a membership is:
+
+- inventory-specific rather than owned by one role
+- intentionally manual
+- not tied to a role enable or disable toggle
+
+Use `user_groups_role_declared_memberships` when a membership belongs to a role
+and should be added while that role is enabled.
+Use a later `append: false` inventory entry when you need exact final
+supplementary-group ownership for that user.

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,7 +10,7 @@ The inventory variables and role inputs assume the repository's Debian-family de
 ## Structure
 - `ansible.cfg`: Test-specific Ansible configuration that points at the example inventory and hides skipped-host output for quieter local runs.
 - `inventory/hosts.ini`: Test inventory.
-- `inventory/group_vars/all/`: Shared variables for test hosts, split into aggregate-scoped files such as `base.yml` and `user.yml`, plus role-scoped files such as `bootstrap.yml`, `base_packages.yml`, `base_hostname.yml`, `base_hosts.yml`, `base_dns.yml`, `base_locale.yml`, `base_ntp.yml`, `base_sudo.yml`, `base_sshd.yml`, `base_firewall.yml`, `base_fail2ban.yml`, `base_logging.yml`, `base_updates.yml`, `base_apparmor.yml`, `base_auditd.yml`, `base_upgrade.yml`, `base_needrestart.yml`, `base_timezone.yml`, `user_account.yml`, `user_password.yml`, and `monitoring_authorized_key.yml`.
+- `inventory/group_vars/all/`: Shared variables for test hosts, split into aggregate-scoped files such as `base.yml` and `user.yml`, plus role-scoped files such as `bootstrap.yml`, `base_packages.yml`, `base_hostname.yml`, `base_hosts.yml`, `base_dns.yml`, `base_locale.yml`, `base_ntp.yml`, `base_sudo.yml`, `base_sshd.yml`, `base_firewall.yml`, `base_fail2ban.yml`, `base_logging.yml`, `base_updates.yml`, `base_apparmor.yml`, `base_auditd.yml`, `base_upgrade.yml`, `base_needrestart.yml`, `base_timezone.yml`, `user_account.yml`, `user_groups.yml`, `user_password.yml`, and `monitoring_authorized_key.yml`.
 - `playbooks/bootstrap.yml`: Bootstrap phase playbook that connects with the initial admin account and applies the standalone `bootstrap` role.
 - `playbooks/base.yml`: Base phase playbook that connects as the automation account, applies the `base` role, and uses `serial: 1` so reboot-capable base runs process one host at a time.
 - `playbooks/user.yml`: User phase playbook that connects as the automation account after the base phase and applies the aggregate `user` role.
@@ -71,7 +71,8 @@ This means the example base run may fail intentionally after package maintenance
 When the example run's `base_upgrade` role makes no package-maintenance changes and leaves no reboot-required follow-up, `base_needrestart` now skips the batch check automatically to reduce no-change noise.
 `playbooks/base.yml` uses `serial: 1`, which is safer when optional roles such as `base_upgrade` may reboot a host during the run.
 `inventory/group_vars/all/user_account.yml` defines the example human admin account enforced after the base phase through the aggregate `user` role.
-`inventory/group_vars/all/user.yml` enables the optional password role in the example lab, while `inventory/group_vars/all/user_password.yml` sets a demo SHA-512 password hash for the example human admin account using the plaintext test password `password` and documents that a real host should use a Vault-managed hash instead.
+`inventory/group_vars/all/user_groups.yml` defines the example supplementary admin-group baseline, the future role-declared accumulator, and the inventory-specific follow-up layer used when `user.yml` enables `user_groups`.
+`inventory/group_vars/all/user.yml` enables the optional supplementary-group and password roles in the example lab, while `inventory/group_vars/all/user_password.yml` sets a demo SHA-512 password hash for the example human admin account using the plaintext test password `password` and documents that a real host should use a Vault-managed hash instead.
 `ansible.cfg` sets `display_skipped_hosts = False`, so optional-role and conditional-task skips are hidden during normal example runs.
 
 ## Bootstrap Credentials

--- a/examples/inventory/group_vars/all/user.yml
+++ b/examples/inventory/group_vars/all/user.yml
@@ -3,6 +3,14 @@
 # Shared aggregate user-role variables for the example lab.
 # Defines the optional aggregate-role toggles for the example user layer.
 
+# Keep these aggregate toggles in the same order used by
+# `roles/user/tasks/main.yml`.
+#
+# 1. `user_account` always runs first and has no aggregate toggle.
+# 2. `user_groups` runs next when enabled.
+user_include_groups: true
+
+# 3. `user_password` runs after account and group state when enabled.
 # Keep password management enabled in the example lab so the example human
 # admin account has a usable local password in addition to any SSH access.
 # The companion `user_password.yml` file uses the plaintext test password

--- a/examples/inventory/group_vars/all/user_account.yml
+++ b/examples/inventory/group_vars/all/user_account.yml
@@ -13,7 +13,9 @@ user_account_uid: 1050
 user_account_gid: 1050
 
 # Primary group for the example human admin account.
-user_account_primary_group: human-user
+# Keep this named after the user so the managed home directory keeps the
+# expected user-owned group baseline.
+user_account_primary_group: "{{ user_account_name }}"
 
 # Keep the example account present after the base phase.
 user_account_state: present

--- a/examples/inventory/group_vars/all/user_groups.yml
+++ b/examples/inventory/group_vars/all/user_groups.yml
@@ -1,0 +1,36 @@
+---
+# examples/inventory/group_vars/all/user_groups.yml
+# Shared human admin supplementary-group variables for the example lab.
+# Defines the example supplementary-group baseline enforced after account creation through the aggregate `user` role.
+
+# The user-named primary group for home-directory ownership is managed in
+# `user_account.yml` through `user_account_primary_group`.
+# This file only defines extra supplementary admin groups.
+
+# Keep automatic group creation disabled in the example lab so group names must
+# come from the base system or another role instead of being created silently.
+user_groups_manage_groups: false
+
+# Keep the shared example admin-group baseline additive so future roles can
+# still register extra memberships without this baseline taking explicit full
+# ownership.
+user_groups_base_memberships:
+  - user: "{{ user_account_name }}"
+    groups:
+      - sudo
+      - adm
+      - systemd-journal
+    append: true
+
+# Future roles can append their own managed memberships here before
+# `user_groups` runs, following the same pattern as `base_firewall`.
+# Example future role shape:
+#   - user: "{{ user_account_name }}"
+#     groups:
+#       - docker
+#     append: true
+user_groups_role_declared_memberships: []
+
+# Keep inventory-specific one-off additions separate from the shared baseline
+# and future role-declared layer.
+user_groups_additional_memberships: []

--- a/roles/user/README.md
+++ b/roles/user/README.md
@@ -7,6 +7,7 @@ Explains how the aggregate user role delegates recurring human admin account con
 - Runs the recurring human-admin user configuration on every `user` execution
 - Keeps the aggregate user-role execution order in `roles/user/tasks/main.yml`
 - Includes `user_account` through an explicit `ansible.builtin.include_role` entry
+- Can include `user_groups` as an explicit opt-in follow-up role when `user_include_groups: true`
 - Can include `user_password` as an explicit opt-in follow-up role when `user_include_password: true`
 - Keeps aggregate include-task tags aligned with the child role's phase tags and role-specific tags so targeted runs such as `--tags validate` or `--tags user_account_validate` stay predictable
 
@@ -21,18 +22,19 @@ Use `user` on Debian-family hosts after the `base` role has already applied the 
     - role: user
 ```
 
-Role-specific inputs for `user` currently come from `user_account_*`, plus optional `user_include_password` and `user_password_*`.
+Role-specific inputs for `user` currently come from `user_account_*`, plus optional `user_include_groups` and `user_groups_*`, plus optional `user_include_password` and `user_password_*`.
 
 Current include order in `user` is:
 
 1. `user_account`
-2. `user_password` when `user_include_password: true`
+2. `user_groups` when `user_include_groups: true`
+3. `user_password` when `user_include_password: true`
 
 `roles/user/tasks/main.yml` is the single source of truth for this sequence.
 This keeps the human-admin account layer explicit and leaves future `user_*` roles room to be added in a stable order.
 
 Aggregate include-task tags in `roles/user/tasks/main.yml` intentionally mirror the child role phase tags and role-specific tags.
-This keeps broad phase runs such as `--tags validate` working across the user stack while also allowing narrow runs such as `--tags user_account`, `--tags user_password`, `--tags user_account_validate`, or `--tags user_password_validate` without unrelated role execution.
+This keeps broad phase runs such as `--tags validate` working across the user stack while also allowing narrow runs such as `--tags user_account`, `--tags user_groups`, `--tags user_password`, `--tags user_account_validate`, `--tags user_groups_validate`, or `--tags user_password_validate` without unrelated role execution.
 
 ## Dependencies
 None

--- a/roles/user/defaults/main.yml
+++ b/roles/user/defaults/main.yml
@@ -3,4 +3,5 @@
 # Default variables for the `user` role.
 # Defines optional aggregate-role toggles that extend the human-admin user layer without changing existing consumers by default.
 
+user_include_groups: false
 user_include_password: false

--- a/roles/user/tasks/main.yml
+++ b/roles/user/tasks/main.yml
@@ -10,6 +10,14 @@
       tags: [user, user_account]
   tags: [user, user_account, assert, config, validate, user_account_assert, user_account_config, user_account_validate]
 
+- name: "User | Include optional user_groups role"
+  ansible.builtin.include_role:
+    name: user_groups
+    apply:
+      tags: [user, user_groups]
+  when: user_include_groups | default(false)
+  tags: [user, user_groups, assert, config, validate, user_groups_assert, user_groups_config, user_groups_validate]
+
 - name: "User | Include optional user_password role"
   ansible.builtin.include_role:
     name: user_password

--- a/roles/user_groups/README.md
+++ b/roles/user_groups/README.md
@@ -1,0 +1,94 @@
+# roles/user_groups/README.md
+
+Reference for the `user_groups` role.
+Explains how the role enforces supplementary group membership for existing human admin accounts after the base phase on Debian-family hosts in this repository.
+
+## Features
+- Validates a clear per-user supplementary-group inventory structure before making changes
+- Requires target human admin accounts to already exist, typically from `user_account`
+- Merges base, role-declared, and inventory-specific supplementary-group inputs into one effective per-user policy
+- Supports append-versus-explicit supplementary-group behavior per managed user
+- Can optionally create missing supplementary groups when that is intentional
+- Validates the resulting effective supplementary-group state after configuration
+
+## Variables
+
+| Variable | Default | Required | Description |
+|----------|---------|----------|-------------|
+| `user_groups_manage_groups` | `false` | no | If true, create requested supplementary groups before membership enforcement; if false, requested groups must already exist |
+| `user_groups_base_memberships` | `[]` | no | Shared baseline supplementary-group membership definitions owned directly by `user_groups` |
+| `user_groups_role_declared_memberships` | `[]` | no | Supplementary-group membership definitions registered by future roles before `user_groups` runs |
+| `user_groups_additional_memberships` | `[]` | no | Inventory-specific supplementary-group membership definitions appended after the base and role-declared layers |
+| `user_groups_memberships` | merged from the three lists above | no | Effective pre-normalized membership input used internally by the role before duplicate users are merged |
+
+Each membership item in the three input lists above supports:
+
+| Key | Default | Required | Description |
+|-----|---------|----------|-------------|
+| `user` | none | yes | Existing human admin username whose supplementary groups are managed |
+| `groups` | none | yes | Desired supplementary groups for that user |
+| `append` | `true` | no | If true, add the requested groups without removing unmanaged supplementary groups; if false, make supplementary-group membership explicit |
+
+## Usage
+
+Use `user_groups` after `user_account` or another earlier account-creation step has already ensured the target users exist:
+
+```yaml
+- hosts: all
+  become: true
+  roles:
+    - role: user_account
+    - role: user_groups
+      vars:
+        user_groups_memberships:
+          - user: alice
+            groups:
+              - sudo
+              - adm
+              - systemd-journal
+            append: true
+```
+
+Example aggregate-role usage:
+
+```yaml
+- hosts: all
+  become: true
+  vars:
+    user_include_groups: true
+    user_groups_memberships:
+      - user: "{{ user_account_name }}"
+        groups:
+          - sudo
+          - adm
+        append: true
+  roles:
+    - role: user
+```
+
+Aggregation order inside `user_groups` is:
+
+1. `user_groups_base_memberships`
+2. `user_groups_role_declared_memberships`
+3. `user_groups_additional_memberships`
+
+Entries for the same user are merged into one effective membership definition.
+Requested groups are combined uniquely per user while entries remain additive.
+If a later entry for the same user sets `append: false`, it resets the
+effective group list to exactly that entry's groups and takes explicit
+ownership from that point forward.
+
+Keep `append: true` when you want to add known admin groups without removing unrelated memberships created elsewhere.
+Use `append: false` when you want this role to become the explicit owner of the user's full supplementary-group set, including the intentional empty-list case that removes all supplementary groups.
+When `user_groups_manage_groups: false`, every requested group must already exist on the host before the role runs.
+Future role declarations through `user_groups_role_declared_memberships` are additive by default; they do not get automatic stale-membership cleanup on their own the way `base_firewall` cleans up managed live rules.
+Keep user-named primary-group ownership, such as the group that owns the home directory, in `user_account_primary_group`; `user_groups` only manages supplementary groups.
+
+## Dependencies
+None
+
+## Author
+tatbyte
+
+## License
+MIT

--- a/roles/user_groups/defaults/main.yml
+++ b/roles/user_groups/defaults/main.yml
@@ -1,0 +1,30 @@
+---
+# roles/user_groups/defaults/main.yml
+# Default variables for the `user_groups` role.
+# Defines supplementary group membership enforcement for existing human admin accounts after account creation.
+
+# If true, create any requested supplementary groups before enforcing
+# membership. Leave this false when the desired groups should already exist
+# from the base system or another role.
+user_groups_manage_groups: false
+
+# Shared baseline supplementary group memberships enforced for human admin
+# accounts.
+user_groups_base_memberships: []
+
+# Supplementary group memberships declared by other roles before `user_groups`
+# runs.
+user_groups_role_declared_memberships: []
+
+# Extra inventory-specific supplementary group memberships appended after the
+# baseline and role-declared layers.
+user_groups_additional_memberships: []
+
+# Effective supplementary group memberships after the base, role-declared, and
+# additional layers are combined.
+user_groups_memberships: >-
+  {{
+    (user_groups_base_memberships | default([]))
+    + (user_groups_role_declared_memberships | default([]))
+    + (user_groups_additional_memberships | default([]))
+  }}

--- a/roles/user_groups/tasks/assert.yml
+++ b/roles/user_groups/tasks/assert.yml
@@ -1,0 +1,124 @@
+---
+# roles/user_groups/tasks/assert.yml
+# Assert phase tasks for the `user_groups` role.
+# Validates the requested human admin supplementary-group policy before group membership management starts.
+
+- name: "Assert | Validate user_groups variable structure"
+  ansible.builtin.assert:
+    that:
+      - user_groups_manage_groups is boolean
+      - user_groups_base_memberships is sequence
+      - user_groups_base_memberships is not string
+      - user_groups_role_declared_memberships is sequence
+      - user_groups_role_declared_memberships is not string
+      - user_groups_additional_memberships is sequence
+      - user_groups_additional_memberships is not string
+      - user_groups_memberships is sequence
+      - user_groups_memberships is not string
+    fail_msg: >-
+      user_groups_manage_groups must be a boolean and
+      user_groups_base_memberships, user_groups_role_declared_memberships,
+      user_groups_additional_memberships, and user_groups_memberships must be
+      lists
+    quiet: true
+
+- name: "Assert | Validate requested human admin supplementary-group memberships"
+  ansible.builtin.assert:
+    that:
+      - item is mapping
+      - (item.keys() | difference(['user', 'groups', 'append']) | length) == 0
+      - item.user is defined
+      - item.user is string
+      - item.user | trim | length > 0
+      - item.user == (item.user | trim)
+      - item.user is not match('.*\\s+.*')
+      - item.groups is defined
+      - item.groups is sequence
+      - item.groups is not string
+      - (item.groups | map('string') | list | length) == (item.groups | length)
+      - (item.groups | map('trim') | reject('equalto', '') | list | length) == (item.groups | length)
+      - >-
+        (
+          item.groups
+          | select('match', '.*\\s+.*')
+          | list
+          | length
+        ) == 0
+      - (item.groups | unique | list | length) == (item.groups | length)
+      - item.append is not defined or item.append is boolean
+    fail_msg: >-
+      Each user_groups_memberships item must be a mapping with only user,
+      groups, and optional append keys. user must be a non-empty username
+      without whitespace, groups must be a list of unique non-empty group
+      names without whitespace, and append must be a boolean when set
+    quiet: true
+  loop: "{{ user_groups_memberships }}"
+  loop_control:
+    label: "{{ item.user | default('user-membership') }}"
+
+- name: "Assert | Derive Effective Human Admin Supplementary-Group Memberships"
+  ansible.builtin.import_tasks: derive_effective_memberships.yml
+
+- name: "Assert | Collect Existing Human Admin Account Entries For Group Management"
+  ansible.builtin.getent:
+    database: passwd
+    key: "{{ item.user }}"
+  register: user_groups_assert_passwd_lookup
+  changed_when: false
+  failed_when: false
+  loop: "{{ user_groups_effective_memberships }}"
+  loop_control:
+    label: "{{ item.user }}"
+
+- name: "Assert | Validate Human Admin Accounts Exist Before Group Management"
+  ansible.builtin.assert:
+    that:
+      - item.item.user in (item.ansible_facts.getent_passwd | default({}))
+    fail_msg: >-
+      Every user_groups effective user must already exist before the
+      user_groups role manages supplementary groups
+    quiet: true
+  loop: "{{ user_groups_assert_passwd_lookup.results }}"
+  loop_control:
+    label: "{{ item.item.user }}"
+
+- name: "Assert | Derive Requested Supplementary Group List"
+  ansible.builtin.set_fact:
+    user_groups_desired_groups: >-
+      {{
+        user_groups_effective_memberships
+        | map(attribute='groups')
+        | flatten
+        | unique
+        | list
+      }}
+  changed_when: false
+
+- name: "Assert | Collect Requested Supplementary Group Entries When Automatic Group Creation Is Disabled"
+  ansible.builtin.getent:
+    database: group
+    key: "{{ item }}"
+  register: user_groups_assert_group_lookup
+  changed_when: false
+  failed_when: false
+  loop: "{{ user_groups_desired_groups }}"
+  loop_control:
+    label: "{{ item }}"
+  when:
+    - not user_groups_manage_groups | bool
+    - user_groups_desired_groups | length > 0
+
+- name: "Assert | Validate Requested Supplementary Groups Exist When Automatic Group Creation Is Disabled"
+  ansible.builtin.assert:
+    that:
+      - item.item in (item.ansible_facts.getent_group | default({}))
+    fail_msg: >-
+      Every requested user_groups supplementary group must already exist when
+      user_groups_manage_groups is false
+    quiet: true
+  loop: "{{ user_groups_assert_group_lookup.results | default([]) }}"
+  loop_control:
+    label: "{{ item.item }}"
+  when:
+    - not user_groups_manage_groups | bool
+    - user_groups_desired_groups | length > 0

--- a/roles/user_groups/tasks/config.yml
+++ b/roles/user_groups/tasks/config.yml
@@ -1,0 +1,42 @@
+---
+# roles/user_groups/tasks/config.yml
+# Config phase tasks for the `user_groups` role.
+# Ensures requested supplementary groups exist when needed and enforces per-user group membership policy.
+
+- name: "Config | Derive Requested Supplementary Group List"
+  ansible.builtin.import_tasks: derive_effective_memberships.yml
+
+- name: "Config | Derive Requested Supplementary Group List"
+  ansible.builtin.set_fact:
+    user_groups_desired_groups: >-
+      {{
+        user_groups_effective_memberships
+        | map(attribute='groups')
+        | flatten
+        | unique
+        | list
+      }}
+  changed_when: false
+
+- name: "Config | Ensure Requested Supplementary Groups Exist When Automatic Group Creation Is Enabled"
+  ansible.builtin.group:
+    name: "{{ item }}"
+    state: present
+  loop: "{{ user_groups_desired_groups }}"
+  loop_control:
+    label: "{{ item }}"
+  when:
+    - user_groups_manage_groups | bool
+    - user_groups_desired_groups | length > 0
+
+- name: "Config | Enforce Human Admin Supplementary Group Membership"
+  ansible.builtin.user:
+    name: "{{ item.user }}"
+    state: present
+    groups: "{{ item.groups | join(',') }}"
+    append: "{{ item.append | default(true) }}"
+  loop: "{{ user_groups_effective_memberships }}"
+  loop_control:
+    label: "{{ item.user }}"
+  when:
+    - (item.groups | length) > 0 or not (item.append | default(true) | bool)

--- a/roles/user_groups/tasks/derive_effective_memberships.yml
+++ b/roles/user_groups/tasks/derive_effective_memberships.yml
@@ -1,0 +1,33 @@
+---
+# roles/user_groups/tasks/derive_effective_memberships.yml
+# Shared derived-state tasks for the `user_groups` role.
+# Builds the effective per-user supplementary-group policy from the aggregated membership inputs.
+
+- name: "Derive | Build Effective Human Admin Supplementary-Group Memberships"
+  ansible.builtin.set_fact:
+    user_groups_effective_memberships: >-
+      {%- set merged = {} -%}
+      {%- for item in user_groups_memberships -%}
+        {%- set user_name = item.user -%}
+        {%- set current = merged.get(user_name, {'user': user_name, 'groups': [], 'append': true}) -%}
+        {%- set item_groups = item.groups | default([]) -%}
+        {%- set merged_groups = (
+          item_groups
+          if item.append | default(true) | bool == false
+          else ((current.groups | default([])) + item_groups)
+        ) | unique | list -%}
+        {%- set merged_append = (
+          item.append | default(true)
+          if item.append | default(true) | bool == false
+          else current.append | default(true)
+        ) -%}
+        {%- set _ = merged.update({
+          user_name: {
+            'user': user_name,
+            'groups': merged_groups,
+            'append': merged_append,
+          }
+        }) -%}
+      {%- endfor -%}
+      {{ merged | dict2items | map(attribute='value') | list }}
+  changed_when: false

--- a/roles/user_groups/tasks/main.yml
+++ b/roles/user_groups/tasks/main.yml
@@ -1,0 +1,16 @@
+---
+# roles/user_groups/tasks/main.yml
+# Task entrypoint for the `user_groups` role.
+# Imports the assert, config, and validate phase files in order.
+
+- name: Assert
+  ansible.builtin.import_tasks: assert.yml
+  tags: [user_groups, assert, user_groups_assert]
+
+- name: Config
+  ansible.builtin.import_tasks: config.yml
+  tags: [user_groups, config, user_groups_config]
+
+- name: Validate
+  ansible.builtin.import_tasks: validate.yml
+  tags: [user_groups, validate, user_groups_validate]

--- a/roles/user_groups/tasks/validate.yml
+++ b/roles/user_groups/tasks/validate.yml
@@ -1,0 +1,78 @@
+---
+# roles/user_groups/tasks/validate.yml
+# Validate phase tasks for the `user_groups` role.
+# Verifies the resulting supplementary-group state for each managed human admin account after configuration.
+
+- name: "Validate | Derive Effective Human Admin Supplementary-Group Memberships"
+  ansible.builtin.import_tasks: derive_effective_memberships.yml
+
+- name: "Validate | Collect Human Admin Account Entries For Group Validation"
+  ansible.builtin.getent:
+    database: passwd
+    key: "{{ item.user }}"
+  register: user_groups_validate_passwd_lookup
+  changed_when: false
+  failed_when: false
+  loop: "{{ user_groups_effective_memberships }}"
+  loop_control:
+    label: "{{ item.user }}"
+
+- name: "Validate | Collect Effective Group Lists For Managed Human Admin Accounts"
+  ansible.builtin.command:
+    cmd: "id -Gn {{ item.user }}"
+  register: user_groups_validate_all_groups
+  changed_when: false
+  failed_when: false
+  loop: "{{ user_groups_effective_memberships }}"
+  loop_control:
+    label: "{{ item.user }}"
+
+- name: "Validate | Collect Primary Groups For Managed Human Admin Accounts"
+  ansible.builtin.command:
+    cmd: "id -gn {{ item.user }}"
+  register: user_groups_validate_primary_groups
+  changed_when: false
+  failed_when: false
+  loop: "{{ user_groups_effective_memberships }}"
+  loop_control:
+    label: "{{ item.user }}"
+
+- name: "Validate | Verify Human Admin Supplementary Group Membership"
+  vars:
+    user_groups_validate_desired_groups: "{{ item.groups | unique | sort }}"
+    user_groups_validate_primary_group: >-
+      {{
+        user_groups_validate_primary_groups.results[user_groups_membership_index].stdout
+        | trim
+      }}
+    user_groups_validate_actual_supplementary_groups: >-
+      {{
+        (
+          user_groups_validate_all_groups.results[user_groups_membership_index].stdout
+          | trim
+          | split()
+        )
+        | difference([user_groups_validate_primary_group])
+        | unique
+        | sort
+      }}
+  ansible.builtin.assert:
+    that:
+      - item.user in (user_groups_validate_passwd_lookup.results[user_groups_membership_index].ansible_facts.getent_passwd | default({}))
+      - user_groups_validate_all_groups.results[user_groups_membership_index].rc == 0
+      - user_groups_validate_primary_groups.results[user_groups_membership_index].rc == 0
+      - (user_groups_validate_desired_groups | difference(user_groups_validate_actual_supplementary_groups) | length) == 0
+      - >-
+        (
+          item.append | default(true) | bool
+        ) or (
+          user_groups_validate_actual_supplementary_groups == user_groups_validate_desired_groups
+        )
+    fail_msg: >-
+      Validate | Human admin supplementary-group state does not match the
+      requested user_groups policy
+    quiet: true
+  loop: "{{ user_groups_effective_memberships }}"
+  loop_control:
+    label: "{{ item.user }}"
+    index_var: user_groups_membership_index


### PR DESCRIPTION
- Added the `user_groups` role to enforce supplementary group membership for existing human admin accounts.
- Implemented variable structure for managing groups, including base memberships, role-declared memberships, and additional memberships.
- Created tasks for asserting, configuring, and validating group memberships.
- Updated the aggregate `user` role to include `user_groups` as an optional follow-up role.
- Enhanced documentation to cover the new role and its integration with existing user management workflows.
- Added example inventory variables for `user_groups` to demonstrate usage in the example lab. `user_groups` role Fixes #61