### PR TITLE
feat(base_packages): refactor package management to support default and additional packages

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,7 +58,6 @@ repos:
     hooks:
       - id: ansible-lint
         name: ansible-lint (pipx)
-        entry: ansible-lint -q
+        entry: bash -lc 'ansible-lint -q "$@"' --
         language: system
-        pass_filenames: false
         files: \.ya?ml$

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 Release history for `homelab-roles`.
 Documents notable changes across repository structure, roles, examples, and documentation.
 
+## [v2.11.3]
+### Changed
+- Added the additive `base_packages_default` plus `base_packages_additional` pattern to `base_packages`, with derived effective install handling so inventories can extend the shared baseline without replacing it.
+- Updated the example inventory and downstream role docs so Traefik-published service hostnames now derive from `docker_public_host_alias` plus `docker_public_domain_suffix` for AdGuard Sync, WireGuard, Plex, Rustatio, Radarr, and Sonarr.
+
+### Documentation
+- Fixed the Vault guidance and example inventory comments so they no longer point maintainers at the removed host-specific public-host vault keys.
+
 ## [v2.11.2]
 ### Added
 - Added standalone `restore_restic`, plus example inventory wiring and a dedicated `examples/playbooks/ops/restore_restic.yml` helper so downstream repos can restore the full Restic backup scope by default or override one specific path for targeted repair work.

--- a/docs/08-docker-traefik-downstream-services.md
+++ b/docs/08-docker-traefik-downstream-services.md
@@ -71,6 +71,8 @@ docker_public_host_alias: "{{ alias | default(inventory_hostname) }}"
 docker_public_domain_suffix: "{{ vault_docker_public_domain_suffix }}"
 docker_traefik_dashboard_host: "traefik.{{ docker_public_host_alias }}.{{ docker_public_domain_suffix }}"
 docker_adguard_host: "adguard.{{ docker_public_host_alias }}.{{ docker_public_domain_suffix }}"
+docker_adguard_sync_host: "adguard-sync.{{ docker_public_host_alias }}.{{ docker_public_domain_suffix }}"
+docker_wireguard_host: "wireguard.{{ docker_public_host_alias }}.{{ docker_public_domain_suffix }}"
 ```
 
 This keeps host-specific dashboard names predictable while storing only the
@@ -80,6 +82,8 @@ For a host with `alias=proxy1`, this produces:
 
 - `traefik.proxy1.example.com`
 - `adguard.proxy1.example.com`
+- `adguard-sync.proxy1.example.com`
+- `wireguard.proxy1.example.com`
 
 If you adopt this pattern, keep DNS aligned with it through either:
 

--- a/examples/inventory/examples/vault.yml.example
+++ b/examples/inventory/examples/vault.yml.example
@@ -29,8 +29,10 @@ vault_user_password_hash: "$6$replace-me"
 # Example ACME contact email used by Traefik for Let's Encrypt registration.
 vault_docker_traefik_acme_email: "admin@example.com"
 
-# Shared public domain suffix used to build Traefik and AdGuard dashboard
-# hostnames from the inventory `alias`.
+# Shared public domain suffix used to build all Traefik-published service
+# hostnames from the inventory `alias`.  The inventory derives each service
+# host as `<service>.<alias>.<suffix>`, for example
+# `adguard.lab.example.com` or `wireguard.lab.example.com`.
 vault_docker_public_domain_suffix: "example.com"
 
 # Example DNS provider credential used by Traefik for ACME DNS-01.
@@ -54,8 +56,9 @@ vault_docker_adguard_admin_credentials: "admin:$2a$10$replace-me"
 # docker_adguard_sync
 # ---------------------------------------------------------------------------
 
-# Example public host name used by Traefik for the AdGuard Sync dashboard.
-vault_docker_adguard_sync_host: "adguard-sync.example.com"
+# The AdGuard Sync dashboard host is now derived automatically from the
+# inventory alias and `vault_docker_public_domain_suffix`, so no separate
+# vault host variable is needed.
 
 # Example direct LAN IP for the origin AdGuard instance.
 vault_docker_adguard_sync_origin_ip: "192.168.1.53"
@@ -80,14 +83,15 @@ vault_docker_adguard_sync_api_password: ""
 # docker_wireguard
 # ---------------------------------------------------------------------------
 
-# Example public host name used by both the wg-easy initial setup and the
-# Traefik router for the WireGuard dashboard.
-vault_docker_wireguard_host: "wireguard.example.com"
+# The WireGuard dashboard host is now derived automatically from the inventory
+# alias and `vault_docker_public_domain_suffix`, so no separate vault host
+# variable is needed.
 
 # Optional separate VPN endpoint host name passed to wg-easy as `INIT_HOST`.
 # Set this when WireGuard clients should connect through DuckDNS or another
-# DDNS name while the dashboard stays on `vault_docker_wireguard_host`.
-# Omit this key entirely to reuse `vault_docker_wireguard_host`.
+# DDNS name while the dashboard stays on the derived
+# `wireguard.<alias>.<domain>` host.
+# Omit this key entirely to reuse the derived dashboard host.
 vault_docker_wireguard_duckdns_host: "myhomelabvpn.duckdns.org"
 
 # Example initial admin username for the wg-easy dashboard.

--- a/examples/inventory/group_vars/base/base_packages.yml
+++ b/examples/inventory/group_vars/base/base_packages.yml
@@ -6,7 +6,7 @@
 base_packages_enabled: true
 # Packages that should exist on almost every homelab host.
 # Keep this role generic: only "common everywhere" packages belong here.
-base_packages_install:
+base_packages_default:
   # HTTPS / repo / package trust
   - ca-certificates   # trusted CA bundle for HTTPS downloads and APT repos
   - curl              # download files / test HTTP endpoints
@@ -52,6 +52,10 @@ base_packages_install:
   # Ansible-managed host requirements
   - python3           # required on most hosts for Ansible modules
   - python3-apt       # lets Ansible manage apt packages properly on Debian/Ubuntu
+
+# Host-specific additions belong in host_vars or more specific group_vars.
+# Leave empty here so the shared baseline stays authoritative.
+base_packages_additional: []
 
 # Packages to remove from all hosts if you want to enforce absence.
 # Leave empty until you have a clear reason to remove something globally.

--- a/examples/inventory/group_vars/docker/docker_adguard_sync.yml
+++ b/examples/inventory/group_vars/docker/docker_adguard_sync.yml
@@ -32,8 +32,10 @@ docker_adguard_sync_access_group_members: "{{ docker_adguard_access_group_member
 # Publish the AdGuard Sync web UI through Traefik, but keep the internal sync
 # traffic on LAN IP plus direct AdGuard HTTP bind port so replica updates do
 # not depend on public-name resolution.
+# Build the sync host from the inventory alias so each host gets a stable URL
+# such as `adguard-sync.lab.example.com` in the example lab.
 docker_adguard_sync_proxy_network_name: "{{ docker_traefik_network_name }}"
-docker_adguard_sync_host: "{{ vault_docker_adguard_sync_host }}"
+docker_adguard_sync_host: "adguard-sync.{{ docker_public_host_alias }}.{{ docker_public_domain_suffix }}"
 docker_adguard_sync_origin:
   url: "http://{{ vault_docker_adguard_sync_origin_ip }}:{{ docker_adguard_http_bind_port }}"
   username: "{{ docker_adguard_admin_credentials.split(':', 1)[0] }}"

--- a/examples/inventory/group_vars/docker/docker_wireguard.yml
+++ b/examples/inventory/group_vars/docker/docker_wireguard.yml
@@ -35,8 +35,10 @@ docker_wireguard_access_group_members:
 # Join the Traefik-owned proxy network and publish the `wg-easy` web UI
 # through Compose labels instead of exposing the dashboard directly on the
 # host.
+# Build the dashboard host from the inventory alias so each host gets a stable
+# URL such as `wireguard.lab.example.com` in the example lab.
 docker_wireguard_proxy_network_name: "{{ docker_traefik_network_name }}"
-docker_wireguard_host: "{{ vault_docker_wireguard_host }}"
+docker_wireguard_host: "wireguard.{{ docker_public_host_alias }}.{{ docker_public_domain_suffix }}"
 docker_wireguard_web_ui_enabled: true
 docker_wireguard_router_name: wireguard
 docker_wireguard_router_entrypoints:

--- a/examples/inventory/host_vars/lab/vars.yml
+++ b/examples/inventory/host_vars/lab/vars.yml
@@ -5,6 +5,8 @@
 
 # Base layer role overrides for this host.
 base_packages_enabled: true
+# Add host-only packages here without replacing the shared baseline list.
+base_packages_additional: []
 base_locale_enabled: true
 base_timezone_enabled: true
 base_ntp_enabled: true

--- a/roles/base_packages/defaults/main.yml
+++ b/roles/base_packages/defaults/main.yml
@@ -1,7 +1,15 @@
 ---
 # roles/base_packages/defaults/main.yml
 # Default variables for the `base_packages` role.
-# Defines package lists to install everywhere and packages to enforce as absent.
+# Defines default and host-additive package lists plus packages to enforce as absent.
 
+# Shared baseline packages for all hosts using the role.
+base_packages_default: []
+
+# Host- or group-specific additions layered on top of the shared baseline.
+base_packages_additional: []
+
+# Legacy full-override install list. When non-empty, the role uses this list
+# instead of combining `base_packages_default` and `base_packages_additional`.
 base_packages_install: []
 base_packages_remove: []

--- a/roles/base_packages/tasks/assert.yml
+++ b/roles/base_packages/tasks/assert.yml
@@ -6,20 +6,28 @@
 - name: "Assert | Validate base_packages variable structure"
   ansible.builtin.assert:
     that:
+      - base_packages_default is sequence
+      - base_packages_additional is sequence
       - base_packages_install is sequence
       - base_packages_remove is sequence
+      - base_packages_default is not string
+      - base_packages_additional is not string
       - base_packages_install is not string
       - base_packages_remove is not string
+      - (base_packages_default | map('string') | list | length) == (base_packages_default | length)
+      - (base_packages_additional | map('string') | list | length) == (base_packages_additional | length)
       - (base_packages_install | map('string') | list | length) == (base_packages_install | length)
       - (base_packages_remove | map('string') | list | length) == (base_packages_remove | length)
+      - (base_packages_default | map('trim') | reject('equalto', '') | list | length) == (base_packages_default | length)
+      - (base_packages_additional | map('trim') | reject('equalto', '') | list | length) == (base_packages_additional | length)
       - (base_packages_install | map('trim') | reject('equalto', '') | list | length) == (base_packages_install | length)
       - (base_packages_remove | map('trim') | reject('equalto', '') | list | length) == (base_packages_remove | length)
-    fail_msg: "base_packages_install and base_packages_remove must be lists of non-empty strings"
+    fail_msg: "base_packages_default, base_packages_additional, base_packages_install, and base_packages_remove must be lists of non-empty strings"
     quiet: true
 
 - name: "Assert | Ensure install and remove lists do not overlap"
   ansible.builtin.assert:
     that:
-      - (base_packages_install | intersect(base_packages_remove) | length) == 0
-    fail_msg: "base_packages_install and base_packages_remove cannot contain the same package names"
+      - (base_packages_effective_install | intersect(base_packages_remove) | length) == 0
+    fail_msg: "base_packages_effective_install and base_packages_remove cannot contain the same package names"
     quiet: true

--- a/roles/base_packages/tasks/derive_effective.yml
+++ b/roles/base_packages/tasks/derive_effective.yml
@@ -1,0 +1,22 @@
+---
+# roles/base_packages/tasks/derive_effective.yml
+# Helper tasks for the `base_packages` role.
+# Resolves the effective install list from the default/additional pattern.
+
+- name: "Derive | Resolve effective install package list"
+  ansible.builtin.set_fact:
+    base_packages_effective_install: >-
+      {{
+        (
+          base_packages_install
+          if (base_packages_install | length) > 0
+          else (
+            (
+              base_packages_default
+              + base_packages_additional
+            )
+            | unique
+          )
+        )
+      }}
+  changed_when: false

--- a/roles/base_packages/tasks/install.yml
+++ b/roles/base_packages/tasks/install.yml
@@ -5,8 +5,8 @@
 
 - name: "Install | Ensure requested packages are present"
   ansible.builtin.apt:
-    name: "{{ base_packages_install }}"
+    name: "{{ base_packages_effective_install }}"
     state: present
     update_cache: true
     cache_valid_time: 3600
-  when: base_packages_install | length > 0
+  when: base_packages_effective_install | length > 0

--- a/roles/base_packages/tasks/main.yml
+++ b/roles/base_packages/tasks/main.yml
@@ -1,7 +1,11 @@
 ---
 # roles/base_packages/tasks/main.yml
 # Task entrypoint for the `base_packages` role.
-# Imports the assert, install, config, and validate phase files in order.
+# Imports the derive, assert, install, config, and validate phase files in order.
+
+- name: Derive effective packages
+  ansible.builtin.import_tasks: derive_effective.yml
+  tags: [assert, install, validate, base_packages_assert, base_packages_install, base_packages_validate]
 
 - name: Assert
   ansible.builtin.import_tasks: assert.yml

--- a/roles/base_packages/tasks/validate.yml
+++ b/roles/base_packages/tasks/validate.yml
@@ -10,10 +10,10 @@
 - name: "Validate | Assert requested install packages are present"
   ansible.builtin.assert:
     that:
-      - (base_packages_install | difference(ansible_facts.packages.keys() | list) | length) == 0
+      - (base_packages_effective_install | difference(ansible_facts.packages.keys() | list) | length) == 0
     fail_msg: >-
       Missing packages after install phase:
-      {{ base_packages_install | difference(ansible_facts.packages.keys() | list) | join(', ') }}
+      {{ base_packages_effective_install | difference(ansible_facts.packages.keys() | list) | join(', ') }}
     quiet: true
 
 - name: "Validate | Assert requested removed packages are absent"

--- a/roles/docker_adguard_sync/README.md
+++ b/roles/docker_adguard_sync/README.md
@@ -69,7 +69,7 @@ docker_adguard_sync_service_user: "{{ docker_adguard_service_user }}"
 docker_adguard_sync_access_group: "{{ docker_adguard_access_group }}"
 docker_adguard_sync_access_group_members: "{{ docker_adguard_access_group_members }}"
 docker_adguard_sync_proxy_network_name: "{{ docker_traefik_network_name }}"
-docker_adguard_sync_host: "{{ vault_docker_adguard_sync_host }}"
+docker_adguard_sync_host: "adguard-sync.{{ docker_public_host_alias }}.{{ docker_public_domain_suffix }}"
 docker_adguard_sync_origin:
   url: "http://{{ vault_docker_adguard_sync_origin_ip }}:{{ docker_adguard_http_bind_port }}"
   username: "{{ docker_adguard_admin_credentials.split(':', 1)[0] }}"

--- a/roles/docker_wireguard/README.md
+++ b/roles/docker_wireguard/README.md
@@ -81,7 +81,7 @@ docker_wireguard_access_group_members: >-
     | list
   }}
 docker_wireguard_proxy_network_name: "{{ docker_traefik_network_name }}"
-docker_wireguard_host: "{{ vault_docker_wireguard_host }}"
+docker_wireguard_host: "wireguard.{{ docker_public_host_alias }}.{{ docker_public_domain_suffix }}"
 docker_wireguard_init_host: "{{ vault_docker_wireguard_duckdns_host | default(docker_wireguard_host) }}"
 docker_wireguard_web_ui_enabled: true
 docker_wireguard_admin_username: "{{ vault_docker_wireguard_admin_username }}"


### PR DESCRIPTION
feat(docs): update documentation for AdGuard Sync and WireGuard hostnames

feat(vault): derive AdGuard Sync and WireGuard hostnames from inventory alias

feat(assert): enhance validation for base package lists

feat(derive): add task to resolve effective package installation list

fix(docker): update README to reflect new host naming conventions