### PR TITLE
feat(docker): add aggregate Docker role and engine management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 Release history for `homelab-roles`.
 Documents notable changes across repository structure, roles, examples, and documentation.
 
+## [v2.2.0]
+### Added
+- Added the aggregate `docker` role with explicit include ordering and toggle-based expansion support for Docker-related child roles.
+- Added the standalone `docker_engine` role with full assert/install/config/validate phases for Debian-family Docker engine package installation and daemon enablement.
+- Added Docker example lab coverage through `examples/playbooks/docker.yml`, `examples/inventory/group_vars/all/docker.yml`, and `examples/inventory/group_vars/all/docker_engine.yml`.
+
+### Changed
+- Updated the example post-bootstrap flow so `examples/playbooks/site.yml` now runs `base`, `user`, then `docker`.
+- Added Docker supplementary-group automation that targets both the bootstrap automation account (`bootstrap_user`) and the managed human admin account (`user_account_name`) when present.
+- Kept direct Docker supplementary-group enforcement as the default behavior and made optional `user_groups` registration opt-in instead of default.
+
+### Documentation
+- Updated repository and example documentation to include the new Docker layer, aggregate role descriptions, and the expanded example phase commands.
+
 ## [v2.1.0]
 ### Added
 - Implemented Vault-backed credentials for the bootstrap process, enabling secure handling of sensitive data during initial setup.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The current role set is centered on:
 
 - bootstrap access for the automation account
 - recurring base host configuration and hardening
+- recurring Docker engine setup and access policy
 - recurring human admin account management
 - monitoring-related access primitives
 
@@ -30,6 +31,7 @@ Role implementations, package-management tasks, and example configuration assume
 homelab-roles/
 ├── roles/
 │   ├── base/                  # aggregate base workflow
+│   ├── docker/                # aggregate Docker workflow
 │   ├── user/                  # aggregate human-admin workflow
 │   ├── bootstrap/             # bootstrap-phase automation account setup
 │   ├── monitoring/            # aggregate monitoring workflow
@@ -46,12 +48,13 @@ homelab-roles/
 ## Available Roles
 - `bootstrap`: standalone bootstrap role for initial automation-account setup.
 - `base`: aggregate base-phase role with required foundation plus optional hardening and maintenance child roles.
+- `docker`: aggregate Docker-phase role with Docker-related child roles such as `docker_engine`.
 - `user`: aggregate human-admin role with account baseline plus optional user-environment child roles.
 - `monitoring`: aggregate monitoring namespace currently delegating to focused monitoring child roles.
-- `base_*`, `user_*`, and other standalone roles: focused capabilities grouped by domain and consumed either directly or via aggregate roles.
+- `base_*`, `docker_*`, `user_*`, and other standalone roles: focused capabilities grouped by domain and consumed either directly or via aggregate roles.
 
 Role details live in each role README under `roles/<role>/README.md`.
-Aggregate execution order is documented by, and sourced from, `roles/base/tasks/main.yml` and `roles/user/tasks/main.yml`.
+Aggregate execution order is documented by, and sourced from, `roles/base/tasks/main.yml`, `roles/docker/tasks/main.yml`, and `roles/user/tasks/main.yml`.
 
 ## Consume From Another Repo
 Recommended pattern: add this repository to your infra repository (submodule or vendored checkout), then point `roles_path` to `homelab-roles/roles`.
@@ -86,6 +89,12 @@ Example infra playbook:
   roles:
     - role: user
 
+- name: Apply Docker setup
+  hosts: all
+  become: true
+  roles:
+    - role: docker
+
 - name: Apply monitoring access
   hosts: monitoring_targets
   become: true
@@ -113,9 +122,10 @@ Then run the full post-bootstrap stack:
 ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/site.yml
 ```
 
-Equivalent direct user-phase command:
+Equivalent direct phase commands:
 
 ```sh
+ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/docker.yml
 ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/user.yml
 ```
 
@@ -134,6 +144,7 @@ ansible-playbook playbooks/site.yml
 
 See [examples/README.md](examples/README.md) and [docs/01-examples.md](docs/01-examples.md) for lab details.
 The current example lab intentionally keeps `base_upgrade` and strict `base_needrestart` follow-up enabled, so a base run may fail when pending reboot or service-restart work is detected after upgrades.
+The current example lab enables the aggregate Docker layer after the user phase so Docker engine package, daemon, and group-access behavior are validated once both target accounts exist.
 The current example lab also enables a representative set of optional `user_*` roles so the human-admin layer exercises account access, shell/profile, workspace, and editor/Git workflows; replace example identity values, password material, and demo SSH keys before using the pattern on real hosts.
 
 ## Linting
@@ -159,7 +170,7 @@ See [docs/00-pre-commit.mb](docs/00-pre-commit.mb) for full setup details.
 Core repository docs:
 
 - [docs/01-examples.md](docs/01-examples.md): Example lab layout and execution flow
-- [docs/02-role-workflow.md](docs/02-role-workflow.md): Shared role phase structure and aggregate base-role plus user-role ordering
+- [docs/02-role-workflow.md](docs/02-role-workflow.md): Shared role phase structure and aggregate base-role plus Docker-role plus user-role ordering
 - [docs/03-file-consistency.md](docs/03-file-consistency.md): File header and wording consistency rules
 - [docs/04-firewall-role-integration.md](docs/04-firewall-role-integration.md): How future roles should register firewall rules for `base_firewall`
 - [docs/05-vault.md](docs/05-vault.md): Short Vault guidance for secret-bearing inventory values such as `user_password`

--- a/docs/01-examples.md
+++ b/docs/01-examples.md
@@ -23,12 +23,13 @@ The example assumes Debian-family hosts.
 - `examples/playbooks/bootstrap.yml`: bootstrap-phase playbook.
 - `examples/playbooks/base.yml`: base-phase playbook.
 - `examples/playbooks/user.yml`: user-phase playbook.
-- `examples/playbooks/site.yml`: post-bootstrap entrypoint (`base` then `user`).
+- `examples/playbooks/docker.yml`: Docker-phase playbook.
+- `examples/playbooks/site.yml`: post-bootstrap entrypoint (`base`, `user`, then `docker`).
 - `examples/playbooks/tests/`: optional integration test playbooks.
 
 ## Variable Layout Convention
 
-- Keep aggregate toggles in aggregate files such as `base.yml` and `user.yml`.
+- Keep aggregate toggles in aggregate files such as `base.yml`, `docker.yml`, and `user.yml`.
 - Keep child role inputs in role-scoped files named `<role>.yml`.
 - Use this split consistently so adding a role usually means:
 1. add one toggle in an aggregate file
@@ -53,6 +54,7 @@ Equivalent direct phase runs:
 
 ```bash
 ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/base.yml
+ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/docker.yml
 ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/user.yml
 ```
 

--- a/docs/02-role-workflow.md
+++ b/docs/02-role-workflow.md
@@ -43,7 +43,7 @@ Use only the phases that make sense, but keep `tasks/main.yml` as the stable pha
 
 ## Aggregate Role Conventions
 
-For aggregate roles such as `base` and `user`:
+For aggregate roles such as `base`, `docker`, and `user`:
 
 - Keep execution order explicit with `ansible.builtin.include_role` in `tasks/main.yml`.
 - Keep required baseline roles first, then optional follow-up roles.

--- a/examples/README.md
+++ b/examples/README.md
@@ -16,12 +16,13 @@ Variables and defaults are intentionally simple and should be adapted before pro
 - `playbooks/bootstrap.yml`: bootstrap phase.
 - `playbooks/base.yml`: base phase.
 - `playbooks/user.yml`: user phase.
-- `playbooks/site.yml`: post-bootstrap entrypoint (`base` then `user`).
+- `playbooks/docker.yml`: Docker phase.
+- `playbooks/site.yml`: post-bootstrap entrypoint (`base`, `user`, then `docker`).
 - `playbooks/tests/`: optional integration tests.
 
 ## Variable Conventions
 
-- Keep aggregate toggles in aggregate files (`base.yml`, `user.yml`).
+- Keep aggregate toggles in aggregate files (`base.yml`, `docker.yml`, `user.yml`).
 - Keep role-specific inputs in `<role>.yml`.
 - Add new role coverage by adding a role-scoped file and a toggle, not by rewriting this README.
 
@@ -49,6 +50,7 @@ Direct phase runs:
 
 ```sh
 ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/base.yml
+ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/docker.yml
 ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/user.yml
 ```
 

--- a/examples/inventory/group_vars/all/docker.yml
+++ b/examples/inventory/group_vars/all/docker.yml
@@ -1,0 +1,8 @@
+---
+# examples/inventory/group_vars/all/docker.yml
+# Shared aggregate Docker-role variables for the example lab.
+# Defines the optional aggregate-role toggles for the example Docker layer.
+
+# Keep Docker engine enabled in the example lab so the Docker role installs
+# and configures the engine plus Docker supplementary-group access.
+docker_include_engine: true

--- a/examples/inventory/group_vars/all/docker_engine.yml
+++ b/examples/inventory/group_vars/all/docker_engine.yml
@@ -1,0 +1,28 @@
+---
+# examples/inventory/group_vars/all/docker_engine.yml
+# Shared Docker engine variables for the example lab.
+# Defines Docker package, service, and supplementary-group behavior exercised through the aggregate `docker` role.
+
+# Keep Docker engine management enabled in the example lab.
+docker_engine_enabled: true
+
+# Use Debian-family Docker engine package names.
+docker_engine_packages:
+  - docker.io
+
+# Keep the default Docker daemon service identity.
+docker_engine_service_name: docker
+docker_engine_group_name: docker
+
+# Add both the bootstrap automation account and the example human admin account
+# to the Docker supplementary group when they exist.
+docker_engine_manage_group_memberships: true
+docker_engine_group_members:
+  - "{{ bootstrap_user }}"
+  - "{{ user_account_name }}"
+
+# Keep optional `user_groups` integration disabled in the example lab because
+# the Docker phase runs after the user layer and can enforce memberships
+# directly once both target accounts exist.
+docker_engine_register_user_groups_memberships: false
+docker_engine_user_group_memberships: []

--- a/examples/playbooks/docker.yml
+++ b/examples/playbooks/docker.yml
@@ -1,0 +1,10 @@
+---
+# examples/playbooks/docker.yml
+# Docker phase playbook for the example lab.
+# Connects as the automation account after the user phase and applies the aggregate `docker` role.
+
+- name: Apply docker role after user
+  hosts: all
+  become: true
+  roles:
+    - role: docker

--- a/examples/playbooks/site.yml
+++ b/examples/playbooks/site.yml
@@ -1,10 +1,14 @@
 ---
 # examples/playbooks/site.yml
 # Post-bootstrap entry playbook for the example lab.
-# Imports `base.yml` and `user.yml` so the recurring host baseline and human-admin user layer can be run through a stable entrypoint.
+# Imports `base.yml`, `user.yml`, and `docker.yml` so the recurring host baseline,
+# human-admin user layer, and Docker layer can be run through a stable entrypoint.
 
 - name: Include base playbook
   ansible.builtin.import_playbook: base.yml
 
 - name: Include user playbook
   ansible.builtin.import_playbook: user.yml
+
+- name: Include docker playbook
+  ansible.builtin.import_playbook: docker.yml

--- a/roles/docker/README.md
+++ b/roles/docker/README.md
@@ -1,0 +1,57 @@
+# roles/docker/README.md
+
+Reference for the `docker` role.
+Explains how the aggregate Docker role orchestrates Docker-related host setup roles.
+
+## Features
+
+- Runs a stable Docker-layer workflow through explicit `include_role` tasks.
+- Uses aggregate toggles (`docker_include_*`) to enable optional child roles.
+- Keeps aggregate include tags aligned with child role tags for predictable targeted runs.
+
+## Usage
+
+Use `docker` after `user` so both the automation account and the managed human
+admin account already exist before Docker supplementary-group access is
+applied:
+
+```yaml
+- hosts: all
+  become: true
+  roles:
+    - role: base
+    - role: user
+    - role: docker
+```
+
+Enable optional child roles with aggregate toggles:
+
+```yaml
+docker_include_<role>: true
+```
+
+Keep child-role inputs in matching role-scoped vars using `<role>_*`.
+
+## Ordering and Source Of Truth
+
+- Current include order is defined in `roles/docker/tasks/main.yml`.
+- Keep this README general; update `tasks/main.yml` when adding or reordering child roles.
+
+## Tag Behavior
+
+Aggregate include tasks should expose:
+
+- generic phase tags (`assert`, `install`, `config`, `validate`)
+- aggregate tag (`docker`)
+- child-role tags (`<child_role>`, `<child_role>_validate`, etc.)
+
+This keeps both broad and narrow tagged runs predictable.
+
+## Dependencies
+None
+
+## License
+MIT
+
+## Author
+Tatbyte

--- a/roles/docker/defaults/main.yml
+++ b/roles/docker/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+# roles/docker/defaults/main.yml
+# Default variables for the `docker` role.
+# Defines optional aggregate-role toggles that extend the Docker layer without changing existing consumers by default.
+
+docker_include_engine: true

--- a/roles/docker/meta/main.yml
+++ b/roles/docker/meta/main.yml
@@ -1,0 +1,6 @@
+---
+# roles/docker/meta/main.yml
+# Role metadata for `docker`.
+# Leaves dependencies empty because aggregate Docker-role ordering is defined in `roles/docker/tasks/main.yml`.
+
+dependencies: []

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -1,0 +1,24 @@
+---
+# roles/docker/tasks/main.yml
+# Task entrypoint for the `docker` role.
+# Defines the aggregate Docker-role execution order through explicit role includes.
+
+- name: "Docker | Include optional docker_engine role"
+  ansible.builtin.include_role:
+    name: docker_engine
+    apply:
+      tags: [docker, docker_engine]
+  when: docker_include_engine | default(true)
+  tags:
+    [
+      docker,
+      docker_engine,
+      assert,
+      install,
+      config,
+      validate,
+      docker_engine_assert,
+      docker_engine_install,
+      docker_engine_config,
+      docker_engine_validate,
+    ]

--- a/roles/docker_engine/README.md
+++ b/roles/docker_engine/README.md
@@ -1,0 +1,63 @@
+# roles/docker_engine/README.md
+
+Reference for the `docker_engine` role.
+Explains how the role installs and validates Docker engine plus Docker supplementary-group access on Debian-family hosts.
+
+## Features
+- Installs requested Docker engine packages with APT
+- Ensures the Docker service is enabled and running
+- Ensures the Docker supplementary group exists
+- Adds requested existing users to the Docker supplementary group
+- Optionally registers Docker group memberships for the aggregate `user_groups` role
+- Verifies package, service, and group-membership state after changes
+
+## Variables
+
+| Variable | Default | Required | Description |
+|----------|---------|----------|-------------|
+| `docker_engine_enabled` | `true` | no | Enables Docker engine package/service/group management in this role |
+| `docker_engine_packages` | `['docker.io']` | no | Docker engine package list installed with APT |
+| `docker_engine_service_name` | `docker` | no | Docker service name to enable and start |
+| `docker_engine_group_name` | `docker` | no | Supplementary group used for non-root Docker access |
+| `docker_engine_manage_group_memberships` | `true` | no | Whether this role should add existing users to the Docker supplementary group |
+| `docker_engine_group_members` | de-duplicated `bootstrap_user` / `user_account_name` list with `admin` fallback | no | Existing users that should receive Docker supplementary-group access when present; the default falls back safely for standalone use and removes duplicates |
+| `docker_engine_register_user_groups_memberships` | `false` | no | Whether to append role-declared memberships into `user_groups_role_declared_memberships` |
+| `docker_engine_user_group_memberships` | `[]` | no | Membership entries registered for `user_groups` when optional centralized group enforcement is desired |
+
+## Usage
+
+The aggregate `docker` role can include `docker_engine` when `docker_include_engine: true`.
+Run the Docker layer after the user layer when you want direct Docker
+supplementary-group access applied to both the automation account and the
+managed human admin account in one pass.
+When used standalone, the default member list falls back to `admin` for either
+account variable if the related bootstrap or user role vars are not present.
+
+Direct usage:
+
+```yaml
+- hosts: all
+  become: true
+  roles:
+    - docker_engine
+```
+
+Example variables:
+
+```yaml
+docker_engine_enabled: true
+docker_engine_packages:
+  - docker.io
+docker_engine_group_members:
+  - "{{ bootstrap_user }}"
+  - "{{ user_account_name }}"
+```
+
+## Dependencies
+None
+
+## License
+MIT
+
+## Author
+Tatbyte

--- a/roles/docker_engine/defaults/main.yml
+++ b/roles/docker_engine/defaults/main.yml
@@ -1,0 +1,31 @@
+---
+# roles/docker_engine/defaults/main.yml
+# Default variables for the `docker_engine` role.
+# Defines Docker engine package, service, and user-group integration inputs for Debian-family hosts.
+
+docker_engine_enabled: true
+
+docker_engine_packages:
+  - docker.io
+
+docker_engine_service_name: docker
+docker_engine_group_name: docker
+
+# If true, ensure Docker supplementary-group membership for existing users.
+docker_engine_manage_group_memberships: true
+docker_engine_group_members: >-
+  {{
+    [
+      (bootstrap_user | default('admin')),
+      (user_account_name | default('admin'))
+    ]
+    | map('trim')
+    | reject('equalto', '')
+    | unique
+    | list
+  }}
+
+# If true, register Docker group memberships for `user_groups` instead of
+# relying only on direct group enforcement in this role.
+docker_engine_register_user_groups_memberships: false
+docker_engine_user_group_memberships: []

--- a/roles/docker_engine/tasks/assert.yml
+++ b/roles/docker_engine/tasks/assert.yml
@@ -1,0 +1,59 @@
+---
+# roles/docker_engine/tasks/assert.yml
+# Assert phase tasks for the `docker_engine` role.
+# Validates Docker package, service, group, and supplementary-group registration inputs before setup starts.
+
+- name: "Assert | Validate docker_engine variable structure"
+  ansible.builtin.assert:
+    that:
+      - docker_engine_enabled is boolean
+      - docker_engine_packages is sequence
+      - docker_engine_packages is not string
+      - docker_engine_service_name is string
+      - docker_engine_service_name | trim | length > 0
+      - docker_engine_group_name is string
+      - docker_engine_group_name | trim | length > 0
+      - docker_engine_manage_group_memberships is boolean
+      - docker_engine_group_members is sequence
+      - docker_engine_group_members is not string
+      - docker_engine_register_user_groups_memberships is boolean
+      - docker_engine_user_group_memberships is sequence
+      - docker_engine_user_group_memberships is not string
+      - (docker_engine_packages | map('string') | list | length) == (docker_engine_packages | length)
+      - (docker_engine_packages | map('trim') | reject('equalto', '') | list | length) == (docker_engine_packages | length)
+      - (docker_engine_group_members | map('string') | list | length) == (docker_engine_group_members | length)
+      - (docker_engine_group_members | map('trim') | reject('equalto', '') | list | length) == (docker_engine_group_members | length)
+      - (docker_engine_group_members | unique | list | length) == (docker_engine_group_members | length)
+      - >-
+        (
+          docker_engine_user_group_memberships | length
+        ) == 0 or (
+          (docker_engine_user_group_memberships | map('type_debug') | unique | list) == ['dict']
+        )
+    fail_msg: >-
+      docker_engine_enabled and docker_engine_manage_group_memberships must be booleans,
+      docker_engine_packages and docker_engine_group_members must be lists of unique
+      non-empty strings, docker_engine_service_name and docker_engine_group_name must
+      be non-empty strings, and docker_engine_user_group_memberships must be a list of mappings
+    quiet: true
+
+- name: "Assert | Validate requested user_groups registration structure"
+  ansible.builtin.assert:
+    that:
+      - item.user is defined
+      - item.user is string
+      - item.user | trim | length > 0
+      - item.groups is defined
+      - item.groups is sequence
+      - item.groups is not string
+      - (item.groups | map('string') | list | length) == (item.groups | length)
+      - (item.groups | map('trim') | reject('equalto', '') | list | length) == (item.groups | length)
+      - (item.groups | unique | list | length) == (item.groups | length)
+      - item.append is not defined or item.append is boolean
+    fail_msg: >-
+      Each docker_engine_user_group_memberships entry must include a non-empty user,
+      a list of unique non-empty groups, and optional boolean append
+    quiet: true
+  loop: "{{ docker_engine_user_group_memberships }}"
+  loop_control:
+    label: "{{ item.user | default('docker-membership') }}"

--- a/roles/docker_engine/tasks/config.yml
+++ b/roles/docker_engine/tasks/config.yml
@@ -1,0 +1,57 @@
+---
+# roles/docker_engine/tasks/config.yml
+# Config phase tasks for the `docker_engine` role.
+# Ensures the Docker group exists, registers user_groups memberships, applies direct group membership for existing users, and enables the Docker service.
+
+- name: "Config | Ensure Docker supplementary group exists"
+  ansible.builtin.group:
+    name: "{{ docker_engine_group_name }}"
+    state: present
+  when: docker_engine_enabled | bool
+
+- name: "Config | Register user supplementary groups" # noqa: var-naming[no-role-prefix]
+  ansible.builtin.set_fact:
+    user_groups_role_declared_memberships: >-
+      {{
+        (user_groups_role_declared_memberships | default([]))
+        + (docker_engine_user_group_memberships | default([]))
+      }}
+  when:
+    - docker_engine_enabled | bool
+    - docker_engine_register_user_groups_memberships | bool
+
+- name: "Config | Collect existing user entries for Docker supplementary-group management"
+  ansible.builtin.getent:
+    database: passwd
+    key: "{{ item }}"
+  register: docker_engine_config_passwd_lookup
+  changed_when: false
+  failed_when: false
+  loop: "{{ docker_engine_group_members }}"
+  loop_control:
+    label: "{{ item }}"
+  when:
+    - docker_engine_enabled | bool
+    - docker_engine_manage_group_memberships | bool
+    - docker_engine_group_members | length > 0
+
+- name: "Config | Ensure Docker supplementary-group membership for existing users"
+  ansible.builtin.user:
+    name: "{{ item.item }}"
+    state: present
+    groups: "{{ docker_engine_group_name }}"
+    append: true
+  loop: "{{ docker_engine_config_passwd_lookup.results | default([]) }}"
+  loop_control:
+    label: "{{ item.item }}"
+  when:
+    - docker_engine_enabled | bool
+    - docker_engine_manage_group_memberships | bool
+    - item.item in (item.ansible_facts.getent_passwd | default({}))
+
+- name: "Config | Ensure Docker engine service is enabled and running"
+  ansible.builtin.service:
+    name: "{{ docker_engine_service_name }}"
+    enabled: true
+    state: started
+  when: docker_engine_enabled | bool

--- a/roles/docker_engine/tasks/install.yml
+++ b/roles/docker_engine/tasks/install.yml
@@ -1,0 +1,14 @@
+---
+# roles/docker_engine/tasks/install.yml
+# Install phase tasks for the `docker_engine` role.
+# Ensures the requested Docker engine packages are installed with APT when Docker is enabled.
+
+- name: "Install | Ensure requested Docker engine packages are present"
+  ansible.builtin.apt:
+    name: "{{ docker_engine_packages }}"
+    state: present
+    update_cache: true
+    cache_valid_time: 3600
+  when:
+    - docker_engine_enabled | bool
+    - docker_engine_packages | length > 0

--- a/roles/docker_engine/tasks/main.yml
+++ b/roles/docker_engine/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+# roles/docker_engine/tasks/main.yml
+# Task entrypoint for the `docker_engine` role.
+# Imports the assert, install, config, and validate phase files in order.
+
+- name: Assert
+  ansible.builtin.import_tasks: assert.yml
+  tags: [assert, docker_engine, docker_engine_assert]
+
+- name: Install
+  ansible.builtin.import_tasks: install.yml
+  tags: [install, docker_engine, docker_engine_install]
+
+- name: Config
+  ansible.builtin.import_tasks: config.yml
+  tags: [config, docker_engine, docker_engine_config]
+
+- name: Validate
+  ansible.builtin.import_tasks: validate.yml
+  tags: [validate, docker_engine, docker_engine_validate]

--- a/roles/docker_engine/tasks/validate.yml
+++ b/roles/docker_engine/tasks/validate.yml
@@ -1,0 +1,76 @@
+---
+# roles/docker_engine/tasks/validate.yml
+# Validate phase tasks for the `docker_engine` role.
+# Verifies Docker package state, service state, and requested supplementary-group membership for existing users when enabled.
+
+- name: "Validate | Gather package facts"
+  ansible.builtin.package_facts:
+    manager: auto
+  when: docker_engine_enabled | bool
+
+- name: "Validate | Gather service facts"
+  ansible.builtin.service_facts:
+  when: docker_engine_enabled | bool
+
+- name: "Validate | Collect existing user entries for Docker group validation"
+  ansible.builtin.getent:
+    database: passwd
+    key: "{{ item }}"
+  register: docker_engine_validate_passwd_lookup
+  changed_when: false
+  failed_when: false
+  loop: "{{ docker_engine_group_members }}"
+  loop_control:
+    label: "{{ item }}"
+  when:
+    - docker_engine_enabled | bool
+    - docker_engine_manage_group_memberships | bool
+    - docker_engine_group_members | length > 0
+
+- name: "Validate | Collect effective group lists for Docker-managed existing users"
+  ansible.builtin.command:
+    cmd: "id -Gn {{ item.item }}"
+  register: docker_engine_validate_groups
+  changed_when: false
+  failed_when: false
+  loop: "{{ docker_engine_validate_passwd_lookup.results | default([]) }}"
+  loop_control:
+    label: "{{ item.item }}"
+  when:
+    - docker_engine_enabled | bool
+    - docker_engine_manage_group_memberships | bool
+    - item.item in (item.ansible_facts.getent_passwd | default({}))
+
+- name: "Validate | Assert Docker engine state"
+  vars:
+    docker_engine_service_unit: >-
+      {{
+        docker_engine_service_name
+        if docker_engine_service_name.endswith('.service')
+        else (docker_engine_service_name ~ '.service')
+      }}
+  ansible.builtin.assert:
+    that:
+      - (docker_engine_packages | difference(ansible_facts.packages.keys() | list) | length) == 0
+      - docker_engine_service_unit in ansible_facts.services
+      - ansible_facts.services[docker_engine_service_unit].status in ['enabled', 'enabled-runtime']
+      - ansible_facts.services[docker_engine_service_unit].state == 'running'
+    fail_msg: >-
+      Configured Docker engine state does not match the requested docker_engine values
+    quiet: true
+  when: docker_engine_enabled | bool
+
+- name: "Validate | Assert Docker supplementary-group membership for existing users"
+  ansible.builtin.assert:
+    that:
+      - docker_engine_group_name in (item.stdout | trim | split())
+    fail_msg: >-
+      Docker supplementary-group membership does not match requested docker_engine_group_members
+    quiet: true
+  loop: "{{ docker_engine_validate_groups.results | default([]) }}"
+  loop_control:
+    label: "{{ item.item.item }}"
+  when:
+    - docker_engine_enabled | bool
+    - docker_engine_manage_group_memberships | bool
+    - item.rc == 0


### PR DESCRIPTION
- Introduced the aggregate `docker` role with support for child roles.
- Added `docker_engine` role for managing Docker installation and configuration.
- Updated playbooks and documentation to include Docker phase.
- Enhanced example lab coverage with Docker-related configurations.