### PR TITLE
feat(docker_adguard): Implement initial role structure with configuration, validation, and installation tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,15 +3,25 @@
 Release history for `homelab-roles`.
 Documents notable changes across repository structure, roles, examples, and documentation.
 
-## [v2.3.0]
+## [v2.4.0]
 ### Added
-- Added managed Docker daemon JSON defaults (`/etc/docker/daemon.json`), `srv_traefik`/`access_traefik` conventions, `/srv/<service>/data` backup paths, and standalone `docker_traefik` with Compose-managed Traefik, dashboard-only dynamic config, DNS-01 ACME, and Vault-based scaffolding.
+- Added standalone `docker_adguard` with Compose-managed AdGuard Home, Traefik proxy-network integration, role-owned service/access identities, Vault-backed admin inputs, and backup-friendly `/srv/adguard` host paths.
 
 ### Changed
-- Added `docker_traefik` service user/group behavior, aligned engine/Traefik example vars with the new defaults, added a base-firewall managed-rule cleanup guard (`base_firewall_remove_stale_managed_rules: false`), and moved the example Docker playbook flow to support reapplying firewall after Docker service declarations.
+- Updated the example Docker layer to include AdGuard coverage, moved the example AdGuard lab to a non-default host DNS port, split host-published versus container-internal DNS listener ports for Traefik-backed downstream services, and changed AdGuard config handling to merge role-owned settings into the live config while preserving AdGuard-managed fields for idempotent reruns.
 
 ### Documentation
-- Updated Docker role docs and example docs for daemon JSON management, Traefik access-group behavior, and standardized external Vault workflow (`~/.config/ansible/vault.yml` + `~/.config/ansible/vault.pass`).
+- Added Docker downstream-service guidance for Traefik-connected services and updated Docker docs/examples to cover the AdGuard role, Compose-label routing, and host-versus-container port modeling.
+
+## [v2.3.0]
+### Added
+- Added managed Docker daemon JSON defaults (`/etc/docker/daemon.json`), `srv_*`/`access_*` Docker service conventions, `/srv/<service>/data` backup paths, and standalone `docker_traefik` with Compose-managed Traefik integration over the shared proxy network.
+
+### Changed
+- Added service user/group behavior for the Docker service roles, aligned engine and Traefik example vars with the new defaults, added a base-firewall managed-rule cleanup guard (`base_firewall_remove_stale_managed_rules: false`), and kept the Docker playbook flow ready to reapply firewall state after Docker service declarations.
+
+### Documentation
+- Updated Docker role docs and example docs for daemon JSON management, Traefik proxy-network behavior, and standardized external Vault workflow (`~/.config/ansible/vault.yml` + `~/.config/ansible/vault.pass`).
 
 ## [v2.2.0]
 ### Added

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ homelab-roles/
 ## Available Roles
 - `bootstrap`: standalone bootstrap role for initial automation-account setup.
 - `base`: aggregate base-phase role with required foundation plus optional hardening and maintenance child roles.
-- `docker`: aggregate Docker-phase role with Docker-related child roles such as `docker_engine`.
+- `docker`: aggregate Docker-phase role with Docker-related child roles such as `docker_engine`, `docker_traefik`, and `docker_adguard`.
 - `user`: aggregate human-admin role with account baseline plus optional user-environment child roles.
 - `monitoring`: aggregate monitoring namespace currently delegating to focused monitoring child roles.
 - `base_*`, `docker_*`, `user_*`, and other standalone roles: focused capabilities grouped by domain and consumed either directly or via aggregate roles.
@@ -176,6 +176,7 @@ Core repository docs:
 - [docs/05-vault.md](docs/05-vault.md): Short Vault guidance for secret-bearing inventory values such as `user_password`
 - [docs/06-user-groups-role-integration.md](docs/06-user-groups-role-integration.md): How future roles should register human admin supplementary-group needs for `user_groups`
 - [docs/07-docker-role-conventions.md](docs/07-docker-role-conventions.md): Shared Docker daemon, access-group, and backup-path conventions
+- [docs/08-docker-traefik-downstream-services.md](docs/08-docker-traefik-downstream-services.md): How future Docker service roles should join Traefik, publish direct host ports, and split host-versus-container listeners safely
 
 ## License
 MIT

--- a/docs/01-examples.md
+++ b/docs/01-examples.md
@@ -78,5 +78,8 @@ ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/tests/<t
 - The Docker example keeps service projects under `/srv/<service>` and
   persistent data under `/srv/<service>/data` so backup and restore behavior
   stays aligned with the repository Docker conventions.
+- The Docker example can also layer downstream services onto the shared
+  Traefik proxy network, so service roles such as `docker_adguard` can expose
+  web UIs through Compose labels while still keeping host data under `/srv`.
 - Example values are intentionally demo-friendly; replace identity, password, and key material before production use.
 - Keep role-specific behavior documentation in each role README so this example guide stays stable as roles are added.

--- a/docs/07-docker-role-conventions.md
+++ b/docs/07-docker-role-conventions.md
@@ -36,3 +36,13 @@ rebuilds, backups, and access control stay predictable across services.
   `/var/lib/docker` when practical.
 - This keeps Restic backup scope simple because `/srv` can be backed up and
   restored before Ansible re-applies the host configuration.
+
+## Traefik-Managed Service Conventions
+
+- Downstream service roles that publish HTTP or HTTPS through Traefik should
+  join the stable external proxy network created by `docker_traefik`.
+- Prefer Docker Compose labels for Traefik router and service metadata when the
+  service only needs its own HTTP routing, instead of adding more file-provider
+  config under the Traefik role.
+- Keep the shared network name explicit in role vars so the service can follow
+  the same proxy-network contract in both the example lab and consumer repos.

--- a/docs/08-docker-traefik-downstream-services.md
+++ b/docs/08-docker-traefik-downstream-services.md
@@ -1,0 +1,167 @@
+# docs/08-docker-traefik-downstream-services.md
+
+Reference for Docker services that sit behind `docker_traefik`.
+Explains how future Docker service roles should join the shared Traefik proxy
+network, when to use Compose labels, and how to model host-versus-container
+ports for services that also expose non-HTTP listeners such as DNS.
+
+## Purpose
+
+Some Docker services in this repository need two different access paths:
+
+- an HTTP or HTTPS web UI published through Traefik
+- a separate non-HTTP service published directly on the host
+
+`docker_adguard` is the current example:
+
+- the web UI is published through Traefik
+- DNS is published directly from the container to a host port
+
+This pattern is useful for future services that have both:
+
+- a browser-facing admin UI
+- a second protocol Traefik does not proxy in the current role model
+
+## Network Pattern
+
+Use the Traefik-owned external Docker network for the web UI path.
+
+The downstream service Compose file should:
+
+1. join the external proxy network created by `docker_traefik`
+2. set Traefik router and service labels on its own container
+3. avoid adding more Traefik file-provider config unless the service really
+   needs shared Traefik-side middleware or a non-label routing pattern
+
+Example shape:
+
+```yaml
+services:
+  app:
+    networks:
+      - proxy
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network={{ docker_traefik_network_name }}"
+      - "traefik.http.routers.app.rule=Host(`app.example.com`)"
+      - "traefik.http.routers.app.entrypoints=websecure"
+      - "traefik.http.routers.app.tls=true"
+      - "traefik.http.routers.app.tls.certresolver=letsencrypt"
+      - "traefik.http.services.app.loadbalancer.server.port=3000"
+
+networks:
+  proxy:
+    external: true
+    name: "{{ docker_traefik_network_name }}"
+```
+
+This keeps each service role self-contained while still reusing the shared
+Traefik reverse proxy.
+
+## Host Port Versus Container Port
+
+When the service also exposes a non-HTTP port directly on the host, keep the
+host port and the container-internal port as separate variables.
+
+This is the key rule.
+
+Do not reuse one variable for both sides of the mapping unless they are
+intentionally always the same.
+
+Example:
+
+```yaml
+app_host_dns_port: 5353
+app_container_dns_port: 53
+```
+
+Then render the files like this:
+
+```yaml
+ports:
+  - "{{ app_host_dns_port }}:{{ app_container_dns_port }}/tcp"
+  - "{{ app_host_dns_port }}:{{ app_container_dns_port }}/udp"
+```
+
+```yaml
+dns:
+  port: {{ app_container_dns_port }}
+```
+
+Why this matters:
+
+- the host may need a non-default port in the example lab because something
+  else already binds the standard port
+- the application inside the container often still expects its standard
+  protocol port
+- using one variable for both can make Docker publish one port while the app
+  listens on another
+
+`docker_adguard` uses this exact split:
+
+- `docker_adguard_dns_bind_port`: host-published port
+- `docker_adguard_container_dns_port`: internal AdGuard DNS listener port
+
+## Firewall Pattern
+
+If the downstream service exposes a direct host port, register firewall rules
+through `base_firewall_role_declared_rules`.
+
+Use the host-published port for firewall rules, not the container-internal
+port.
+
+Example:
+
+```yaml
+app_manage_firewall_rules: true
+app_firewall_rules:
+  - rule: allow
+    direction: in
+    port: "{{ app_host_dns_port | string }}"
+    proto: tcp
+    comment: "managed:app:dns-tcp"
+  - rule: allow
+    direction: in
+    port: "{{ app_host_dns_port | string }}"
+    proto: udp
+    comment: "managed:app:dns-udp"
+```
+
+Then have the role append those rules during config, and run `base_firewall`
+after the service role if you want UFW to enforce them in the same playbook
+flow.
+
+## When To Use This Pattern
+
+Use this Traefik-plus-direct-port pattern when:
+
+- the service has a web UI that fits normal HTTP or HTTPS reverse proxying
+- the service also exposes another protocol directly to clients
+- the direct protocol should remain bind-mounted and backup-friendly under
+  `/srv/<service>/data`
+
+Examples that fit this model:
+
+- DNS services
+- web apps with additional TCP or UDP listener ports
+- admin tools that have both a browser UI and a direct client protocol
+
+## When Not To Use It
+
+Do not use this pattern when:
+
+- the service only needs HTTP or HTTPS
+  then use Traefik labels only and skip direct host ports
+- the service must own the full host network stack
+  then a host-network design may be more appropriate, but that is a different
+  convention than the current `docker_adguard` role
+
+## Summary
+
+For future Docker roles that behave like `docker_adguard`:
+
+- join the shared Traefik proxy network
+- publish the web UI with Compose labels
+- keep host ports and container ports separate variables
+- register firewall rules for the host-published port only
+- keep service data under `/srv/<service>/data`

--- a/examples/README.md
+++ b/examples/README.md
@@ -72,6 +72,9 @@ ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/tests/<t
 - The Docker example keeps service projects under `/srv/<service>` and
   persistent service data under `/srv/<service>/data` so backup-friendly host
   restores stay predictable.
+- The Docker example can optionally layer downstream services onto the shared
+  Traefik proxy network, so roles such as `docker_adguard` can publish web UIs
+  through Compose labels without adding more Traefik file-provider config.
 - Replace demo identity, password, and SSH key values before using these patterns outside a lab.
 
 ## Extending

--- a/examples/inventory/examples/vault.yml.example
+++ b/examples/inventory/examples/vault.yml.example
@@ -39,3 +39,14 @@ vault_docker_traefik_dns_api_token: "replace-me"
 # Generate hashes with `htpasswd -nB <user>`.
 vault_docker_traefik_dashboard_basic_auth_users:
   - "admin:replace-me-with-htpasswd-hash"
+
+# ---------------------------------------------------------------------------
+# docker_adguard
+# ---------------------------------------------------------------------------
+
+# Example host name used by the AdGuard web router.
+vault_docker_adguard_host: "adguard.example.com"
+
+# Example AdGuard Home admin password hash.
+# Use an AdGuard-compatible bcrypt hash here.
+vault_docker_adguard_admin_password_hash: "$2a$10$replace-me"

--- a/examples/inventory/group_vars/all/docker.yml
+++ b/examples/inventory/group_vars/all/docker.yml
@@ -10,3 +10,8 @@ docker_include_engine: true
 # Keep the Traefik reverse proxy enabled in the example lab so the Docker role
 # also exercises a Compose-managed service workload.
 docker_include_traefik: true
+
+# Keep AdGuard enabled in the example lab so the Docker layer also exercises a
+# Traefik-connected downstream service that binds the host DNS port and joins
+# the shared proxy network after Traefik.
+docker_include_adguard: true

--- a/examples/inventory/group_vars/all/docker_adguard.yml
+++ b/examples/inventory/group_vars/all/docker_adguard.yml
@@ -1,0 +1,79 @@
+---
+# examples/inventory/group_vars/all/docker_adguard.yml
+# Shared Docker AdGuard variables for the example lab.
+# Defines the AdGuard Home Compose, Traefik proxy-network, service identity,
+# admin-auth, and DNS firewall behavior exercised through the aggregate
+# `docker` role.
+
+# Keep the AdGuard role internally enabled when the aggregate toggle turns it
+# on for the example lab.
+docker_adguard_enabled: true
+
+# Let the role auto-detect a working Compose support package for the host.
+docker_adguard_packages: []
+
+# Keep the example AdGuard project under `/srv` so backup and host-restore
+# workflows can capture the whole service layout predictably.
+docker_adguard_project_dir: /srv/adguard
+docker_adguard_data_dir: "{{ docker_adguard_project_dir }}/data"
+docker_adguard_compose_project_name: adguard
+docker_adguard_compose_service_name: adguard
+docker_adguard_container_name: adguard
+docker_adguard_image: adguard/adguardhome:v0.107.65
+docker_adguard_service_user: srv_adguard
+docker_adguard_service_uid: 1210
+docker_adguard_access_group: access_adguard
+docker_adguard_access_gid: 1210
+docker_adguard_service_user_shell: /usr/sbin/nologin
+docker_adguard_manage_access_group_memberships: true
+docker_adguard_access_group_members: >-
+  {{
+    [
+      bootstrap_user,
+      user_account_name
+    ]
+    | map('trim')
+    | reject('equalto', '')
+    | unique
+    | list
+  }}
+
+# Join the Traefik-owned proxy network and publish the AdGuard web UI through
+# Compose labels instead of Traefik file-provider dynamic config.
+docker_adguard_proxy_network_name: "{{ docker_traefik_network_name }}"
+docker_adguard_host: "{{ vault_docker_adguard_host }}"
+docker_adguard_router_name: adguard
+docker_adguard_router_entrypoints:
+  - websecure
+docker_adguard_tls_certresolver: "{{ docker_traefik_certresolver_name | default('letsencrypt') }}"
+
+# Keep the AdGuard Home admin account managed from Vault-backed input so the
+# example can start without an interactive setup wizard.
+docker_adguard_admin_user: admin
+docker_adguard_admin_password_hash: "{{ vault_docker_adguard_admin_password_hash }}"
+
+# Keep the example DNS listener off the host's standard port because local
+# Debian-family lab hosts often already have a resolver bound to `53`.
+docker_adguard_dns_bind_port: 5353
+docker_adguard_container_dns_port: 53
+docker_adguard_upstream_dns:
+  - https://dns10.quad9.net/dns-query
+  - https://dns.quad9.net/dns-query
+docker_adguard_bootstrap_dns:
+  - 9.9.9.10
+  - 149.112.112.10
+
+# Register DNS firewall rules so the follow-up base_firewall run in the Docker
+# playbook can enforce them after this role has declared them.
+docker_adguard_manage_firewall_rules: true
+docker_adguard_firewall_rules:
+  - rule: allow
+    direction: in
+    port: "{{ docker_adguard_dns_bind_port | string }}"
+    proto: tcp
+    comment: "managed:docker_adguard:dns-tcp"
+  - rule: allow
+    direction: in
+    port: "{{ docker_adguard_dns_bind_port | string }}"
+    proto: udp
+    comment: "managed:docker_adguard:dns-udp"

--- a/roles/docker/defaults/main.yml
+++ b/roles/docker/defaults/main.yml
@@ -5,3 +5,4 @@
 
 docker_include_engine: true
 docker_include_traefik: false
+docker_include_adguard: false

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -42,3 +42,23 @@
       docker_traefik_config,
       docker_traefik_validate,
     ]
+
+- name: "Docker | Include optional docker_adguard role"
+  ansible.builtin.include_role:
+    name: docker_adguard
+    apply:
+      tags: [docker, docker_adguard]
+  when: docker_include_adguard | default(false)
+  tags:
+    [
+      docker,
+      docker_adguard,
+      assert,
+      install,
+      config,
+      validate,
+      docker_adguard_assert,
+      docker_adguard_install,
+      docker_adguard_config,
+      docker_adguard_validate,
+    ]

--- a/roles/docker_adguard/README.md
+++ b/roles/docker_adguard/README.md
@@ -1,0 +1,113 @@
+# roles/docker_adguard/README.md
+
+Reference for the `docker_adguard` role.
+Explains how the role manages AdGuard Home through Docker Compose with a
+Traefik-connected proxy-network deployment, role-owned access identities, and
+`/srv`-based persistence on Debian-family hosts.
+
+## Features
+- Installs requested or auto-detected Docker Compose support packages with APT
+- Creates a role-owned service user and feature access group for AdGuard host files
+- Adds requested existing admin users to the role-owned AdGuard access group
+- Manages a Docker Compose AdGuard Home project under a fixed `/srv` project directory
+- Bootstraps `AdGuardHome.yaml` from a Jinja template on first run, then merges later role-owned setting updates while preserving unrelated AdGuard-managed fields and non-managed users
+- Renders a Docker Compose file that publishes Traefik routing through Compose labels
+- Reuses the external Traefik proxy network so the web UI stays behind the reverse proxy
+- Optionally registers managed DNS firewall rules for TCP and UDP on the configured host DNS port
+- Verifies package, rendered-file, network, and running service state after changes
+
+## Variables
+
+| Variable | Default | Required | Description |
+|----------|---------|----------|-------------|
+| `docker_adguard_enabled` | `true` | no | Enables AdGuard package, file, and Docker Compose management |
+| `docker_adguard_packages` | `[]` | no | Explicit package list installed to support `docker compose`; when empty, the role auto-detects an available package |
+| `docker_adguard_project_dir` | `/srv/adguard` | no | Directory that stores the managed Compose project files |
+| `docker_adguard_data_dir` | `/srv/adguard/data` | no | Directory that stores AdGuard persistent data for backup-friendly restores |
+| `docker_adguard_service_user` | `srv_adguard` | no | Role-owned service user that owns AdGuard data paths on the host |
+| `docker_adguard_access_group` | `access_adguard` | no | Role-owned feature access group used for AdGuard host access |
+| `docker_adguard_access_group_members` | de-duplicated `bootstrap_user` / `user_account_name` list with `admin` fallback | no | Existing admin users that should receive AdGuard host access when present |
+| `docker_adguard_proxy_network_name` | `docker_traefik_network_name` or `traefik_proxy` fallback | no | External Docker network name created by Traefik and joined by AdGuard |
+| `docker_adguard_host` | `adguard.example.com` | yes | Host name used by the Traefik router labels for the AdGuard web UI |
+| `docker_adguard_admin_user` | `admin` | no | Admin account name written into the managed AdGuard configuration |
+| `docker_adguard_admin_password_hash` | `''` | yes | AdGuard-compatible bcrypt hash for the managed admin account |
+| `docker_adguard_dns_bind_port` | `53` | no | Host DNS port published by the AdGuard container for TCP and UDP |
+| `docker_adguard_container_dns_port` | `53` | no | Internal DNS port that AdGuard listens on inside the container |
+| `docker_adguard_manage_firewall_rules` | `true` | no | Whether to register managed DNS firewall rules |
+
+## Usage
+
+The aggregate `docker` role can include `docker_adguard` when
+`docker_include_adguard: true`.
+Run it after `docker_traefik` so the shared external proxy network already
+exists before AdGuard Compose startup.
+
+Direct usage:
+
+```yaml
+- hosts: all
+  become: true
+  roles:
+    - docker_engine
+    - docker_traefik
+    - docker_adguard
+```
+
+Minimal example variables:
+
+```yaml
+docker_adguard_project_dir: /srv/adguard
+docker_adguard_service_user: srv_adguard
+docker_adguard_access_group: access_adguard
+docker_adguard_access_group_members: >-
+  {{
+    [
+      bootstrap_user,
+      user_account_name
+    ]
+    | map('trim')
+    | reject('equalto', '')
+    | unique
+    | list
+  }}
+docker_adguard_proxy_network_name: "{{ docker_traefik_network_name }}"
+docker_adguard_host: adguard.example.com
+docker_adguard_admin_password_hash: "{{ vault_docker_adguard_admin_password_hash }}"
+docker_adguard_dns_bind_port: 5353
+docker_adguard_container_dns_port: 53
+docker_adguard_firewall_rules:
+  - rule: allow
+    direction: in
+    port: "{{ docker_adguard_dns_bind_port | string }}"
+    proto: tcp
+    comment: "managed:docker_adguard:dns-tcp"
+  - rule: allow
+    direction: in
+    port: "{{ docker_adguard_dns_bind_port | string }}"
+    proto: udp
+    comment: "managed:docker_adguard:dns-udp"
+```
+
+This role keeps Traefik routing local to the AdGuard Compose file through
+service labels, so no extra Traefik file-provider dynamic config is needed for
+the AdGuard web UI.
+
+Keep persistent service data under `{{ docker_adguard_project_dir }}/data` so
+backups of `/srv` capture the full AdGuard host-side state needed for host
+recreation.
+
+## Firewall Integration
+
+This role registers DNS firewall rules into `base_firewall_role_declared_rules`
+when `docker_adguard_manage_firewall_rules: true`.
+If you use `base_firewall`, re-run that role after `docker_adguard` has
+registered its rules, or run the AdGuard role before `base_firewall`.
+
+## Dependencies
+None
+
+## License
+MIT
+
+## Author
+Tatbyte

--- a/roles/docker_adguard/defaults/main.yml
+++ b/roles/docker_adguard/defaults/main.yml
@@ -1,0 +1,79 @@
+---
+# roles/docker_adguard/defaults/main.yml
+# Default variables for the `docker_adguard` role.
+# Defines Docker Compose, AdGuard Home, Traefik proxy-network, service-identity,
+# admin-auth, and optional firewall inputs for a Debian-family host.
+
+docker_adguard_enabled: true
+
+docker_adguard_packages: []
+docker_adguard_compose_package_candidates:
+  - docker-compose-plugin
+  - docker-compose-v2
+
+docker_adguard_project_dir: /srv/adguard
+docker_adguard_data_dir: "{{ docker_adguard_project_dir }}/data"
+docker_adguard_work_dir: "{{ docker_adguard_data_dir }}/work"
+docker_adguard_conf_dir: "{{ docker_adguard_data_dir }}/conf"
+docker_adguard_config_path: "{{ docker_adguard_conf_dir }}/AdGuardHome.yaml"
+docker_adguard_compose_project_name: adguard
+docker_adguard_compose_service_name: adguard
+docker_adguard_container_name: adguard
+docker_adguard_image: adguard/adguardhome:v0.107.65
+docker_adguard_docker_service_name: "{{ docker_engine_service_name | default('docker') }}"
+docker_adguard_service_user: srv_adguard
+docker_adguard_service_uid: 1160
+docker_adguard_access_group: access_adguard
+docker_adguard_access_gid: 1160
+docker_adguard_service_user_shell: /usr/sbin/nologin
+docker_adguard_manage_access_group_memberships: true
+docker_adguard_access_group_members: >-
+  {{
+    [
+      (bootstrap_user | default('admin')),
+      (user_account_name | default('admin'))
+    ]
+    | map('trim')
+    | reject('equalto', '')
+    | unique
+    | list
+  }}
+
+docker_adguard_compose_file_path: "{{ docker_adguard_project_dir }}/compose.yml"
+docker_adguard_proxy_network_name: "{{ docker_traefik_network_name | default('traefik_proxy') }}"
+docker_adguard_host: adguard.example.com
+docker_adguard_router_name: adguard
+docker_adguard_router_entrypoints:
+  - websecure
+docker_adguard_tls_certresolver: "{{ docker_traefik_certresolver_name | default('letsencrypt') }}"
+docker_adguard_container_web_port: 3000
+
+docker_adguard_admin_user: admin
+docker_adguard_admin_password_hash: ""
+docker_adguard_dns_bind_port: 53
+docker_adguard_container_dns_port: 53
+docker_adguard_upstream_dns:
+  - https://dns10.quad9.net/dns-query
+  - https://dns.quad9.net/dns-query
+docker_adguard_bootstrap_dns:
+  - 9.9.9.10
+  - 149.112.112.10
+docker_adguard_http_session_ttl: 720h
+docker_adguard_theme: auto
+docker_adguard_filters:
+  - enabled: true
+    url: https://adguardteam.github.io/HostlistsRegistry/assets/filter_1.txt
+    name: AdGuard DNS filter
+
+docker_adguard_manage_firewall_rules: true
+docker_adguard_firewall_rules:
+  - rule: allow
+    direction: in
+    port: "{{ docker_adguard_dns_bind_port | string }}"
+    proto: tcp
+    comment: "managed:docker_adguard:dns-tcp"
+  - rule: allow
+    direction: in
+    port: "{{ docker_adguard_dns_bind_port | string }}"
+    proto: udp
+    comment: "managed:docker_adguard:dns-udp"

--- a/roles/docker_adguard/meta/main.yml
+++ b/roles/docker_adguard/meta/main.yml
@@ -1,0 +1,7 @@
+---
+# roles/docker_adguard/meta/main.yml
+# Role metadata for `docker_adguard`.
+# Leaves dependencies empty because direct and aggregate Docker-role ordering is
+# defined in the related playbook or `roles/docker/tasks/main.yml`.
+
+dependencies: []

--- a/roles/docker_adguard/tasks/assert.yml
+++ b/roles/docker_adguard/tasks/assert.yml
@@ -1,0 +1,196 @@
+---
+# roles/docker_adguard/tasks/assert.yml
+# Assert phase tasks for the `docker_adguard` role.
+# Validates Docker Compose, AdGuard Home, Traefik proxy-network, identity,
+# admin-auth, and firewall inputs before configuration starts.
+
+- name: "Assert | Validate docker_adguard variable structure"
+  ansible.builtin.assert:
+    that:
+      - docker_adguard_enabled is boolean
+      - docker_adguard_manage_firewall_rules is boolean
+      - docker_adguard_packages is sequence
+      - docker_adguard_packages is not string
+      - docker_adguard_compose_package_candidates is sequence
+      - docker_adguard_compose_package_candidates is not string
+      - docker_adguard_access_group_members is sequence
+      - docker_adguard_access_group_members is not string
+      - docker_adguard_router_entrypoints is sequence
+      - docker_adguard_router_entrypoints is not string
+      - docker_adguard_upstream_dns is sequence
+      - docker_adguard_upstream_dns is not string
+      - docker_adguard_bootstrap_dns is sequence
+      - docker_adguard_bootstrap_dns is not string
+      - docker_adguard_filters is sequence
+      - docker_adguard_filters is not string
+      - docker_adguard_firewall_rules is sequence
+      - docker_adguard_firewall_rules is not string
+      - docker_adguard_manage_access_group_memberships is boolean
+      - docker_adguard_project_dir is string
+      - docker_adguard_project_dir.startswith('/')
+      - docker_adguard_data_dir is string
+      - docker_adguard_data_dir.startswith('/')
+      - docker_adguard_work_dir is string
+      - docker_adguard_work_dir.startswith('/')
+      - docker_adguard_conf_dir is string
+      - docker_adguard_conf_dir.startswith('/')
+      - docker_adguard_config_path is string
+      - docker_adguard_config_path.startswith('/')
+      - docker_adguard_compose_project_name is string
+      - docker_adguard_compose_project_name | trim | length > 0
+      - docker_adguard_compose_service_name is string
+      - docker_adguard_compose_service_name | trim | length > 0
+      - docker_adguard_container_name is string
+      - docker_adguard_container_name | trim | length > 0
+      - docker_adguard_image is string
+      - docker_adguard_image | trim | length > 0
+      - docker_adguard_docker_service_name is string
+      - docker_adguard_docker_service_name | trim | length > 0
+      - docker_adguard_service_user is string
+      - docker_adguard_service_user | trim | length > 0
+      - docker_adguard_service_uid is number
+      - docker_adguard_service_uid | int >= 1000
+      - docker_adguard_access_group is string
+      - docker_adguard_access_group | trim | length > 0
+      - docker_adguard_access_gid is number
+      - docker_adguard_access_gid | int >= 1000
+      - docker_adguard_service_user_shell is string
+      - docker_adguard_service_user_shell | trim | length > 0
+      - docker_adguard_proxy_network_name is string
+      - docker_adguard_proxy_network_name | trim | length > 0
+      - docker_adguard_host is string
+      - docker_adguard_host | trim | length > 0
+      - docker_adguard_router_name is string
+      - docker_adguard_router_name | trim | length > 0
+      - docker_adguard_tls_certresolver is string
+      - docker_adguard_tls_certresolver | trim | length > 0
+      - docker_adguard_container_web_port is integer
+      - docker_adguard_container_web_port > 0
+      - docker_adguard_admin_user is string
+      - docker_adguard_admin_user | trim | length > 0
+      - docker_adguard_admin_password_hash is string
+      - docker_adguard_admin_password_hash | trim | length > 0
+      - docker_adguard_dns_bind_port is integer
+      - docker_adguard_dns_bind_port > 0
+      - docker_adguard_container_dns_port is integer
+      - docker_adguard_container_dns_port > 0
+      - docker_adguard_http_session_ttl is string
+      - docker_adguard_http_session_ttl | trim | length > 0
+      - docker_adguard_theme is string
+      - docker_adguard_theme | trim | length > 0
+      - (docker_adguard_packages | map('string') | list | length) == (docker_adguard_packages | length)
+      - (docker_adguard_packages | map('trim') | reject('equalto', '') | list | length) == (docker_adguard_packages | length)
+      - >-
+        (
+          docker_adguard_compose_package_candidates | map('string') | list | length
+        ) == (docker_adguard_compose_package_candidates | length)
+      - >-
+        (
+          docker_adguard_compose_package_candidates
+          | map('trim')
+          | reject('equalto', '')
+          | list
+          | length
+        ) == (docker_adguard_compose_package_candidates | length)
+      - >-
+        (
+          docker_adguard_access_group_members | map('string') | list | length
+        ) == (docker_adguard_access_group_members | length)
+      - >-
+        (
+          docker_adguard_access_group_members
+          | map('trim')
+          | reject('equalto', '')
+          | list
+          | length
+        ) == (docker_adguard_access_group_members | length)
+      - >-
+        (
+          docker_adguard_access_group_members | unique | list | length
+        ) == (docker_adguard_access_group_members | length)
+      - >-
+        (
+          docker_adguard_router_entrypoints | map('string') | list | length
+        ) == (docker_adguard_router_entrypoints | length)
+      - >-
+        (
+          docker_adguard_router_entrypoints
+          | map('trim')
+          | reject('equalto', '')
+          | list
+          | length
+        ) == (docker_adguard_router_entrypoints | length)
+      - >-
+        (
+          docker_adguard_upstream_dns | map('string') | list | length
+        ) == (docker_adguard_upstream_dns | length)
+      - >-
+        (
+          docker_adguard_upstream_dns
+          | map('trim')
+          | reject('equalto', '')
+          | list
+          | length
+        ) == (docker_adguard_upstream_dns | length)
+      - >-
+        (
+          docker_adguard_bootstrap_dns | map('string') | list | length
+        ) == (docker_adguard_bootstrap_dns | length)
+      - >-
+        (
+          docker_adguard_bootstrap_dns
+          | map('trim')
+          | reject('equalto', '')
+          | list
+          | length
+        ) == (docker_adguard_bootstrap_dns | length)
+    fail_msg: >-
+      docker_adguard variables must define valid booleans, non-empty strings,
+      absolute project and data paths, valid fixed IDs, unique access-group
+      members, non-empty upstream DNS entries, and a non-empty admin password
+      hash
+    quiet: true
+
+- name: "Assert | Validate requested filter structure"
+  ansible.builtin.assert:
+    that:
+      - item is mapping
+      - item.name is defined
+      - item.name is string
+      - item.name | trim | length > 0
+      - item.url is defined
+      - item.url is string
+      - item.url | trim | length > 0
+      - item.enabled is not defined or item.enabled is boolean
+    fail_msg: >-
+      Each docker_adguard_filters item must include a non-empty name and URL,
+      plus an optional boolean enabled flag
+    quiet: true
+  loop: "{{ docker_adguard_filters }}"
+  loop_control:
+    label: "{{ item.name | default('docker-adguard-filter') }}"
+  when: docker_adguard_filters | length > 0
+
+- name: "Assert | Validate requested firewall rule structure"
+  ansible.builtin.assert:
+    that:
+      - item is mapping
+      - item.rule is defined
+      - item.rule is string
+      - item.rule | trim | length > 0
+      - item.port is defined
+      - item.port | string | trim | length > 0
+      - item.proto is not defined or (item.proto is string and item.proto | trim | length > 0)
+      - item.comment is defined
+      - item.comment is string
+      - item.comment.startswith('managed:')
+    fail_msg: >-
+      Each docker_adguard_firewall_rules item must include a non-empty rule,
+      port, and managed: comment prefix, plus an optional non-empty proto
+    quiet: true
+  loop: "{{ docker_adguard_firewall_rules }}"
+  loop_control:
+    label: "{{ item.comment | default('docker-adguard-rule') }}"
+  when:
+    - docker_adguard_manage_firewall_rules | bool
+    - docker_adguard_firewall_rules | length > 0

--- a/roles/docker_adguard/tasks/config.yml
+++ b/roles/docker_adguard/tasks/config.yml
@@ -1,0 +1,469 @@
+---
+# roles/docker_adguard/tasks/config.yml
+# Config phase tasks for the `docker_adguard` role.
+# Creates the AdGuard access identities and project files, registers optional
+# firewall rules, and starts the managed Docker Compose project against the
+# existing Traefik proxy network.
+
+- name: "Config | Ensure AdGuard access group exists"
+  ansible.builtin.group:
+    name: "{{ docker_adguard_access_group }}"
+    gid: "{{ docker_adguard_access_gid }}"
+    state: present
+  when: docker_adguard_enabled | bool
+
+- name: "Config | Ensure AdGuard service user exists"
+  ansible.builtin.user:
+    name: "{{ docker_adguard_service_user }}"
+    uid: "{{ docker_adguard_service_uid }}"
+    group: "{{ docker_adguard_access_group }}"
+    shell: "{{ docker_adguard_service_user_shell }}"
+    home: "{{ docker_adguard_project_dir }}"
+    create_home: false
+    state: present
+    comment: "AdGuard service account managed by Ansible"
+  when: docker_adguard_enabled | bool
+
+- name: "Config | Register firewall rules" # noqa: var-naming[no-role-prefix]
+  ansible.builtin.set_fact:
+    base_firewall_role_declared_rules: >-
+      {{
+        (base_firewall_role_declared_rules | default([]))
+        + (docker_adguard_firewall_rules | default([]))
+      }}
+  when:
+    - docker_adguard_enabled | bool
+    - docker_adguard_manage_firewall_rules | bool
+
+- name: "Config | Collect existing user entries for AdGuard access-group management"
+  ansible.builtin.getent:
+    database: passwd
+    key: "{{ item }}"
+  register: docker_adguard_config_passwd_lookup
+  changed_when: false
+  failed_when: false
+  loop: "{{ docker_adguard_access_group_members }}"
+  loop_control:
+    label: "{{ item }}"
+  when:
+    - docker_adguard_enabled | bool
+    - docker_adguard_manage_access_group_memberships | bool
+    - docker_adguard_access_group_members | length > 0
+
+- name: "Config | Ensure AdGuard access-group membership for existing users"
+  ansible.builtin.user:
+    name: "{{ item.item }}"
+    state: present
+    groups: "{{ docker_adguard_access_group }}"
+    append: true
+  loop: "{{ docker_adguard_config_passwd_lookup.results | default([]) }}"
+  loop_control:
+    label: "{{ item.item }}"
+  when:
+    - docker_adguard_enabled | bool
+    - docker_adguard_manage_access_group_memberships | bool
+    - item.item in (item.ansible_facts.getent_passwd | default({}))
+
+- name: "Config | Check whether a managed Docker Compose file already exists"
+  ansible.builtin.stat:
+    path: "{{ docker_adguard_compose_file_path }}"
+  register: docker_adguard_compose_file_stat
+  changed_when: false
+
+- name: "Config | Stop managed Docker Compose project when AdGuard is disabled"
+  ansible.builtin.command:
+    argv:
+      - docker
+      - compose
+      - --project-name
+      - "{{ docker_adguard_compose_project_name }}"
+      - --file
+      - "{{ docker_adguard_compose_file_path }}"
+      - down
+  register: docker_adguard_compose_down
+  changed_when: docker_adguard_compose_file_stat.stat.exists
+  when:
+    - not docker_adguard_enabled | bool
+    - docker_adguard_compose_file_stat.stat.exists
+
+- name: "Config | Inspect required Traefik proxy network"
+  ansible.builtin.command:
+    argv:
+      - docker
+      - network
+      - inspect
+      - "{{ docker_adguard_proxy_network_name }}"
+  register: docker_adguard_config_proxy_network
+  changed_when: false
+  failed_when: false
+  when: docker_adguard_enabled | bool
+
+- name: "Config | Require Traefik proxy network before starting AdGuard"
+  ansible.builtin.assert:
+    that:
+      - docker_adguard_config_proxy_network.rc == 0
+    fail_msg: >-
+      docker_adguard requires the external proxy network
+      {{ docker_adguard_proxy_network_name }}. Run docker_traefik first or
+      point docker_adguard_proxy_network_name at an existing Traefik network.
+    quiet: true
+  when: docker_adguard_enabled | bool
+
+- name: "Config | Ensure AdGuard project directory exists"
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    state: directory
+    owner: "{{ item.owner }}"
+    group: "{{ item.group }}"
+    mode: "{{ item.mode }}"
+  loop:
+    - path: "{{ docker_adguard_project_dir }}"
+      owner: root
+      group: "{{ docker_adguard_access_group }}"
+      mode: "0750"
+    - path: "{{ docker_adguard_data_dir }}"
+      owner: "{{ docker_adguard_service_user }}"
+      group: "{{ docker_adguard_access_group }}"
+      mode: "0750"
+    - path: "{{ docker_adguard_conf_dir }}"
+      owner: "{{ docker_adguard_service_user }}"
+      group: "{{ docker_adguard_access_group }}"
+      mode: "0750"
+  loop_control:
+    label: "{{ item.path }}"
+  when: docker_adguard_enabled | bool
+
+- name: "Config | Check whether AdGuard work directory already exists"
+  ansible.builtin.stat:
+    path: "{{ docker_adguard_work_dir }}"
+  register: docker_adguard_work_dir_stat
+  changed_when: false
+  when: docker_adguard_enabled | bool
+
+- name: "Config | Bootstrap AdGuard work directory when missing"
+  ansible.builtin.file:
+    path: "{{ docker_adguard_work_dir }}"
+    state: directory
+    owner: "{{ docker_adguard_service_user }}"
+    group: "{{ docker_adguard_access_group }}"
+    mode: "0750"
+  when:
+    - docker_adguard_enabled | bool
+    - not docker_adguard_work_dir_stat.stat.exists
+
+- name: "Config | Check whether managed AdGuard configuration already exists"
+  ansible.builtin.stat:
+    path: "{{ docker_adguard_config_path }}"
+  register: docker_adguard_config_file_stat
+  changed_when: false
+  when: docker_adguard_enabled | bool
+
+- name: "Config | Bootstrap AdGuard Home configuration when missing"
+  ansible.builtin.template:
+    src: docker_adguard_AdGuardHome.yaml.j2
+    dest: "{{ docker_adguard_config_path }}"
+    owner: root
+    group: "{{ docker_adguard_access_group }}"
+    mode: "0640"
+  register: docker_adguard_config_template_result
+  when:
+    - docker_adguard_enabled | bool
+    - not docker_adguard_config_file_stat.stat.exists
+
+- name: "Config | Read existing AdGuard Home configuration"
+  ansible.builtin.slurp:
+    path: "{{ docker_adguard_config_path }}"
+  register: docker_adguard_existing_config_file
+  when:
+    - docker_adguard_enabled | bool
+    - docker_adguard_config_file_stat.stat.exists
+
+- name: "Config | Derive merged AdGuard Home configuration"
+  vars:
+    docker_adguard_existing_config: >-
+      {{
+        docker_adguard_existing_config_file.content | b64decode | from_yaml
+      }}
+    docker_adguard_existing_users: >-
+      {{
+        docker_adguard_existing_config.users | default([])
+      }}
+    docker_adguard_preserved_users: >-
+      {{
+        docker_adguard_existing_users
+        | rejectattr('name', 'equalto', docker_adguard_admin_user)
+        | list
+      }}
+    docker_adguard_managed_user: >-
+      {{
+        {
+          'name': docker_adguard_admin_user,
+          'password': docker_adguard_admin_password_hash,
+        }
+      }}
+    docker_adguard_merged_managed_filters: >-
+      {%- set result = [] -%}
+      {%- for item in docker_adguard_filters -%}
+      {%-   set existing_filter = (
+              docker_adguard_existing_config.filters | default([])
+              | selectattr('url', 'equalto', item.url)
+              | list
+              | first
+              | default({})
+            ) -%}
+      {%-   set _ = result.append(
+              existing_filter
+              | combine(
+                  {
+                    'name': item.name,
+                    'url': item.url,
+                    'enabled': item.enabled | default(true),
+                  },
+                  recursive=true
+                )
+            ) -%}
+      {%- endfor -%}
+      {{ result | sort(attribute='name') | sort(attribute='url') }}
+    docker_adguard_normalized_desired_filters: >-
+      {%- set result = [] -%}
+      {%- for item in docker_adguard_filters -%}
+      {%-   set _ = result.append(
+              {
+                'name': item.name,
+                'url': item.url,
+                'enabled': item.enabled | default(true),
+              }
+            ) -%}
+      {%- endfor -%}
+      {{ result | sort(attribute='name') | sort(attribute='url') }}
+    docker_adguard_managed_config: >-
+      {{
+        {
+          'http': {
+            'address': '0.0.0.0:' ~ (docker_adguard_container_web_port | string),
+            'session_ttl': docker_adguard_http_session_ttl,
+          },
+          'users': docker_adguard_preserved_users + [docker_adguard_managed_user],
+          'dns': {
+            'port': docker_adguard_container_dns_port,
+            'upstream_dns': docker_adguard_upstream_dns,
+            'bootstrap_dns': docker_adguard_bootstrap_dns,
+          },
+          'filters': docker_adguard_merged_managed_filters,
+          'theme': docker_adguard_theme,
+        }
+      }}
+  ansible.builtin.set_fact:
+    docker_adguard_effective_config: >-
+      {{
+        docker_adguard_existing_config
+        | combine(docker_adguard_managed_config, recursive=true)
+      }}
+  changed_when: false
+  when:
+    - docker_adguard_enabled | bool
+    - docker_adguard_config_file_stat.stat.exists
+
+- name: "Config | Derive whether managed AdGuard settings differ"
+  vars:
+    docker_adguard_existing_config: >-
+      {{
+        docker_adguard_existing_config_file.content | b64decode | from_yaml
+      }}
+    docker_adguard_existing_users: >-
+      {{
+        docker_adguard_existing_config.users | default([])
+      }}
+    docker_adguard_existing_admin_matches: >-
+      {{
+        docker_adguard_existing_users
+        | selectattr('name', 'equalto', docker_adguard_admin_user)
+        | selectattr('password', 'equalto', docker_adguard_admin_password_hash)
+        | list
+      }}
+    docker_adguard_normalized_desired_filters: >-
+      {%- set result = [] -%}
+      {%- for item in docker_adguard_filters -%}
+      {%-   set _ = result.append(
+              {
+                'name': item.name,
+                'url': item.url,
+                'enabled': item.enabled | default(true),
+              }
+            ) -%}
+      {%- endfor -%}
+      {{ result | sort(attribute='name') | sort(attribute='url') }}
+    docker_adguard_normalized_existing_filters: >-
+      {%- set result = [] -%}
+      {%- for item in (docker_adguard_existing_config.filters | default([])) -%}
+      {%-   set _ = result.append(
+              {
+                'name': item.name,
+                'url': item.url,
+                'enabled': item.enabled | default(true),
+              }
+            ) -%}
+      {%- endfor -%}
+      {{ result | sort(attribute='name') | sort(attribute='url') }}
+  ansible.builtin.set_fact:
+    docker_adguard_managed_config_differs: >-
+      {{
+        (
+          docker_adguard_effective_config.http.address
+          != (docker_adguard_existing_config.http.address | default(''))
+        )
+        or (
+          docker_adguard_effective_config.http.session_ttl
+          != (docker_adguard_existing_config.http.session_ttl | default(''))
+        )
+        or (
+          (docker_adguard_existing_admin_matches | length) == 0
+        )
+        or (
+          docker_adguard_effective_config.dns.port
+          != (docker_adguard_existing_config.dns.port | default(0))
+        )
+        or (
+          docker_adguard_effective_config.dns.upstream_dns
+          | difference(docker_adguard_existing_config.dns.upstream_dns | default([]))
+          | length > 0
+        )
+        or (
+          (docker_adguard_existing_config.dns.upstream_dns | default([]))
+          | difference(docker_adguard_effective_config.dns.upstream_dns)
+          | length > 0
+        )
+        or (
+          docker_adguard_effective_config.dns.bootstrap_dns
+          | difference(docker_adguard_existing_config.dns.bootstrap_dns | default([]))
+          | length > 0
+        )
+        or (
+          (docker_adguard_existing_config.dns.bootstrap_dns | default([]))
+          | difference(docker_adguard_effective_config.dns.bootstrap_dns)
+          | length > 0
+        )
+        or (
+          docker_adguard_effective_config.theme
+          != (docker_adguard_existing_config.theme | default(''))
+        )
+        or (
+          docker_adguard_normalized_desired_filters | to_json
+          != (docker_adguard_normalized_existing_filters | to_json)
+        )
+      }}
+  changed_when: false
+  when:
+    - docker_adguard_enabled | bool
+    - docker_adguard_config_file_stat.stat.exists
+
+- name: "Config | Update managed AdGuard Home settings in existing configuration"
+  ansible.builtin.copy:
+    dest: "{{ docker_adguard_config_path }}"
+    owner: root
+    group: "{{ docker_adguard_access_group }}"
+    mode: "0640"
+    content: |-
+      # Managed by Ansible: docker_adguard
+      # Source: roles/docker_adguard/tasks/config.yml
+      {{ docker_adguard_effective_config | to_nice_yaml(indent=2) | trim }}
+  register: docker_adguard_config_merge_result
+  when:
+    - docker_adguard_enabled | bool
+    - docker_adguard_config_file_stat.stat.exists
+    - docker_adguard_managed_config_differs | bool
+
+- name: "Config | Render Docker Compose file"
+  ansible.builtin.template:
+    src: docker_adguard_compose.yml.j2
+    dest: "{{ docker_adguard_compose_file_path }}"
+    owner: root
+    group: "{{ docker_adguard_access_group }}"
+    mode: "0640"
+  register: docker_adguard_compose_template_result
+  when: docker_adguard_enabled | bool
+
+- name: "Config | Read current Docker Compose running services"
+  ansible.builtin.command:
+    argv:
+      - docker
+      - compose
+      - --project-name
+      - "{{ docker_adguard_compose_project_name }}"
+      - --file
+      - "{{ docker_adguard_compose_file_path }}"
+      - ps
+      - --services
+      - --status
+      - running
+  register: docker_adguard_compose_ps
+  changed_when: false
+  failed_when: false
+  when: docker_adguard_enabled | bool
+
+- name: "Config | Inspect running AdGuard container"
+  ansible.builtin.command:
+    argv:
+      - docker
+      - inspect
+      - "{{ docker_adguard_container_name }}"
+  register: docker_adguard_container_inspect
+  changed_when: false
+  failed_when: false
+  when: docker_adguard_enabled | bool
+
+- name: "Config | Derive whether Docker Compose reconciliation is required"
+  ansible.builtin.set_fact:
+    docker_adguard_requires_compose_up: >-
+      {{
+        (docker_adguard_config_template_result.changed | default(false))
+        or (docker_adguard_config_merge_result.changed | default(false))
+        or docker_adguard_compose_template_result.changed
+        or (docker_adguard_container_inspect.rc != 0)
+        or (
+          docker_adguard_container_inspect.rc == 0
+          and (
+            (
+              docker_adguard_container_inspect.stdout | from_json | first
+            ).HostConfig.PortBindings[
+              (docker_adguard_container_dns_port | string) ~ '/tcp'
+            ][0].HostPort
+            != (docker_adguard_dns_bind_port | string)
+          )
+        )
+        or (
+          docker_adguard_container_inspect.rc == 0
+          and (
+            (
+              docker_adguard_container_inspect.stdout | from_json | first
+            ).HostConfig.PortBindings[
+              (docker_adguard_container_dns_port | string) ~ '/udp'
+            ][0].HostPort
+            != (docker_adguard_dns_bind_port | string)
+          )
+        )
+        or (
+          docker_adguard_compose_service_name
+          not in (docker_adguard_compose_ps.stdout_lines | default([]))
+        )
+      }}
+  changed_when: false
+  when: docker_adguard_enabled | bool
+
+- name: "Config | Reconcile Docker Compose project"
+  ansible.builtin.command:
+    argv:
+      - docker
+      - compose
+      - --project-name
+      - "{{ docker_adguard_compose_project_name }}"
+      - --file
+      - "{{ docker_adguard_compose_file_path }}"
+      - up
+      - --detach
+      - --force-recreate
+  register: docker_adguard_compose_up
+  changed_when: docker_adguard_requires_compose_up | bool
+  when:
+    - docker_adguard_enabled | bool
+    - docker_adguard_requires_compose_up | bool

--- a/roles/docker_adguard/tasks/derive_effective_packages.yml
+++ b/roles/docker_adguard/tasks/derive_effective_packages.yml
@@ -1,0 +1,51 @@
+---
+# roles/docker_adguard/tasks/derive_effective_packages.yml
+# Helper tasks for the `docker_adguard` role.
+# Derives the effective Compose support packages, auto-detecting an available
+# package when none are set explicitly.
+
+- name: "Derive Packages | Probe available Compose support packages"
+  ansible.builtin.command:
+    argv:
+      - apt-cache
+      - show
+      - "{{ item }}"
+  register: docker_adguard_package_probe
+  changed_when: false
+  failed_when: false
+  loop: "{{ docker_adguard_compose_package_candidates }}"
+  loop_control:
+    label: "{{ item }}"
+  when:
+    - docker_adguard_enabled | bool
+    - docker_adguard_packages | length == 0
+
+- name: "Derive Packages | Build effective package list"
+  ansible.builtin.set_fact:
+    docker_adguard_effective_packages: >-
+      {{
+        docker_adguard_packages
+        if (docker_adguard_packages | length > 0)
+        else (
+          docker_adguard_package_probe.results
+          | default([])
+          | selectattr('rc', 'equalto', 0)
+          | map(attribute='item')
+          | list
+        )[:1]
+      }}
+  changed_when: false
+  when: docker_adguard_enabled | bool
+
+- name: "Derive Packages | Assert an installable Compose support package exists"
+  ansible.builtin.assert:
+    that:
+      - docker_adguard_effective_packages is sequence
+      - docker_adguard_effective_packages is not string
+      - docker_adguard_effective_packages | length > 0
+    fail_msg: >-
+      No installable Docker Compose support package was found. Set
+      docker_adguard_packages explicitly or extend
+      docker_adguard_compose_package_candidates for this host family.
+    quiet: true
+  when: docker_adguard_enabled | bool

--- a/roles/docker_adguard/tasks/install.yml
+++ b/roles/docker_adguard/tasks/install.yml
@@ -1,0 +1,19 @@
+---
+# roles/docker_adguard/tasks/install.yml
+# Install phase tasks for the `docker_adguard` role.
+# Ensures the requested Docker Compose support packages are installed with APT
+# when AdGuard is enabled.
+
+- name: "Install | Derive effective Compose support packages"
+  ansible.builtin.import_tasks: derive_effective_packages.yml
+  when: docker_adguard_enabled | bool
+
+- name: "Install | Ensure requested Docker AdGuard packages are present"
+  ansible.builtin.apt:
+    name: "{{ docker_adguard_effective_packages }}"
+    state: present
+    update_cache: true
+    cache_valid_time: 3600
+  when:
+    - docker_adguard_enabled | bool
+    - docker_adguard_effective_packages | length > 0

--- a/roles/docker_adguard/tasks/main.yml
+++ b/roles/docker_adguard/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+# roles/docker_adguard/tasks/main.yml
+# Task entrypoint for the `docker_adguard` role.
+# Imports the assert, install, config, and validate phase files in order.
+
+- name: Assert
+  ansible.builtin.import_tasks: assert.yml
+  tags: [assert, docker_adguard, docker_adguard_assert]
+
+- name: Install
+  ansible.builtin.import_tasks: install.yml
+  tags: [install, docker_adguard, docker_adguard_install]
+
+- name: Config
+  ansible.builtin.import_tasks: config.yml
+  tags: [config, docker_adguard, docker_adguard_config]
+
+- name: Validate
+  ansible.builtin.import_tasks: validate.yml
+  tags: [validate, docker_adguard, docker_adguard_validate]

--- a/roles/docker_adguard/tasks/validate.yml
+++ b/roles/docker_adguard/tasks/validate.yml
@@ -1,0 +1,229 @@
+---
+# roles/docker_adguard/tasks/validate.yml
+# Validate phase tasks for the `docker_adguard` role.
+# Verifies package state, identities, rendered files, Docker network state, and
+# the running Docker Compose AdGuard service.
+
+- name: "Validate | Gather package facts"
+  ansible.builtin.package_facts:
+    manager: auto
+  when: docker_adguard_enabled | bool
+
+- name: "Validate | Derive effective Compose support packages"
+  ansible.builtin.import_tasks: derive_effective_packages.yml
+  when: docker_adguard_enabled | bool
+
+- name: "Validate | Collect AdGuard service-user entry"
+  ansible.builtin.getent:
+    database: passwd
+    key: "{{ docker_adguard_service_user }}"
+  register: docker_adguard_validate_service_user
+  changed_when: false
+  when: docker_adguard_enabled | bool
+
+- name: "Validate | Collect AdGuard access-group entry"
+  ansible.builtin.getent:
+    database: group
+    key: "{{ docker_adguard_access_group }}"
+  register: docker_adguard_validate_access_group
+  changed_when: false
+  when: docker_adguard_enabled | bool
+
+- name: "Validate | Collect existing user entries for AdGuard access-group validation"
+  ansible.builtin.getent:
+    database: passwd
+    key: "{{ item }}"
+  register: docker_adguard_validate_passwd_lookup
+  changed_when: false
+  failed_when: false
+  loop: "{{ docker_adguard_access_group_members }}"
+  loop_control:
+    label: "{{ item }}"
+  when:
+    - docker_adguard_enabled | bool
+    - docker_adguard_manage_access_group_memberships | bool
+    - docker_adguard_access_group_members | length > 0
+
+- name: "Validate | Collect effective group lists for AdGuard-managed existing users"
+  ansible.builtin.command:
+    cmd: "id -Gn {{ item.item }}"
+  register: docker_adguard_validate_groups
+  changed_when: false
+  failed_when: false
+  loop: "{{ docker_adguard_validate_passwd_lookup.results | default([]) }}"
+  loop_control:
+    label: "{{ item.item }}"
+  when:
+    - docker_adguard_enabled | bool
+    - docker_adguard_manage_access_group_memberships | bool
+    - item.item in (item.ansible_facts.getent_passwd | default({}))
+
+- name: "Validate | Read Docker Compose file"
+  ansible.builtin.slurp:
+    path: "{{ docker_adguard_compose_file_path }}"
+  register: docker_adguard_validate_compose_file
+  when: docker_adguard_enabled | bool
+
+- name: "Validate | Read AdGuard Home configuration"
+  ansible.builtin.slurp:
+    path: "{{ docker_adguard_config_path }}"
+  register: docker_adguard_validate_config_file
+  when: docker_adguard_enabled | bool
+
+- name: "Validate | Gather service facts"
+  ansible.builtin.service_facts:
+  when: docker_adguard_enabled | bool
+
+- name: "Validate | Inspect Docker proxy network"
+  ansible.builtin.command:
+    argv:
+      - docker
+      - network
+      - inspect
+      - "{{ docker_adguard_proxy_network_name }}"
+  register: docker_adguard_validate_proxy_network
+  changed_when: false
+  when: docker_adguard_enabled | bool
+
+- name: "Validate | Read Docker Compose running services"
+  ansible.builtin.command:
+    argv:
+      - docker
+      - compose
+      - --project-name
+      - "{{ docker_adguard_compose_project_name }}"
+      - --file
+      - "{{ docker_adguard_compose_file_path }}"
+      - ps
+      - --services
+      - --status
+      - running
+  register: docker_adguard_validate_compose_ps
+  changed_when: false
+  when: docker_adguard_enabled | bool
+
+- name: "Validate | Check Docker Compose availability"
+  ansible.builtin.command:
+    argv:
+      - docker
+      - compose
+      - version
+  register: docker_adguard_validate_compose_version
+  changed_when: false
+  when: docker_adguard_enabled | bool
+
+- name: "Validate | Assert Docker AdGuard state"
+  vars:
+    docker_adguard_expected_compose: "{{ lookup('template', 'docker_adguard_compose.yml.j2') }}"
+    docker_adguard_live_config: >-
+      {{
+        (docker_adguard_validate_config_file.content | b64decode | from_yaml)
+      }}
+    docker_adguard_live_admin_matches: >-
+      {{
+        docker_adguard_live_config.users | default([])
+        | selectattr('name', 'equalto', docker_adguard_admin_user)
+        | selectattr('password', 'equalto', docker_adguard_admin_password_hash)
+        | list
+      }}
+    docker_adguard_desired_filters: >-
+      {%- set result = [] -%}
+      {%- for item in docker_adguard_filters -%}
+      {%-   set _ = result.append(
+              {
+                'name': item.name,
+                'url': item.url,
+                'enabled': item.enabled | default(true),
+              }
+            ) -%}
+      {%- endfor -%}
+      {{ result | sort(attribute='name') | sort(attribute='url') }}
+    docker_adguard_live_filters: >-
+      {%- set result = [] -%}
+      {%- for item in (docker_adguard_live_config.filters | default([])) -%}
+      {%-   set _ = result.append(
+              {
+                'name': item.name,
+                'url': item.url,
+                'enabled': item.enabled | default(true),
+              }
+            ) -%}
+      {%- endfor -%}
+      {{ result | sort(attribute='name') | sort(attribute='url') }}
+    docker_adguard_service_unit: >-
+      {{
+        docker_adguard_docker_service_name
+        if docker_adguard_docker_service_name.endswith('.service')
+        else (docker_adguard_docker_service_name ~ '.service')
+      }}
+  ansible.builtin.assert:
+    that:
+      - (docker_adguard_effective_packages | difference(ansible_facts.packages.keys() | list) | length) == 0
+      - docker_adguard_service_user in (docker_adguard_validate_service_user.ansible_facts.getent_passwd | default({}))
+      - docker_adguard_access_group in (docker_adguard_validate_access_group.ansible_facts.getent_group | default({}))
+      - (docker_adguard_validate_compose_file.content | b64decode) == docker_adguard_expected_compose
+      - docker_adguard_live_config.http.address == ('0.0.0.0:' ~ (docker_adguard_container_web_port | string))
+      - docker_adguard_live_config.http.session_ttl == docker_adguard_http_session_ttl
+      - docker_adguard_live_config.users is sequence
+      - docker_adguard_live_config.users | length > 0
+      - (docker_adguard_live_admin_matches | length) > 0
+      - docker_adguard_live_config.dns.port == docker_adguard_container_dns_port
+      - >-
+        (
+          docker_adguard_live_config.dns.upstream_dns | default([])
+          | difference(docker_adguard_upstream_dns)
+          | length
+        ) == 0
+      - >-
+        (
+          docker_adguard_upstream_dns
+          | difference(docker_adguard_live_config.dns.upstream_dns | default([]))
+          | length
+        ) == 0
+      - >-
+        (
+          docker_adguard_live_config.dns.bootstrap_dns | default([])
+          | difference(docker_adguard_bootstrap_dns)
+          | length
+        ) == 0
+      - >-
+        (
+          docker_adguard_bootstrap_dns
+          | difference(docker_adguard_live_config.dns.bootstrap_dns | default([]))
+          | length
+        ) == 0
+      - docker_adguard_live_config.theme == docker_adguard_theme
+      - docker_adguard_live_filters | to_json == docker_adguard_desired_filters | to_json
+      - docker_adguard_validate_compose_version.rc == 0
+      - docker_adguard_docker_service_name in ansible_facts.services or docker_adguard_service_unit in ansible_facts.services
+      - >-
+        (
+          docker_adguard_service_unit in ansible_facts.services
+          and ansible_facts.services[docker_adguard_service_unit].state == 'running'
+        ) or (
+          docker_adguard_docker_service_name in ansible_facts.services
+          and ansible_facts.services[docker_adguard_docker_service_name].state == 'running'
+        )
+      - docker_adguard_validate_proxy_network.rc == 0
+      - docker_adguard_compose_service_name in (docker_adguard_validate_compose_ps.stdout_lines | default([]))
+    fail_msg: >-
+      Configured Docker AdGuard state does not match the requested
+      docker_adguard values
+    quiet: true
+  when: docker_adguard_enabled | bool
+
+- name: "Validate | Assert AdGuard access-group membership for existing users"
+  ansible.builtin.assert:
+    that:
+      - docker_adguard_access_group in (item.stdout | trim | split())
+    fail_msg: >-
+      AdGuard access-group membership does not match requested
+      docker_adguard_access_group_members
+    quiet: true
+  loop: "{{ docker_adguard_validate_groups.results | default([]) }}"
+  loop_control:
+    label: "{{ item.item.item }}"
+  when:
+    - docker_adguard_enabled | bool
+    - docker_adguard_manage_access_group_memberships | bool
+    - item.rc == 0

--- a/roles/docker_adguard/templates/docker_adguard_AdGuardHome.yaml.j2
+++ b/roles/docker_adguard/templates/docker_adguard_AdGuardHome.yaml.j2
@@ -1,0 +1,40 @@
+{# roles/docker_adguard/templates/docker_adguard_AdGuardHome.yaml.j2 #}
+{# Template for the managed AdGuard Home configuration file in the `docker_adguard` role. #}
+# Managed by Ansible: docker_adguard
+# Source: roles/docker_adguard/templates/docker_adguard_AdGuardHome.yaml.j2
+http:
+  address: "0.0.0.0:{{ docker_adguard_container_web_port }}"
+  session_ttl: "{{ docker_adguard_http_session_ttl }}"
+
+users:
+  - name: "{{ docker_adguard_admin_user }}"
+    password: "{{ docker_adguard_admin_password_hash }}"
+
+dns:
+  bind_hosts:
+    - 0.0.0.0
+  port: {{ docker_adguard_container_dns_port }}
+  upstream_dns:
+{% for item in docker_adguard_upstream_dns %}
+    - "{{ item }}"
+{% endfor %}
+  bootstrap_dns:
+{% for item in docker_adguard_bootstrap_dns %}
+    - "{{ item }}"
+{% endfor %}
+
+querylog:
+  enabled: true
+
+statistics:
+  enabled: true
+
+filters:
+{% for item in docker_adguard_filters %}
+  - enabled: {{ 'true' if item.enabled | default(true) else 'false' }}
+    url: "{{ item.url }}"
+    name: "{{ item.name }}"
+{% endfor %}
+
+theme: "{{ docker_adguard_theme }}"
+schema_version: 28

--- a/roles/docker_adguard/templates/docker_adguard_compose.yml.j2
+++ b/roles/docker_adguard/templates/docker_adguard_compose.yml.j2
@@ -1,0 +1,30 @@
+{# roles/docker_adguard/templates/docker_adguard_compose.yml.j2 #}
+{# Template for the managed Docker Compose file used by the `docker_adguard` role. #}
+# Managed by Ansible: docker_adguard
+# Source: roles/docker_adguard/templates/docker_adguard_compose.yml.j2
+services:
+  {{ docker_adguard_compose_service_name }}:
+    image: {{ docker_adguard_image }}
+    container_name: {{ docker_adguard_container_name }}
+    restart: unless-stopped
+    volumes:
+      - ./data/work:/opt/adguardhome/work
+      - ./data/conf:/opt/adguardhome/conf
+    ports:
+      - "{{ docker_adguard_dns_bind_port }}:{{ docker_adguard_container_dns_port }}/tcp"
+      - "{{ docker_adguard_dns_bind_port }}:{{ docker_adguard_container_dns_port }}/udp"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network={{ docker_adguard_proxy_network_name }}"
+      - "traefik.http.routers.{{ docker_adguard_router_name }}.rule=Host(`{{ docker_adguard_host }}`)"
+      - "traefik.http.routers.{{ docker_adguard_router_name }}.entrypoints={{ docker_adguard_router_entrypoints | join(',') }}"
+      - "traefik.http.routers.{{ docker_adguard_router_name }}.tls=true"
+      - "traefik.http.routers.{{ docker_adguard_router_name }}.tls.certresolver={{ docker_adguard_tls_certresolver }}"
+      - "traefik.http.services.{{ docker_adguard_router_name }}.loadbalancer.server.port={{ docker_adguard_container_web_port }}"
+    networks:
+      - proxy
+
+networks:
+  proxy:
+    external: true
+    name: {{ docker_adguard_proxy_network_name }}


### PR DESCRIPTION
- Added default variables for the docker_adguard role in defaults/main.yml.
- Created role metadata in meta/main.yml.
- Implemented assert tasks to validate variable structures in tasks/assert.yml.
- Developed configuration tasks to manage AdGuard setup in tasks/config.yml.
- Added helper tasks to derive effective package lists in tasks/derive_effective_packages.yml.
- Created installation tasks to ensure required packages are installed in tasks/install.yml.
- Structured main task entrypoint in tasks/main.yml to import phase-specific tasks.
- Implemented validation tasks to verify the state of the AdGuard service in tasks/validate.yml.
- Added templates for AdGuard Home configuration and Docker Compose file in templates directory.