### PR TITLE
Add manual restore role for Restic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 Release history for `homelab-roles`.
 Documents notable changes across repository structure, roles, examples, and documentation.
 
+## [v2.11.2]
+### Added
+- Added standalone `restore_restic`, plus example inventory wiring and a dedicated `examples/playbooks/ops/restore_restic.yml` helper so downstream repos can restore the full Restic backup scope by default or override one specific path for targeted repair work.
+
+### Documentation
+- Updated repository, example, and Vault documentation to cover the new manual restore helper, the safe `/backup` sandbox default, and the explicit in-place versus repair-path restore modes.
+
 ## [v2.11.1]
 ### Added
 - Added automatic per-container `review_url` generation to `monitoring_docker_tag`, plus optional inventory-driven `changelog_url` overrides that the dashboard host pages can render as direct review links beside each update candidate.

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ The `examples/` directory is the local validation harness for the shared roles.
 - `docker`: Docker engine plus optional service roles.
 - `backup`: aggregate backup layer for recurring Restic configuration plus repository init.
 - `backup_restic` and companions: focused recurring backup, repository-init,
-  prune, repository-check, and validation helpers used directly or through
-  `backup`.
+  prune, repository-check, restore, and validation helpers used directly or
+  through `backup`.
 - `monitoring` and focused standalone roles: aggregate host monitoring plus
   focused access and status-generation capabilities consumed directly or
   through aggregates.
@@ -111,6 +111,9 @@ ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/ops/boot
 ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/recurring/site.yml
 ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/ops/base_maintenance.yml
 ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/ops/backup_restic_now.yml
+ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/ops/restore_restic.yml
+ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/ops/restore_restic.yml -e restore_restic_mode=in_place
+ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/ops/restore_restic.yml -e restore_restic_mode=repair_path -e restore_restic_only_path=/srv/wireguard/data
 ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/ops/monitoring_ops.yml
 ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/ops/monitoring_docker_tag_now.yml
 ```
@@ -121,6 +124,7 @@ Dedicated maintenance stays separate:
 ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/ops/base_maintenance.yml
 ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/recurring/monitoring.yml
 ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/ops/backup_restic_now.yml
+ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/ops/restore_restic.yml
 ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/ops/monitoring_ops.yml
 ```
 
@@ -137,6 +141,7 @@ ansible-playbook playbooks/ops/bootstrap.yml
 ansible-playbook playbooks/recurring/site.yml
 ansible-playbook playbooks/ops/base_maintenance.yml
 ansible-playbook playbooks/ops/backup_restic_now.yml
+ansible-playbook playbooks/ops/restore_restic.yml
 ansible-playbook playbooks/ops/monitoring_ops.yml
 ```
 

--- a/docs/01-examples.md
+++ b/docs/01-examples.md
@@ -43,7 +43,8 @@ The example assumes Debian-family hosts.
 - Keep non-monitoring manual-run entrypoints explicit, such as
   `examples/playbooks/ops/bootstrap.yml`,
   `examples/playbooks/ops/base_maintenance.yml` and
-  `examples/playbooks/ops/backup_restic_now.yml`, instead of reintroducing an
+  `examples/playbooks/ops/backup_restic_now.yml` plus
+  `examples/playbooks/ops/restore_restic.yml`, instead of reintroducing an
   aggregate ops playbook.
 - Keep `examples/playbooks/recurring/base.yml` for the non-maintenance baseline and
   `examples/playbooks/ops/base_maintenance.yml` for one-host-at-a-time package

--- a/docs/05-vault.md
+++ b/docs/05-vault.md
@@ -179,6 +179,10 @@ those derived hostnames resolve correctly.
   password hashes in Vault. The shared dashboard domain suffix also lives in
   Vault, while the final Traefik and AdGuard hostnames stay derived in normal
   vars files from `alias`.
+- For the Restic backup and restore workflow, keep the repository location,
+  password, and backend-specific environment values in Vault-backed vars and
+  keep the restore mode, sandbox target path, and optional repair-path
+  selection in normal tracked inventory vars.
 - For `adguardhome-sync`, keep the sync UI host, direct AdGuard LAN IPs or
   URLs, and plaintext API passwords in Vault-backed vars because the sync tool
   needs live login input rather than the bcrypt hash used by AdGuard Home

--- a/examples/README.md
+++ b/examples/README.md
@@ -21,6 +21,9 @@ Values are intentionally simple and should be replaced before production use.
 - `playbooks/ops/monitoring_ops.yml`: operator-only aggregate entrypoint for
   the monitoring helper playbooks.
 - `playbooks/ops/backup_restic_now.yml`: validation-only backup helper.
+- `playbooks/ops/restore_restic.yml`: manual restore helper with an explicit
+  safe-by-default sandbox mode, optional full in-place restore mode, and
+  optional single-path repair mode.
 - `playbooks/ops/monitoring_status_now.yml`,
   `playbooks/ops/monitoring_storage_health_now.yml`,
   `playbooks/ops/monitoring_docker_tag_now.yml`,
@@ -42,6 +45,9 @@ ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/ops/boot
 ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/recurring/site.yml
 ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/ops/base_maintenance.yml
 ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/ops/backup_restic_now.yml
+ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/ops/restore_restic.yml
+ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/ops/restore_restic.yml -e restore_restic_mode=in_place
+ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/ops/restore_restic.yml -e restore_restic_mode=repair_path -e restore_restic_only_path=/srv/wireguard/data
 ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/ops/monitoring_ops.yml
 ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/ops/monitoring_docker_tag_now.yml
 ```
@@ -61,6 +67,7 @@ ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/recurrin
 ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/recurring/backup.yml
 ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/recurring/monitoring.yml
 ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/ops/backup_restic_now.yml
+ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/ops/restore_restic.yml
 ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/ops/monitoring_ops.yml
 ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/ops/monitoring_status_now.yml
 ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/ops/monitoring_docker_tag_now.yml
@@ -76,6 +83,7 @@ ansible-playbook playbooks/recurring/backup.yml
 ansible-playbook playbooks/recurring/monitoring.yml
 ansible-playbook playbooks/ops/base_maintenance.yml
 ansible-playbook playbooks/ops/backup_restic_now.yml
+ansible-playbook playbooks/ops/restore_restic.yml
 ansible-playbook playbooks/ops/monitoring_ops.yml
 ansible-playbook playbooks/ops/monitoring_status_now.yml
 ansible-playbook playbooks/ops/monitoring_docker_tag_now.yml
@@ -96,6 +104,10 @@ ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/tests/<t
 - `backup.yml` now runs the aggregate `backup` role, which applies the
   recurring Restic setup, initializes a missing repository, and manages the
   separate prune/check timers in the same steady-state path.
+- `restore_restic.yml` is intentionally separate from the aggregate backup flow
+  because restores are manual operator actions, not part of recurring
+  convergence. It defaults to restoring into `/backup` so operators can review
+  content safely before choosing an explicit in-place mode.
 - `monitoring.yml` now runs the aggregate `monitoring` role, which currently
   applies host-local status generation through `monitoring_status`, dedicated
   storage checks through `monitoring_storage_health`, and Docker image-tag

--- a/examples/inventory/group_vars/backup/restore_restic.yml
+++ b/examples/inventory/group_vars/backup/restore_restic.yml
@@ -1,0 +1,48 @@
+---
+# examples/inventory/group_vars/backup/restore_restic.yml
+# Shared Restic restore variables for the example lab.
+# Reuses the same repository and backend credentials as `backup_restic`, while
+# keeping the restore mode and selectable restore paths explicit in example
+# inventory.
+#
+# Quick variable guide:
+# - `restore_restic_mode`: choose `sandbox`, `in_place`, or `repair_path`
+# - `restore_restic_sandbox_target_path`: destination used only in `sandbox`
+#   mode; keeps restored files away from the live filesystem
+# - `restore_restic_paths`: full restore scope used by `sandbox` and
+#   `in_place`; default is the same path set as `backup_restic`
+# - `restore_restic_only_path`: single absolute path used only in
+#   `repair_path`, for example `/srv/wireguard/data`
+# - `restore_restic_snapshot`: snapshot ref to restore, usually `latest`
+# - `restore_restic_restore_overwrite`: Restic overwrite policy during restore
+# - `restore_restic_restore_delete`: optionally remove files under the target
+#   that are not present in the selected restore scope
+# - `restore_restic_restore_dry_run`: preview the restore without writing files
+# - `restore_restic_extra_args`: optional extra `restic restore` CLI flags
+
+# Keep the restore helper enabled so the example lab can exercise the manual
+# restore path without introducing separate secret values.
+restore_restic_enabled: true
+
+# Reuse the same repository and password inputs as the recurring backup role.
+restore_restic_repository: "{{ backup_restic_repository }}"
+restore_restic_password: "{{ backup_restic_password }}"
+restore_restic_extra_environment: "{{ backup_restic_extra_environment }}"
+
+# Restore the latest snapshot in safe sandbox mode by default so example runs
+# do not overwrite the live host filesystem accidentally.
+restore_restic_snapshot: latest
+restore_restic_mode: sandbox
+restore_restic_sandbox_target_path: /backup
+
+# Mirror the recurring backup scope by default so a full restore replays the
+# same paths that the backup role protects.
+restore_restic_paths: "{{ backup_restic_paths }}"
+
+# `repair_path` mode requires one absolute path here, such as
+# `/srv/wireguard/data`, when you only want to repair one subtree in place.
+restore_restic_only_path: ""
+
+# Keep the overwrite behavior explicit in inventory so operators can override
+# it per run with extra vars when needed.
+restore_restic_restore_overwrite: always

--- a/examples/playbooks/ops/restore_restic.yml
+++ b/examples/playbooks/ops/restore_restic.yml
@@ -1,0 +1,56 @@
+---
+# examples/playbooks/ops/restore_restic.yml
+# Dedicated manual-run playbook for the shared `restore_restic` role.
+# Loads the optional local Vault vars file from the control machine inside the
+# restore play so `--limit` runs still receive the Restic repository secrets,
+# then restores according to `restore_restic_mode`.
+# Example default safe sandbox restore:
+#   ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/ops/restore_restic.yml
+# Example full in-place restore:
+#   ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook examples/playbooks/ops/restore_restic.yml -e restore_restic_mode=in_place
+# Example single-path repair restore:
+#   ANSIBLE_CONFIG=examples/ansible.cfg ansible-playbook \
+#     examples/playbooks/ops/restore_restic.yml \
+#     -e restore_restic_mode=repair_path \
+#     -e restore_restic_only_path=/srv/wireguard/data
+
+- name: Run restore_restic for manual restore work
+  hosts: backup
+  serial: 1
+  become: true
+  pre_tasks:
+    - name: Check local Vault vars file when enabled # noqa: run-once[task]
+      ansible.builtin.stat:
+        path: "{{ secret_sources_local_vault_file }}"
+      delegate_to: localhost
+      become: false
+      vars:
+        ansible_become: false
+      register: restore_local_vault_file
+      run_once: true
+      tags: [always]
+      when: secret_sources_use_local_vault_file | default(true)
+
+    - name: Fail when local Vault vars are enabled but missing # noqa: run-once[task]
+      ansible.builtin.fail:
+        msg: >-
+          secret_sources_use_local_vault_file is true, but the local Vault vars
+          file was not found at {{ secret_sources_local_vault_file }}.
+      run_once: true
+      tags: [always]
+      when:
+        - secret_sources_use_local_vault_file | default(true)
+        - not restore_local_vault_file.stat.exists
+
+    - name: Load local Vault vars file on localhost
+      ansible.builtin.include_vars:
+        file: "{{ secret_sources_local_vault_file }}"
+      delegate_to: localhost
+      become: false
+      vars:
+        ansible_become: false
+      tags: [always]
+      when: secret_sources_use_local_vault_file | default(true)
+  roles:
+    - role: restore_restic
+      when: backup_include_restic | default(false)

--- a/roles/restore_restic/README.md
+++ b/roles/restore_restic/README.md
@@ -1,0 +1,83 @@
+# roles/restore_restic/README.md
+
+Reference for the `restore_restic` role.
+Explains how the role performs a manual Restic restore run against the same
+repository inputs used by `backup_restic`, while allowing either the full
+backup scope or one specific path to be restored through an explicit restore
+mode.
+
+## Purpose
+- Run a manual Restic restore directly from Ansible without changing the
+  recurring backup timer workflow
+- Reuse the same repository, password, and backend-environment settings as
+  `backup_restic` by default
+- Keep the default restore path safe by restoring the full backup scope into
+  `/backup`
+- Allow explicit in-place full restore or single-path repair mode when you
+  really want to write back to `/`
+
+## Variables
+
+| Variable | Default | Required | Description |
+|----------|---------|----------|-------------|
+| `restore_restic_repository` | `{{ backup_restic_repository }}` fallback | yes | Restic repository location passed through `RESTIC_REPOSITORY` |
+| `restore_restic_password` | `{{ backup_restic_password }}` fallback | yes | Repository password passed through `RESTIC_PASSWORD` |
+| `restore_restic_extra_environment` | `{{ backup_restic_extra_environment }}` fallback | no | Extra backend-specific environment variables such as S3-compatible credentials |
+| `restore_restic_snapshot` | `latest` | no | Snapshot ID or ref passed to `restic restore` |
+| `restore_restic_mode` | `sandbox` | no | Restore behavior: `sandbox`, `in_place`, or `repair_path` |
+| `restore_restic_sandbox_target_path` | `/backup` | no | Target directory used when `restore_restic_mode: sandbox` |
+| `restore_restic_paths` | `{{ backup_restic_paths }}` fallback | no | Default list of snapshot paths to restore when no single-path override is set |
+| `restore_restic_only_path` | `""` | no | Required absolute path when `restore_restic_mode: repair_path`; ignored in other modes |
+| `restore_restic_restore_overwrite` | `always` | no | Restic overwrite policy (`always`, `if-changed`, `if-newer`, `never`) |
+| `restore_restic_restore_delete` | `false` | no | Whether `restic restore --delete` should remove files missing from the selected restore scope |
+| `restore_restic_restore_dry_run` | `false` | no | Whether to preview the restore without writing files |
+| `restore_restic_extra_args` | `[]` | no | Additional CLI flags appended before the include list |
+
+## Usage
+
+```yaml
+- name: Run a manual restore
+  hosts: backup
+  become: true
+  roles:
+    - role: restore_restic
+```
+
+Example inventory vars:
+
+```yaml
+# group_vars/backup/restore_restic.yml
+restore_restic_repository: "{{ backup_restic_repository }}"
+restore_restic_password: "{{ backup_restic_password }}"
+restore_restic_extra_environment: "{{ backup_restic_extra_environment }}"
+restore_restic_mode: sandbox
+restore_restic_sandbox_target_path: /backup
+restore_restic_paths: "{{ backup_restic_paths }}"
+restore_restic_only_path: ""
+```
+
+## Restore Modes
+
+- `sandbox`: restore the full configured backup scope into `restore_restic_sandbox_target_path`. This is the safe default because it avoids overwriting live files.
+- `in_place`: restore the full configured backup scope back onto `/`.
+- `repair_path`: restore only `restore_restic_only_path` back onto `/`.
+
+Examples:
+
+```sh
+ansible-playbook playbooks/ops/restore_restic.yml
+ansible-playbook playbooks/ops/restore_restic.yml -e restore_restic_mode=in_place
+ansible-playbook playbooks/ops/restore_restic.yml -e restore_restic_mode=repair_path -e restore_restic_only_path=/srv/wireguard/data
+```
+
+## Notes
+- The role installs `restic` if it is missing, then runs the restore command immediately; it does not manage a systemd service or timer.
+- `sandbox` mode is the default so operators can inspect restored files under `/backup` before deciding whether anything should be copied back onto the live filesystem.
+- `in_place` and `repair_path` both restore onto `/`. The upstream Restic docs recommend taking a fresh backup first because an interrupted in-place restore can leave partially restored files.
+- `repair_path` uses Restic's native `--include` filtering, so one selected subtree can be repaired without replaying the full host backup.
+
+## Dependencies
+None
+
+## License
+MIT

--- a/roles/restore_restic/defaults/main.yml
+++ b/roles/restore_restic/defaults/main.yml
@@ -1,0 +1,25 @@
+---
+# roles/restore_restic/defaults/main.yml
+# Default variables for the `restore_restic` role.
+# Defines the package, repository, restore mode, target-path behavior, and
+# overwrite behavior used for manual Restic restore runs.
+
+restore_restic_enabled: true
+
+restore_restic_packages:
+  - restic
+
+restore_restic_repository: "{{ backup_restic_repository | default('') }}"
+restore_restic_password: "{{ backup_restic_password | default('') }}"
+restore_restic_extra_environment: "{{ backup_restic_extra_environment | default({}) }}"
+
+restore_restic_snapshot: latest
+restore_restic_mode: sandbox
+restore_restic_sandbox_target_path: /backup
+restore_restic_paths: "{{ backup_restic_paths | default([]) }}"
+restore_restic_only_path: ""
+
+restore_restic_restore_overwrite: always
+restore_restic_restore_delete: false
+restore_restic_restore_dry_run: false
+restore_restic_extra_args: []

--- a/roles/restore_restic/meta/main.yml
+++ b/roles/restore_restic/meta/main.yml
@@ -1,0 +1,7 @@
+---
+# roles/restore_restic/meta/main.yml
+# Role metadata for `restore_restic`.
+# Leaves dependencies empty because the caller decides when restore work should
+# run and which backup inventory vars it should reuse.
+
+dependencies: []

--- a/roles/restore_restic/tasks/assert.yml
+++ b/roles/restore_restic/tasks/assert.yml
@@ -1,0 +1,87 @@
+---
+# roles/restore_restic/tasks/assert.yml
+# Assert phase tasks for the `restore_restic` role.
+# Validates the repository, selected restore mode, and effective restore
+# target/path set before the manual Restic restore command is run.
+
+- name: "Assert | Derive restore_restic effective target path"
+  ansible.builtin.set_fact:
+    restore_restic_effective_target_path: >-
+      {{
+        restore_restic_sandbox_target_path | trim
+        if (restore_restic_mode == 'sandbox')
+        else '/'
+      }}
+  changed_when: false
+  when: restore_restic_enabled
+
+- name: "Assert | Derive restore_restic effective restore paths"
+  ansible.builtin.set_fact:
+    restore_restic_effective_paths: >-
+      {{
+        [restore_restic_only_path | trim]
+        if (restore_restic_mode == 'repair_path')
+        else (
+          restore_restic_paths
+          | map('string')
+          | map('trim')
+          | reject('equalto', '')
+          | list
+        )
+      }}
+  changed_when: false
+  when: restore_restic_enabled
+
+- name: "Assert | Validate restore_restic variables when enabled"
+  ansible.builtin.assert:
+    that:
+      - restore_restic_enabled is boolean
+      - restore_restic_packages is sequence
+      - restore_restic_packages | length > 0
+      - restore_restic_packages | select('string') | list | length == restore_restic_packages | length
+      - restore_restic_repository is string
+      - restore_restic_repository | length > 0
+      - restore_restic_password is string
+      - restore_restic_password | length > 0
+      - restore_restic_extra_environment is mapping
+      - restore_restic_snapshot is string
+      - restore_restic_snapshot | length > 0
+      - restore_restic_mode in ['sandbox', 'in_place', 'repair_path']
+      - restore_restic_sandbox_target_path is string
+      - restore_restic_sandbox_target_path | length > 0
+      - restore_restic_sandbox_target_path is match('^/')
+      - restore_restic_paths is sequence
+      - restore_restic_paths | select('string') | list | length == restore_restic_paths | length
+      - restore_restic_only_path is string
+      - >-
+        (restore_restic_mode != 'repair_path')
+        or (restore_restic_only_path | trim | length > 0)
+      - >-
+        (restore_restic_mode != 'repair_path')
+        or ((restore_restic_only_path | trim) is match('^/'))
+      - restore_restic_restore_overwrite in ['always', 'if-changed', 'if-newer', 'never']
+      - restore_restic_restore_delete is boolean
+      - restore_restic_restore_dry_run is boolean
+      - restore_restic_extra_args is sequence
+      - restore_restic_extra_args | select('string') | list | length == restore_restic_extra_args | length
+      - restore_restic_effective_target_path is string
+      - restore_restic_effective_target_path | length > 0
+      - restore_restic_effective_target_path is match('^/')
+      - restore_restic_effective_paths is sequence
+      - restore_restic_effective_paths | length > 0
+      - restore_restic_effective_paths | select('match', '^/') | list | length == restore_restic_effective_paths | length
+    fail_msg: >-
+      restore_restic requires a non-empty repository, password, valid restore
+      mode, safe sandbox target path, and at least one absolute restore path
+      when the role is enabled. `repair_path` mode also requires a non-empty
+      absolute `restore_restic_only_path`.
+    quiet: true
+  when: restore_restic_enabled
+
+- name: "Assert | Validate restore_restic variables when disabled"
+  ansible.builtin.assert:
+    that:
+      - restore_restic_enabled is boolean
+    fail_msg: "restore_restic_enabled must be a boolean"
+    quiet: true
+  when: not restore_restic_enabled

--- a/roles/restore_restic/tasks/config.yml
+++ b/roles/restore_restic/tasks/config.yml
@@ -1,0 +1,14 @@
+---
+# roles/restore_restic/tasks/config.yml
+# Config phase tasks for the `restore_restic` role.
+# Ensures the requested restore target directory exists before the restore
+# command runs.
+
+- name: "Config | Ensure restore_restic target directory exists"
+  ansible.builtin.file:
+    path: "{{ restore_restic_effective_target_path }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  when: restore_restic_enabled

--- a/roles/restore_restic/tasks/install.yml
+++ b/roles/restore_restic/tasks/install.yml
@@ -1,0 +1,10 @@
+---
+# roles/restore_restic/tasks/install.yml
+# Install phase tasks for the `restore_restic` role.
+# Ensures the Restic CLI is present before a manual restore run.
+
+- name: "Install | Ensure restore_restic packages are present"
+  ansible.builtin.package:
+    name: "{{ restore_restic_packages }}"
+    state: present
+  when: restore_restic_enabled

--- a/roles/restore_restic/tasks/main.yml
+++ b/roles/restore_restic/tasks/main.yml
@@ -1,0 +1,21 @@
+---
+# roles/restore_restic/tasks/main.yml
+# Task entrypoint for the `restore_restic` role.
+# Imports the standard assert, install, config, and validate phase files in
+# order.
+
+- name: Assert
+  ansible.builtin.import_tasks: assert.yml
+  tags: [assert, restore_restic, restore_restic_assert]
+
+- name: Install
+  ansible.builtin.import_tasks: install.yml
+  tags: [install, restore_restic, restore_restic_install]
+
+- name: Config
+  ansible.builtin.import_tasks: config.yml
+  tags: [config, restore_restic, restore_restic_config]
+
+- name: Validate
+  ansible.builtin.import_tasks: validate.yml
+  tags: [validate, restore_restic, restore_restic_validate]

--- a/roles/restore_restic/tasks/validate.yml
+++ b/roles/restore_restic/tasks/validate.yml
@@ -1,0 +1,62 @@
+---
+# roles/restore_restic/tasks/validate.yml
+# Validate phase tasks for the `restore_restic` role.
+# Verifies the Restic binary, runs the manual restore command, prints a short
+# summary, and fails when the restore does not succeed.
+
+- name: "Validate | Check restic binary version"
+  ansible.builtin.command:
+    cmd: restic version
+  register: restore_restic_version
+  changed_when: false
+  when: restore_restic_enabled
+
+- name: "Validate | Run restore_restic command"
+  ansible.builtin.command:
+    cmd: >-
+      restic restore {{ restore_restic_snapshot | quote }}
+      --target {{ restore_restic_effective_target_path | quote }}
+      --overwrite {{ restore_restic_restore_overwrite | quote }}
+      {% if restore_restic_restore_delete %}--delete {% endif %}
+      {% if restore_restic_restore_dry_run %}--dry-run {% endif %}
+      {% for arg in restore_restic_extra_args %}{{ arg | quote }} {% endfor %}
+      {% for path in restore_restic_effective_paths %}--include {{ path | quote }} {% endfor %}
+  environment: >-
+    {{
+      {
+        'RESTIC_REPOSITORY': restore_restic_repository,
+        'RESTIC_PASSWORD': restore_restic_password
+      } | combine(restore_restic_extra_environment)
+    }}
+  register: restore_restic_command
+  changed_when: >-
+    (not restore_restic_restore_dry_run)
+    and ((restore_restic_command.rc | default(1)) == 0)
+  failed_when: false
+  when: restore_restic_enabled
+
+- name: "Validate | Print restore_restic run summary"
+  ansible.builtin.debug:
+    msg: >-
+      [restore_restic] host={{ inventory_hostname }}
+      | mode={{ restore_restic_mode }}
+      | snapshot={{ restore_restic_snapshot }}
+      | target={{ restore_restic_effective_target_path }}
+      | paths={{ restore_restic_effective_paths | join(',') }}
+      | dry_run={{ restore_restic_restore_dry_run }}
+      | overwrite={{ restore_restic_restore_overwrite }}
+      | rc={{ restore_restic_command.rc | default('n/a') }}
+  when: restore_restic_enabled
+
+- name: "Validate | Assert restore_restic final state"
+  ansible.builtin.assert:
+    that:
+      - restore_restic_version.rc == 0
+      - restore_restic_command.rc == 0
+    fail_msg: >-
+      restore_restic failed.
+      rc={{ restore_restic_command.rc | default('n/a') }}
+      stdout={{ restore_restic_command.stdout | default('') | trim }}
+      stderr={{ restore_restic_command.stderr | default('') | trim }}
+    quiet: true
+  when: restore_restic_enabled


### PR DESCRIPTION
Introduce a new `restore_restic` role that facilitates manual restoration of backups, including necessary tasks, configurations, and documentation. This role allows users to perform restores in various modes while ensuring the required environment and dependencies are set up correctly.