### PR TITLE
Fix/vps usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Release history for `homelab-roles`.
 Documents notable changes across repository structure, roles, examples, and documentation.
 
-## [Unreleased]
+## [v2.11.4]
 ### Added
 - Added a dedicated `base_firewall_repair` role plus `examples/playbooks/ops/base_firewall_repair.yml` for manual UFW/backend recovery when a host has masked UFW service state or mixed iptables backends.
 
@@ -14,6 +14,10 @@ Documents notable changes across repository structure, roles, examples, and docu
 - Defaulted `base_firewall_repair` to non-destructive behavior by requiring an explicit opt-in to flush the entire nftables ruleset.
 - Fixed UFW rule validation to match actual `ufw show added` output format (omits `in` direction word for non-interface rules).
 - Fixed `base_firewall` logging convergence on inactive or freshly reset hosts by persisting `LOGLEVEL` in `/etc/ufw/ufw.conf` instead of calling `ufw logging <level>` before the final firewall enable step.
+
+### Fixed
+- Restored runtime UFW logging application during `base_firewall` convergence so the validated live firewall state still matches the requested logging level on enabled hosts.
+- Made `base_firewall_repair` preserve Docker’s pre-repair runtime state, so the helper only restarts Docker if it was already running before backend repair.
 
 ### Documentation
 - Updated the `docker_traefik` role reference and example inventory docs to drop the old Docker API override guidance.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,22 @@
 Release history for `homelab-roles`.
 Documents notable changes across repository structure, roles, examples, and documentation.
 
+## [Unreleased]
+### Added
+- Added a dedicated `base_firewall_repair` role plus `examples/playbooks/ops/base_firewall_repair.yml` for manual UFW/backend recovery when a host has masked UFW service state or mixed iptables backends.
+
+### Changed
+- Simplified `docker_traefik` by removing the Docker API detection and `DOCKER_API_VERSION` injection workaround now that newer pinned Traefik releases cover the Docker-provider compatibility issue directly.
+- Updated the example Traefik inventory and shared role default to pin `traefik:v3.6.13` instead of the older `v3.4` line.
+- Kept destructive firewall backend repair out of the normal `base_firewall` convergence path so recurring runs only manage the requested UFW baseline.
+- Defaulted `base_firewall_repair` to non-destructive behavior by requiring an explicit opt-in to flush the entire nftables ruleset.
+- Fixed UFW rule validation to match actual `ufw show added` output format (omits `in` direction word for non-interface rules).
+- Fixed `base_firewall` logging convergence on inactive or freshly reset hosts by persisting `LOGLEVEL` in `/etc/ufw/ufw.conf` instead of calling `ufw logging <level>` before the final firewall enable step.
+
+### Documentation
+- Updated the `docker_traefik` role reference and example inventory docs to drop the old Docker API override guidance.
+- Updated the `base_firewall` and `base_firewall_repair` role docs to distinguish routine convergence from manual repair.
+
 ## [v2.11.3]
 ### Changed
 - Added the additive `base_packages_default` plus `base_packages_additional` pattern to `base_packages`, with derived effective install handling so inventories can extend the shared baseline without replacing it.

--- a/examples/inventory/group_vars/all/backup.yml
+++ b/examples/inventory/group_vars/all/backup.yml
@@ -12,3 +12,8 @@
 backup_include_restic: false
 backup_include_restic_prune: false
 backup_include_restic_check: false
+
+backup_restic_enabled: false
+backup_restic_prune_enabled: false
+backup_restic_check_enabled: false
+restore_restic_enabled: false

--- a/examples/inventory/group_vars/all/docker.yml
+++ b/examples/inventory/group_vars/all/docker.yml
@@ -1,31 +1,30 @@
 ---
 # examples/inventory/group_vars/all/docker.yml
 # Shared aggregate Docker-role variables for the example lab.
-# Defines the optional aggregate-role toggles for the example Docker layer.
-# Keep these disabled by default here, then enable them per host in
-# `examples/inventory/host_vars/<host>/vars.yml`.
+# Defines default-off aggregate-role toggles for the example Docker layer.
+# `examples/inventory/group_vars/docker/docker.yml` enables the normal example
+# Docker stack for hosts in the `docker` inventory group.
 
-# Keep Docker engine enabled in the example lab so the Docker role installs
-# and configures the engine plus Docker supplementary-group access.
+# Disabled here because this file is the broad default layer.
 docker_include_engine: false
 
-# Keep the Traefik reverse proxy enabled in the example lab so the Docker role
-# also exercises a Compose-managed service workload.
+# Disabled here because this file is the broad default layer.
 docker_include_traefik: false
 
-# Keep AdGuard enabled in the example lab so the Docker layer also exercises a
-# Traefik-connected downstream service that binds the host DNS port and joins
-# the shared proxy network after Traefik.
+# Disabled here because this file is the broad default layer.
 docker_include_adguard: false
 
-# Keep AdGuard Sync disabled by default here, then enable it only on the host
-# that should push AdGuard config to replicas.
+# Disabled here because this file is the broad default layer.
 docker_include_adguard_sync: false
 
-# Keep WireGuard enabled in the example lab so the Docker layer also exercises
-# a `wg-easy` dashboard behind Traefik plus a direct UDP VPN listener.
+# Disabled here because this file is the broad default layer.
 docker_include_wireguard: false
 
-# Public Traefik hostnames are set explicitly by the service group vars and can
-# be overridden per host in `host_vars/<host>/vars.yml`. Do not derive them from
-# inventory aliases or Vault domain suffixes.
+docker_engine_enabled: false
+docker_traefik_enabled: false
+docker_adguard_enabled: false
+docker_adguard_sync_enabled: false
+docker_wireguard_enabled: false
+
+# Public Traefik hostnames are set explicitly by the service group vars. Do not
+# derive them from inventory aliases or Vault domain suffixes.

--- a/examples/inventory/group_vars/all/monitoring.yml
+++ b/examples/inventory/group_vars/all/monitoring.yml
@@ -16,3 +16,10 @@ monitoring_include_docker_tag: false
 monitoring_include_collect: false
 monitoring_include_web: false
 monitoring_include_notify: false
+
+monitoring_status_enabled: false
+monitoring_storage_health_enabled: false
+monitoring_docker_tag_enabled: false
+monitoring_collect_enabled: false
+monitoring_web_enabled: false
+monitoring_notify_enabled: false

--- a/examples/inventory/group_vars/all/user.yml
+++ b/examples/inventory/group_vars/all/user.yml
@@ -1,9 +1,9 @@
 ---
 # examples/inventory/group_vars/all/user.yml
 # Shared aggregate user-role variables for the example lab.
-# Defines the optional aggregate-role toggles for the example user layer.
-# Keep these disabled by default here, then enable them per host in
-# `examples/inventory/host_vars/<host>/vars.yml`.
+# Defines default-off aggregate-role toggles for the example user layer.
+# `examples/inventory/group_vars/user/user.yml` enables the normal example
+# human-admin workflow for hosts in the `user` inventory group.
 
 # Keep these aggregate toggles in the same order used by
 # `roles/user/tasks/main.yml`.
@@ -13,8 +13,7 @@
 user_include_groups: false
 
 # 3. `user_sudo` runs after account and supplementary-group state when enabled.
-# Keep this enabled in the example lab so the human admin account has one
-# explicit managed sudoers drop-in instead of relying only on distro defaults.
+# Disabled here because this file is the broad default layer.
 user_include_sudo: false
 
 # If you later disable `user_include_sudo`, set this to true for one cleanup
@@ -22,39 +21,32 @@ user_include_sudo: false
 user_cleanup_disabled_sudo_drop_in: false
 
 # 4. `user_password` runs after account, group, and sudo state when enabled.
-# Keep password management enabled in the example lab so the example human
-# admin account has a usable local password in addition to any SSH access.
+# Disabled here because this file is the broad default layer.
 # The companion `user_password.yml` file uses the plaintext test password
 # `password` as a documented local-lab example, so replace that demo hash
 # before using this pattern on a real host.
 user_include_password: false
 
 # 5. `user_ssh` runs after account, group, sudo, and password state.
-# Keep this enabled in the example lab so the human admin account gets a
-# managed `.ssh` baseline with authorized keys plus optional client files.
+# Disabled here because this file is the broad default layer.
 user_include_ssh: false
 
 # 6. `user_zshell` runs after the optional SSH-access layer.
-# Keep this enabled in the example lab so the human admin account gets the
-# managed zsh login shell and a managed `.zshrc`.
+# Disabled here because this file is the broad default layer.
 user_include_zshell: false
 
 # 7. `user_profile` runs after the optional zsh shell layer.
-# Keep this enabled in the example lab so the human admin account gets managed
-# login/session defaults in `.profile` and a simple `.bash_profile` bridge.
+# Disabled here because this file is the broad default layer.
 user_include_profile: false
 
 # 8. `user_directories` runs after the optional login/profile layer.
-# Keep this enabled in the example lab so the human admin account gets a small
-# standard workspace layout under its existing home directory.
+# Disabled here because this file is the broad default layer.
 user_include_directories: false
 
 # 9. `user_git` runs after the optional directory-standardization layer.
-# Keep this enabled in the example lab so the human admin account gets a small
-# managed Git identity plus alias baseline in `~/.gitconfig`.
+# Disabled here because this file is the broad default layer.
 user_include_git: false
 
 # 10. `user_vim` runs after the optional Git layer.
-# Keep this enabled in the example lab so the human admin account gets a managed
-# `.vimrc` editor configuration baseline.
+# Disabled here because this file is the broad default layer.
 user_include_vim: false

--- a/examples/inventory/group_vars/backup/backup.yml
+++ b/examples/inventory/group_vars/backup/backup.yml
@@ -3,11 +3,18 @@
 # Backup-layer toggle variables for hosts in the dedicated example `backup`
 # inventory group.
 # Keeps the aggregate backup layer disabled by default in `group_vars/all`, then
-# enables the recurring Restic workflow for the example backup hosts while
-# leaving host_vars free to override any toggle later.
+# enables the recurring Restic workflow for hosts in the `backup` group.
 
 # The example backup group should exercise the recurring Restic workflow by
-# default. A specific example host can still opt out in host vars when needed.
+# default.
 backup_include_restic: true
 backup_include_restic_prune: true
 backup_include_restic_check: true
+
+# Keep the role-internal service states together with the aggregate includes so
+# one file answers both questions: "is the role included?" and "should it keep
+# its managed service/timer active?"
+backup_restic_enabled: true
+backup_restic_prune_enabled: true
+backup_restic_check_enabled: true
+restore_restic_enabled: true

--- a/examples/inventory/group_vars/backup/backup_restic.yml
+++ b/examples/inventory/group_vars/backup/backup_restic.yml
@@ -6,7 +6,6 @@
 
 # Keep the example backup role enabled so the example lab also exercises the
 # shared Restic timer and JSON-status contract.
-backup_restic_enabled: true
 
 # Load the example repository and password from inventory-local Vault vars.
 backup_restic_repository: "{{ vault_backup_restic_repository }}/{{ alias | default(inventory_hostname) }}"

--- a/examples/inventory/group_vars/backup/backup_restic_check.yml
+++ b/examples/inventory/group_vars/backup/backup_restic_check.yml
@@ -6,7 +6,6 @@
 
 # Keep the example check role enabled so the example lab also exercises the
 # recurring repository-health path and its separate JSON-status contract.
-backup_restic_check_enabled: true
 
 # Keep the check JSON status output explicit in inventory so monitoring and
 # validation consumers can see and override it without opening the shared role

--- a/examples/inventory/group_vars/backup/backup_restic_prune.yml
+++ b/examples/inventory/group_vars/backup/backup_restic_prune.yml
@@ -6,7 +6,6 @@
 
 # Keep the example prune role enabled so the example lab also exercises the
 # recurring retention cleanup path and its separate JSON-status contract.
-backup_restic_prune_enabled: true
 
 # Keep the prune JSON status output explicit in inventory so monitoring and
 # validation consumers can see and override it without opening the shared role

--- a/examples/inventory/group_vars/backup/restore_restic.yml
+++ b/examples/inventory/group_vars/backup/restore_restic.yml
@@ -22,7 +22,6 @@
 
 # Keep the restore helper enabled so the example lab can exercise the manual
 # restore path without introducing separate secret values.
-restore_restic_enabled: true
 
 # Reuse the same repository and password inputs as the recurring backup role.
 restore_restic_repository: "{{ backup_restic_repository }}"

--- a/examples/inventory/group_vars/base/base.yml
+++ b/examples/inventory/group_vars/base/base.yml
@@ -1,0 +1,24 @@
+---
+# examples/inventory/group_vars/base/base.yml
+# Base-layer switchboard for hosts in the example `base` inventory group.
+# `group_vars/all/base.yml` keeps every base role disabled by default. This
+# file turns on the base roles that a normal base host should run, so component
+# files can focus on role configuration instead of on/off decisions.
+
+base_packages_enabled: true
+base_locale_enabled: true
+base_timezone_enabled: true
+base_ntp_enabled: true
+base_hostname_enabled: true
+base_hosts_enabled: true
+base_dns_enabled: true
+base_sudo_enabled: true
+base_sshd_enabled: true
+base_firewall_enabled: true
+base_fail2ban_enabled: true
+base_logging_enabled: true
+base_updates_enabled: true
+base_apparmor_enabled: true
+base_auditd_enabled: true
+base_upgrade_enabled: true
+base_needrestart_enabled: true

--- a/examples/inventory/group_vars/base/base_apparmor.yml
+++ b/examples/inventory/group_vars/base/base_apparmor.yml
@@ -16,4 +16,3 @@ base_apparmor_service_name: apparmor
 # the kernel and policy baseline are ready there.
 # Set this to false when you explicitly want the package baseline installed
 # without the service being active.
-base_apparmor_enabled: false

--- a/examples/inventory/group_vars/base/base_auditd.yml
+++ b/examples/inventory/group_vars/base/base_auditd.yml
@@ -12,7 +12,6 @@ base_auditd_service_name: auditd
 
 # Keep the audit daemon disabled in shared example vars, then enable it per
 # host when the base layer should manage audit state there.
-base_auditd_enabled: false
 
 # Flush audit records asynchronously for a safer balance between durability
 # and runtime overhead in the example lab.

--- a/examples/inventory/group_vars/base/base_dns.yml
+++ b/examples/inventory/group_vars/base/base_dns.yml
@@ -3,7 +3,6 @@
 # Shared DNS variables for the example lab.
 # Defines the resolver mode, DNS servers, and optional search domains enforced during the base phase.
 
-base_dns_enabled: false
 # Resolver backend managed during the base phase.
 # Choose this manually after checking the host:
 #   ls -l /etc/resolv.conf

--- a/examples/inventory/group_vars/base/base_fail2ban.yml
+++ b/examples/inventory/group_vars/base/base_fail2ban.yml
@@ -3,7 +3,6 @@
 # Shared Fail2ban variables for the example lab.
 # Defines the Fail2ban package, service, and SSH jail baseline enforced during the base phase.
 
-base_fail2ban_enabled: false
 # Package list installed with APT to provide the Fail2ban baseline.
 base_fail2ban_packages:
   - fail2ban

--- a/examples/inventory/group_vars/base/base_firewall.yml
+++ b/examples/inventory/group_vars/base/base_firewall.yml
@@ -9,7 +9,6 @@ base_firewall_packages:
 
 # Keep the firewall disabled in shared example vars, then enable it per host
 # when the base layer should manage UFW state there.
-base_firewall_enabled: false
 
 # Logging level configured through UFW.
 base_firewall_logging: low

--- a/examples/inventory/group_vars/base/base_hostname.yml
+++ b/examples/inventory/group_vars/base/base_hostname.yml
@@ -3,7 +3,6 @@
 # Shared hostname variables for the example lab.
 # Defines the hostname enforced during the base phase.
 
-base_hostname_enabled: true
 # Hostname enforced during the base phase.
 # Use the final host name or FQDN you want written to /etc/hostname.
 # The current short hostname is expected to match the first label.

--- a/examples/inventory/group_vars/base/base_hosts.yml
+++ b/examples/inventory/group_vars/base/base_hosts.yml
@@ -3,7 +3,6 @@
 # Shared hosts-file variables for the example lab.
 # Defines the inventory-driven `/etc/hosts` block settings used during the base phase.
 
-base_hosts_enabled: false
 # Inventory group used to build the managed `/etc/hosts` block.
 # Keep `all` here so every host in the example lab learns the inventory
 # hostname-to-address mappings for every other managed host.

--- a/examples/inventory/group_vars/base/base_locale.yml
+++ b/examples/inventory/group_vars/base/base_locale.yml
@@ -3,7 +3,6 @@
 # Shared locale variables for the example lab.
 # Defines the locale packages, generated locales, and default locale categories enforced during the base phase.
 
-base_locale_enabled: true
 # Package list installed with APT to provide locale tools and locale data on the host.
 base_locale_packages:
   - locales           # locale support package used by the base_locale role on Debian-family hosts

--- a/examples/inventory/group_vars/base/base_logging.yml
+++ b/examples/inventory/group_vars/base/base_logging.yml
@@ -3,7 +3,6 @@
 # Shared logging variables for the example lab.
 # Defines the journald package, service, storage, and retention values used during the base phase.
 
-base_logging_enabled: false
 # Package list installed with APT before journald configuration.
 # Keep `systemd` here in the example lab so the journald package baseline is
 # explicitly present before the role manages configuration.

--- a/examples/inventory/group_vars/base/base_needrestart.yml
+++ b/examples/inventory/group_vars/base/base_needrestart.yml
@@ -3,7 +3,6 @@
 # Shared needrestart variables for the example lab.
 # Defines the non-interactive restart-check behavior exposed during the base phase.
 
-base_needrestart_enabled: false
 # Package list installed with APT to provide the needrestart restart-check
 # command used by the example lab.
 base_needrestart_packages:

--- a/examples/inventory/group_vars/base/base_ntp.yml
+++ b/examples/inventory/group_vars/base/base_ntp.yml
@@ -3,7 +3,6 @@
 # Shared NTP variables for the example lab.
 # Defines the NTP package, service, and server lists enforced during the base phase.
 
-base_ntp_enabled: true
 # Package list installed with APT to provide the NTP client on the host.
 base_ntp_packages:
   - systemd-timesyncd  # systemd NTP client used by the base_ntp role on Debian-family hosts

--- a/examples/inventory/group_vars/base/base_packages.yml
+++ b/examples/inventory/group_vars/base/base_packages.yml
@@ -3,7 +3,6 @@
 # Shared package variables for the example lab.
 # Defines common packages to install and packages to keep absent during the base phase.
 
-base_packages_enabled: true
 # Packages that should exist on almost every homelab host.
 # Keep this role generic: only "common everywhere" packages belong here.
 base_packages_default:

--- a/examples/inventory/group_vars/base/base_sshd.yml
+++ b/examples/inventory/group_vars/base/base_sshd.yml
@@ -3,7 +3,6 @@
 # Shared SSH daemon variables for the example lab.
 # Defines the SSH daemon package, service, and managed policy enforced during the base phase.
 
-base_sshd_enabled: true
 # Package list installed with APT to provide the SSH daemon on the host.
 base_sshd_packages:
   - openssh-server    # OpenSSH server package for Debian-family hosts
@@ -24,10 +23,18 @@ base_sshd_password_authentication: true
 # Keep public-key authentication enabled for the automation account.
 base_sshd_pubkey_authentication: true
 
-# Optional login allow-list for the example lab. The role validates that these
-# users are present in the effective AllowUsers result after SSH config merge.
-base_sshd_allow_users:
-  - vagrant      # Used by Vagrant for VM lifecycle (halt/up) and testing automation
-  - ansible
-  - admin
-  - human-user    # Example human admin account managed by the user layer
+# Optional login allow-list for the example lab. Keep provider, bootstrap, and
+# human users able to log in; `unique` keeps the list safe when two names match.
+base_sshd_allow_users: >-
+  {{
+    [
+      'vagrant',
+      bootstrap_user,
+      bootstrap_login_user,
+      user_account_name
+    ]
+    | map('trim')
+    | reject('equalto', '')
+    | unique
+    | list
+  }}

--- a/examples/inventory/group_vars/base/base_sudo.yml
+++ b/examples/inventory/group_vars/base/base_sudo.yml
@@ -3,7 +3,6 @@
 # Shared sudo variables for the example lab.
 # Defines the sudo package, managed user, and sudo group enforced during the base phase.
 
-base_sudo_enabled: true
 # Package list installed with APT to provide sudo on the host.
 base_sudo_packages:
   - sudo             # privilege escalation package used by the base_sudo role

--- a/examples/inventory/group_vars/base/base_timezone.yml
+++ b/examples/inventory/group_vars/base/base_timezone.yml
@@ -3,7 +3,6 @@
 # Shared timezone variables for the example lab.
 # Defines the timezone package and timezone enforced during the base phase.
 
-base_timezone_enabled: true
 # Package list installed with APT to provide timezone data on the host.
 base_timezone_packages:
   - tzdata            # timezone database package used by the base_timezone role

--- a/examples/inventory/group_vars/base/base_updates.yml
+++ b/examples/inventory/group_vars/base/base_updates.yml
@@ -3,7 +3,6 @@
 # Shared update variables for the example lab.
 # Defines the unattended-upgrades package and automatic-update policy used during the base phase.
 
-base_updates_enabled: false
 # Package list installed with APT to provide unattended-upgrades support.
 # Keep `unattended-upgrades` in this list whenever automatic upgrades stay
 # enabled so the backend package exists for the managed APT policy.

--- a/examples/inventory/group_vars/base/base_upgrade.yml
+++ b/examples/inventory/group_vars/base/base_upgrade.yml
@@ -3,7 +3,6 @@
 # Shared upgrade variables for the example lab.
 # Defines the immediate APT upgrade behavior available during the base phase.
 
-base_upgrade_enabled: false
 # Reuse package metadata for one hour so repeated explicit maintenance runs can
 # stay idempotent unless the cache is actually stale.
 base_upgrade_cache_valid_time: 3600

--- a/examples/inventory/group_vars/docker/docker.yml
+++ b/examples/inventory/group_vars/docker/docker.yml
@@ -1,0 +1,18 @@
+---
+# examples/inventory/group_vars/docker/docker.yml
+# Docker-layer switchboard for hosts in the example `docker` inventory group.
+# `group_vars/all/docker.yml` keeps Docker features disabled by default. This
+# file enables the full example Docker stack, while each `docker_*.yml` file
+# keeps only that service's configuration.
+
+docker_include_engine: true
+docker_include_traefik: true
+docker_include_adguard: true
+docker_include_adguard_sync: true
+docker_include_wireguard: true
+
+docker_engine_enabled: true
+docker_traefik_enabled: true
+docker_adguard_enabled: true
+docker_adguard_sync_enabled: true
+docker_wireguard_enabled: true

--- a/examples/inventory/group_vars/docker/docker_adguard.yml
+++ b/examples/inventory/group_vars/docker/docker_adguard.yml
@@ -5,10 +5,6 @@
 # admin-auth, and DNS firewall behavior exercised through the aggregate
 # `docker` role.
 
-# Keep the AdGuard role internally enabled when the aggregate toggle turns it
-# on for the example lab.
-docker_adguard_enabled: true
-
 # Inherit the engine-level Compose support package choice so the service role
 # stays on the same package family as `docker_engine`.
 docker_adguard_packages: "{{ docker_engine_compose_packages | default([]) }}"

--- a/examples/inventory/group_vars/docker/docker_adguard_sync.yml
+++ b/examples/inventory/group_vars/docker/docker_adguard_sync.yml
@@ -5,10 +5,6 @@
 # identity, origin/replica endpoints, and Vault-backed sync UI credentials
 # exercised through the aggregate `docker` role.
 
-# Keep the AdGuard Sync role internally enabled when the aggregate toggle turns
-# it on for the example lab.
-docker_adguard_sync_enabled: true
-
 # Reuse the same Docker package family and shared access identities that the
 # AdGuard role already owns on the example host. `docker_adguard_packages`
 # already inherits the engine-level Compose family by default, so sync stays

--- a/examples/inventory/group_vars/docker/docker_engine.yml
+++ b/examples/inventory/group_vars/docker/docker_engine.yml
@@ -3,9 +3,6 @@
 # Shared Docker engine variables for the example lab.
 # Defines Docker package, service, daemon, and supplementary-group behavior exercised through the aggregate `docker` role.
 
-# Keep Docker engine management enabled in the example lab.
-docker_engine_enabled: true
-
 # Use Debian-family Docker engine package names.
 docker_engine_packages:
   - docker.io

--- a/examples/inventory/group_vars/docker/docker_traefik.yml
+++ b/examples/inventory/group_vars/docker/docker_traefik.yml
@@ -3,9 +3,6 @@
 # Shared Docker Traefik variables for the example lab.
 # Defines the Traefik Compose, DNS challenge, service identity, dashboard, and firewall behavior exercised through the aggregate `docker` role.
 
-# Keep the Traefik role enabled in the example lab.
-docker_traefik_enabled: true
-
 # Inherit the engine-level Compose support package choice so the service role
 # stays on the same package family as `docker_engine`.
 docker_traefik_packages: "{{ docker_engine_compose_packages | default([]) }}"
@@ -17,7 +14,7 @@ docker_traefik_data_dir: "{{ docker_traefik_project_dir }}/data"
 docker_traefik_compose_project_name: traefik
 docker_traefik_compose_service_name: traefik
 docker_traefik_container_name: traefik
-docker_traefik_image: traefik:v3.0
+docker_traefik_image: traefik:v3.6.13
 docker_traefik_service_user: srv_traefik
 docker_traefik_service_uid: 1200
 docker_traefik_access_group: access_traefik

--- a/examples/inventory/group_vars/docker/docker_wireguard.yml
+++ b/examples/inventory/group_vars/docker/docker_wireguard.yml
@@ -5,9 +5,6 @@
 # initial admin setup, VPN listener, and firewall behavior exercised through
 # the aggregate `docker` role.
 
-# Keep the WireGuard role enabled in the example lab.
-docker_wireguard_enabled: true
-
 # Inherit the engine-level Compose support package choice so the service role
 # stays on the same package family as `docker_engine`.
 docker_wireguard_packages: "{{ docker_engine_compose_packages | default([]) }}"

--- a/examples/inventory/group_vars/monitoring/monitoring.yml
+++ b/examples/inventory/group_vars/monitoring/monitoring.yml
@@ -3,35 +3,51 @@
 # Monitoring-layer toggle variables for hosts in the dedicated example
 # `monitoring` inventory group.
 # Keeps the aggregate monitoring layer disabled by default in `group_vars/all`,
-# then enables the host-status monitor for the example monitoring hosts while
-# leaving host_vars free to override the toggle later.
+# then enables the monitoring workflow for hosts in the `monitoring` group.
 
 # The example monitoring group should exercise the recurring host-status
 # SSH authorized-key helper by default so remote collection stays inside the
-# monitoring layer. A local-only example host can still opt out in host vars.
-monitoring_include_authorized_key: true
+# monitoring layer. The example lab host is local-only, so this switch stays
+# off while the rest of monitoring runs.
+monitoring_include_authorized_key: false
 
 # The example monitoring group should exercise the recurring host-status
-# monitor by default. A specific example host can still opt out with
-# `monitoring_include_status: false` in host vars.
+# monitor by default.
 monitoring_include_status: true
 
 # The example monitoring group should also exercise the dedicated storage
-# health role by default. A specific host can still opt out in host vars.
+# health role by default.
 monitoring_include_storage_health: true
 
 # The example monitoring group should also exercise the Docker image-tag
 # monitor by default so the dashboard shows container update guidance.
 monitoring_include_docker_tag: true
 
-# Keep the collector disabled by default at the group level so only explicit
-# collector hosts opt into it through host vars.
-monitoring_include_collect: false
+# The example monitoring group also acts as the collector.
+monitoring_include_collect: true
 
-# Keep the web publisher disabled by default at the group level so only
-# explicit collector hosts opt into it through host vars.
-monitoring_include_web: false
+# Publish the web dashboard only when a host name is configured or the role is
+# intentionally managing an existing install.
+monitoring_include_web: >-
+  {{
+    (monitoring_web_host | default('') | trim | length) > 0
+    or (monitoring_web_manage_existing_install | default(false) | bool)
+  }}
 
-# Keep notifications disabled by default at the group level so only explicit
-# collector hosts opt into them through host vars.
-monitoring_include_notify: false
+# Send notifications only when an ntfy URL is configured or the role is
+# intentionally managing an existing install.
+monitoring_include_notify: >-
+  {{
+    (vault_monitoring_notify_ntfy_url | default('') | trim | length) > 0
+    or (monitoring_notify_manage_existing_install | default(false) | bool)
+  }}
+
+# Keep the role-internal service states beside the aggregate includes. This
+# switchboard is the one place to check whether monitoring roles are included
+# and whether their managed services/timers should stay active.
+monitoring_status_enabled: true
+monitoring_storage_health_enabled: true
+monitoring_docker_tag_enabled: true
+monitoring_collect_enabled: true
+monitoring_web_enabled: "{{ monitoring_include_web | bool }}"
+monitoring_notify_enabled: true

--- a/examples/inventory/group_vars/monitoring/monitoring_collect.yml
+++ b/examples/inventory/group_vars/monitoring/monitoring_collect.yml
@@ -2,7 +2,6 @@
 # examples/inventory/group_vars/monitoring/monitoring_collect.yml
 # Shared collector variables for the example lab.
 
-monitoring_collect_enabled: true
 monitoring_collect_output_dir: /var/lib/monitor/collect
 monitoring_collect_hosts_dir: "{{ monitoring_collect_output_dir }}/hosts"
 monitoring_collect_index_path: "{{ monitoring_collect_output_dir }}/index.json"

--- a/examples/inventory/group_vars/monitoring/monitoring_docker_tag.yml
+++ b/examples/inventory/group_vars/monitoring/monitoring_docker_tag.yml
@@ -4,7 +4,6 @@
 # Keeps the example Docker image-tag monitor on the same daily cadence used by
 # the production repo while still allowing host_vars to override later.
 
-monitoring_docker_tag_enabled: true
 monitoring_docker_tag_status_dir: /var/lib/monitor
 monitoring_docker_tag_status_path: "{{ monitoring_docker_tag_status_dir }}/docker-tag.json"
 monitoring_docker_tag_timer_on_calendar: "*-*-* 09:15:00"

--- a/examples/inventory/group_vars/monitoring/monitoring_notify.yml
+++ b/examples/inventory/group_vars/monitoring/monitoring_notify.yml
@@ -2,6 +2,5 @@
 # examples/inventory/group_vars/monitoring/monitoring_notify.yml
 # Shared ntfy notification variables for the example monitoring hosts.
 
-monitoring_notify_enabled: true
 monitoring_notify_ntfy_url: "{{ vault_monitoring_notify_ntfy_url | default('') }}"
 monitoring_notify_ntfy_title_prefix: "{{ monitoring_web_title | default('Lab Monitor') }}"

--- a/examples/inventory/group_vars/monitoring/monitoring_status.yml
+++ b/examples/inventory/group_vars/monitoring/monitoring_status.yml
@@ -7,7 +7,6 @@
 
 # Keep the monitoring status timer enabled so the example lab exercises the
 # recurring JSON contract alongside the backup layer.
-monitoring_status_enabled: true
 
 # Keep the unified status output path explicit in inventory so collection and
 # validation consumers can inspect or override it without opening the shared

--- a/examples/inventory/group_vars/monitoring/monitoring_storage_health.yml
+++ b/examples/inventory/group_vars/monitoring/monitoring_storage_health.yml
@@ -7,7 +7,6 @@
 
 # Keep the storage-health timer enabled so the example lab exercises the
 # dedicated per-device JSON contract alongside the host-status role.
-monitoring_storage_health_enabled: true
 
 # Keep the JSON output path explicit in inventory so collection and validation
 # consumers can inspect or override it without opening the shared role

--- a/examples/inventory/group_vars/monitoring/monitoring_web.yml
+++ b/examples/inventory/group_vars/monitoring/monitoring_web.yml
@@ -2,7 +2,6 @@
 # examples/inventory/group_vars/monitoring/monitoring_web.yml
 # Shared dashboard web variables for the example monitoring hosts.
 
-monitoring_web_enabled: true
 monitoring_web_image_repository: nginx
 monitoring_web_image_tag: "1.27-alpine"
 monitoring_web_image: "{{ monitoring_web_image_repository }}:{{ monitoring_web_image_tag }}"

--- a/examples/inventory/group_vars/user/user.yml
+++ b/examples/inventory/group_vars/user/user.yml
@@ -1,0 +1,20 @@
+---
+# examples/inventory/group_vars/user/user.yml
+# User-layer switchboard for hosts in the example `user` inventory group.
+# `group_vars/all/user.yml` keeps optional user subroles disabled by default.
+# This file enables the complete example human-admin account workflow.
+
+user_include_groups: true
+user_include_sudo: true
+
+# If you later disable `user_include_sudo`, set this to true for one cleanup
+# run so the previously managed example sudoers drop-in is removed explicitly.
+user_cleanup_disabled_sudo_drop_in: false
+
+user_include_password: true
+user_include_ssh: true
+user_include_zshell: true
+user_include_profile: true
+user_include_directories: true
+user_include_git: true
+user_include_vim: true

--- a/examples/inventory/host_vars/lab/vars.yml
+++ b/examples/inventory/host_vars/lab/vars.yml
@@ -1,56 +1,18 @@
 ---
 # examples/inventory/host_vars/lab/vars.yml
 # Host-specific variables for the `lab` example host.
-# Enables the optional aggregate-role features exercised by the example stack.
+# Group switchboard files decide which layers and subroles are enabled. This
+# file keeps only host-specific inputs and small per-host overrides.
 
-# Base layer role overrides for this host.
-base_packages_enabled: true
 # Add host-only packages here without replacing the shared baseline list.
 base_packages_additional: []
-base_locale_enabled: true
-base_timezone_enabled: true
-base_ntp_enabled: true
-base_hostname_enabled: true
-base_hosts_enabled: true
-base_dns_enabled: true
-base_sudo_enabled: true
-base_sshd_enabled: true
-base_firewall_enabled: true
-base_fail2ban_enabled: true
-base_logging_enabled: true
-base_updates_enabled: true
-base_apparmor_enabled: true
-base_auditd_enabled: true
-base_upgrade_enabled: true
-base_needrestart_enabled: true
 
 # This example host keeps the shared `systemd_resolved` DNS default.
 # The role removes any old role-managed NetworkManager DNS override here so
 # `systemd-resolved` remains the single DNS owner for the example lab host.
 
-# Optional user layer roles enabled for this host.
-user_include_groups: true
-user_include_sudo: true
-user_include_password: true
-user_include_ssh: true
-user_include_zshell: true
-user_include_profile: true
-user_include_directories: true
-user_include_git: true
-user_include_vim: true
+# Optional host-specific user layer additions.
 user_zshell_additional_aliases: {}
-
-# Optional Docker layer roles enabled for this host.
-docker_include_engine: true
-docker_include_traefik: true
-docker_include_adguard: true
-docker_include_adguard_sync: true
-docker_include_wireguard: true
-
-# Optional backup layer roles enabled for this host.
-backup_include_restic: true
-backup_include_restic_prune: true
-backup_include_restic_check: true
 
 # Stop only the shared example containers with writable application state
 # before the Restic backup runs. Traefik stays up because its state is
@@ -65,17 +27,8 @@ backup_restic_docker_stop_containers:
 backup_restic_timer_on_calendar: "*-*-* 03:30:00"
 backup_restic_timer_randomized_delay_sec: 0
 
-# Optional monitoring layer roles enabled for this host.
-monitoring_include_authorized_key: false
-monitoring_include_status: true
-monitoring_include_storage_health: true
-monitoring_include_collect: true
+# Host-specific monitoring inputs for the example lab host.
 monitoring_notify_manage_existing_install: false
-monitoring_include_notify: >-
-  {{
-    (vault_monitoring_notify_ntfy_url | default('') | trim | length) > 0
-    or (monitoring_notify_manage_existing_install | bool)
-  }}
 monitoring_status_storage_additional_mounts: []
 monitoring_storage_health_devices:
   - label: root_disk
@@ -83,12 +36,6 @@ monitoring_storage_health_devices:
     type: smart
 monitoring_web_host: "{{ vault_monitoring_collect_web_host | default('') }}"
 monitoring_web_manage_existing_install: false
-monitoring_include_web: >-
-  {{
-    (monitoring_web_host | trim | length) > 0
-    or (monitoring_web_manage_existing_install | bool)
-  }}
-monitoring_web_enabled: "{{ monitoring_include_web | bool }}"
 monitoring_collect_sources:
   - name: lab
     display_name: lab

--- a/examples/playbooks/ops/base_firewall_repair.yml
+++ b/examples/playbooks/ops/base_firewall_repair.yml
@@ -1,0 +1,11 @@
+---
+# examples/playbooks/ops/base_firewall_repair.yml
+# Manual UFW/backend repair helper for hosts where normal firewall convergence
+# is blocked by service masking or iptables backend drift.
+
+- name: Repair UFW backend state on example base hosts
+  hosts: base
+  become: true
+  roles:
+    - role: base_firewall_repair
+      tags: [base_firewall_repair]

--- a/examples/playbooks/ops/bootstrap.yml
+++ b/examples/playbooks/ops/bootstrap.yml
@@ -7,13 +7,15 @@
 - name: Bootstrap hosts using the initial admin account
   hosts: bootstrap
   become: true
+  vars:
+    ansible_user: "{{ bootstrap_login_user }}"
   gather_facts: false
   pre_tasks:
     - name: Set bootstrap connection variables
       ansible.builtin.set_fact:
         ansible_user: "{{ bootstrap_login_user }}"
-        ansible_password: "{{ bootstrap_login_password }}"
-        ansible_become_password: "{{ bootstrap_login_become_password }}"
+        ansible_password: "{{ bootstrap_login_password | default(omit, true) }}"
+        ansible_become_password: "{{ bootstrap_login_become_password | default(omit, true) }}"
       tags: [always]
   roles:
     - role: bootstrap

--- a/roles/base_firewall/README.md
+++ b/roles/base_firewall/README.md
@@ -10,11 +10,19 @@ Explains how the role manages a UFW baseline on Debian-family hosts during the b
 - Requires role-declared firewall rules to use a `managed:`-style comment prefix for traceable cleanup
 - Refuses to enable a deny-or-reject incoming firewall baseline unless the managed rules still allow SSH or Ansible access on the management port
 - Configures UFW logging plus default incoming and outgoing policies
+- Persists UFW logging in `ufw.conf` so first runs and post-reset runs still converge while the firewall is inactive
 - Ensures the requested UFW rules exist without resetting the firewall by default
 - Removes stale UFW rules whose comments use the managed prefix when they are no longer declared
 - Can optionally purge unmanaged UFW rules by resetting and rebuilding the managed ruleset
 - Enables or disables UFW according to the role input
 - Verifies effective firewall status, the stored desired-state checksum, and the stored added-rule commands after changes
+
+## Repair Flow
+
+Destructive backend repair work is intentionally kept out of this normal role.
+Use the separate `base_firewall_repair` role through an ops playbook when a
+host needs manual recovery from a masked UFW service, mixed
+`iptables-legacy`/`iptables-nft` state, or broken UFW cached rule state.
 
 ## Variables
 
@@ -78,6 +86,7 @@ Use `base_firewall_base_rules` for the shared baseline, `base_firewall_role_decl
 If you set `base_firewall_default_incoming_policy` to `deny` or `reject`, keep at least one incoming `allow` or `limit` rule for the SSH or Ansible management port in the effective `base_firewall_rules` list or the role will fail early.
 Keep `base_firewall_rules` ordered for readability and stable `ufw show added` output.
 Rule directions use `in` and `out` so the stored commands match the long-form syntax used by the Ansible UFW module.
+The role writes the requested logging level to `/etc/ufw/ufw.conf` before the final enabled or disabled state is enforced, so inactive or freshly reset hosts do not fail on `ufw logging <level>` while still converging to the requested runtime log level on the next enable or reload.
 When additive mode is active, `base_firewall` only removes live UFW rules whose comments start with `base_firewall_managed_comment_prefix` when `base_firewall_remove_stale_managed_rules: true`.
 Manual rules without that prefix are left untouched unless `base_firewall_purge_unmanaged_rules: true`.
 

--- a/roles/base_firewall/tasks/config.yml
+++ b/roles/base_firewall/tasks/config.yml
@@ -19,6 +19,12 @@
         | to_json
         | hash('sha256')
       }}
+    base_firewall_effective_logging_level: >-
+      {{
+        'low'
+        if base_firewall_logging == 'on'
+        else base_firewall_logging
+      }}
 
 - name: "Config | Read added firewall rules"
   ansible.builtin.command: ufw show added
@@ -41,9 +47,9 @@
         'ufw '
         ~ item.rule
         ~ ' '
-        ~ (item.direction | default('in'))
-        ~ (' log' if (item.log | default(false)) else '')
-        ~ ' from '
+        ~ ((((item.direction | default('in')) ~ ' ') if ((item.direction | default('in')) != 'in') else ''))
+        ~ ('log ' if (item.log | default(false)) else '')
+        ~ 'from '
         ~ (item.from_ip | default('any'))
         ~ ' to '
         ~ (item.to_ip | default('any'))
@@ -101,9 +107,9 @@
         'ufw '
         ~ item.rule
         ~ ' '
-        ~ (item.direction | default('in'))
-        ~ (' log' if (item.log | default(false)) else '')
-        ~ ' from '
+        ~ ((((item.direction | default('in')) ~ ' ') if ((item.direction | default('in')) != 'in') else ''))
+        ~ ('log ' if (item.log | default(false)) else '')
+        ~ 'from '
         ~ (item.from_ip | default('any'))
         ~ ' to '
         ~ (item.to_ip | default('any'))
@@ -295,9 +301,14 @@
     - base_firewall_remove_stale_managed_rules
     - (base_firewall_stale_managed_rule_numbers | default([]) | length) > 0
 
-- name: "Config | Set firewall logging level"
-  community.general.ufw:
-    logging: "{{ base_firewall_logging }}"
+- name: "Config | Set persisted firewall logging level"
+  ansible.builtin.lineinfile:
+    path: /etc/ufw/ufw.conf
+    regexp: '^LOGLEVEL='
+    line: "LOGLEVEL={{ base_firewall_effective_logging_level }}"
+    owner: root
+    group: root
+    mode: "0644"
 
 - name: "Config | Set default incoming firewall policy"
   community.general.ufw:
@@ -330,6 +341,11 @@
 - name: "Config | Ensure firewall enabled state"
   community.general.ufw:
     state: "{{ 'enabled' if base_firewall_enabled else 'disabled' }}"
+
+- name: "Config | Apply runtime firewall logging when enabled"
+  community.general.ufw:
+    logging: "{{ base_firewall_logging }}"
+  when: base_firewall_enabled
 
 - name: "Config | Store firewall state checksum"
   ansible.builtin.copy:

--- a/roles/base_firewall/tasks/main.yml
+++ b/roles/base_firewall/tasks/main.yml
@@ -2,6 +2,8 @@
 # roles/base_firewall/tasks/main.yml
 # Task entrypoint for the `base_firewall` role.
 # Imports the assert, install, config, and validate phase files in order.
+# Destructive firewall recovery work lives in the separate
+# `base_firewall_repair` role and its dedicated ops playbook.
 
 - name: Assert
   ansible.builtin.import_tasks: assert.yml

--- a/roles/base_firewall/tasks/validate.yml
+++ b/roles/base_firewall/tasks/validate.yml
@@ -69,9 +69,9 @@
         'ufw '
         ~ item.rule
         ~ ' '
-        ~ (item.direction | default('in'))
-        ~ (' log' if (item.log | default(false)) else '')
-        ~ ' from '
+        ~ ((((item.direction | default('in')) ~ ' ') if ((item.direction | default('in')) != 'in') else ''))
+        ~ ('log ' if (item.log | default(false)) else '')
+        ~ 'from '
         ~ (item.from_ip | default('any'))
         ~ ' to '
         ~ (item.to_ip | default('any'))
@@ -136,9 +136,9 @@
         'ufw '
         ~ item.rule
         ~ ' '
-        ~ (item.direction | default('in'))
-        ~ (' log' if (item.log | default(false)) else '')
-        ~ ' from '
+        ~ ((((item.direction | default('in')) ~ ' ') if ((item.direction | default('in')) != 'in') else ''))
+        ~ ('log ' if (item.log | default(false)) else '')
+        ~ 'from '
         ~ (item.from_ip | default('any'))
         ~ ' to '
         ~ (item.to_ip | default('any'))
@@ -241,9 +241,9 @@
         'ufw '
         ~ item.rule
         ~ ' '
-        ~ (item.direction | default('in'))
-        ~ (' log' if (item.log | default(false)) else '')
-        ~ ' from '
+        ~ ((((item.direction | default('in')) ~ ' ') if ((item.direction | default('in')) != 'in') else ''))
+        ~ ('log ' if (item.log | default(false)) else '')
+        ~ 'from '
         ~ (item.from_ip | default('any'))
         ~ ' to '
         ~ (item.to_ip | default('any'))

--- a/roles/base_firewall_repair/README.md
+++ b/roles/base_firewall_repair/README.md
@@ -1,0 +1,62 @@
+# roles/base_firewall_repair
+
+Manual repair helper for UFW lockouts and iptables backend drift.
+
+This role is intentionally separate from `base_firewall`. Normal firewall
+convergence should use `base_firewall`; this role is for operator-triggered
+repair when UFW is masked, `ufw enable` fails, or a host has mixed
+`iptables-legacy` and `iptables-nft` state after upgrades.
+
+## Features
+
+- Installs an optional temporary systemd safety timer that runs `ufw disable`
+- Unmasks and enables `ufw.service`
+- Pins `iptables` and `ip6tables` to the nft backend
+- Flushes legacy iptables tables
+- Optionally flushes the nftables ruleset
+- Optionally resets UFW cached rule state
+- Optionally re-enables UFW after repair
+- Stops and restarts Docker around backend repair when requested
+
+## Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `base_firewall_repair_safety_net_enabled` | `true` | Install and start the temporary `ufw disable` safety timer |
+| `base_firewall_repair_pin_nft_backend` | `true` | Set `iptables` and `ip6tables` alternatives to nft |
+| `base_firewall_repair_flush_legacy_tables` | `true` | Flush legacy iptables tables |
+| `base_firewall_repair_flush_nftables_ruleset` | `false` | Flush all nftables rules (destructive; opt-in) |
+| `base_firewall_repair_reset_ufw` | `false` | Run `ufw --force reset` |
+| `base_firewall_repair_enable_ufw_after` | `false` | Enable UFW after repair |
+| `base_firewall_repair_stop_docker` | `true` | Stop Docker before backend repair |
+| `base_firewall_repair_start_docker_after` | `true` | Start Docker after backend repair |
+| `base_firewall_repair_safety_net_cleanup` | `false` | Stop and disable the safety timer at the end of the role run |
+
+## Usage
+
+Use the dedicated ops playbook rather than adding this role to recurring runs:
+
+```bash
+ansible-playbook -i inventory/prod.ini playbooks/ops/base_firewall_repair.yml
+```
+
+To enable UFW during the same run while the safety timer is active:
+
+```bash
+ansible-playbook -i inventory/prod.ini playbooks/ops/base_firewall_repair.yml \
+  -e base_firewall_repair_enable_ufw_after=true
+```
+
+To also flush the entire nftables ruleset (destructive; opt-in):
+
+```bash
+ansible-playbook -i inventory/prod.ini playbooks/ops/base_firewall_repair.yml \
+  -e base_firewall_repair_flush_nftables_ruleset=true
+```
+
+After confirming SSH still works, stop the safety timer:
+
+```bash
+sudo systemctl stop ufw-safedisable.timer
+sudo systemctl disable ufw-safedisable.timer
+```

--- a/roles/base_firewall_repair/defaults/main.yml
+++ b/roles/base_firewall_repair/defaults/main.yml
@@ -1,0 +1,29 @@
+---
+# roles/base_firewall_repair/defaults/main.yml
+# Defaults for the manual UFW/backend repair helper.
+
+base_firewall_repair_safety_net_enabled: true
+base_firewall_repair_safety_net_service_name: ufw-safedisable
+base_firewall_repair_safety_net_on_active_sec: 5
+base_firewall_repair_safety_net_on_unit_active_sec: 30
+
+base_firewall_repair_manage_ufw_service: true
+base_firewall_repair_pin_nft_backend: true
+base_firewall_repair_flush_legacy_tables: true
+# Default to non-destructive behavior. Flushing the entire ruleset is a
+# recovery tactic that should be explicitly requested per incident.
+base_firewall_repair_flush_nftables_ruleset: false
+base_firewall_repair_reset_ufw: false
+base_firewall_repair_stop_docker: true
+base_firewall_repair_start_docker_after: true
+base_firewall_repair_enable_ufw_after: false
+
+# When true, stop and disable the safety timer at the end of the role run.
+# The unit files are left in place so a future repair can re-enable quickly.
+base_firewall_repair_safety_net_cleanup: false
+
+base_firewall_repair_legacy_tables:
+  - filter
+  - nat
+  - mangle
+  - raw

--- a/roles/base_firewall_repair/tasks/assert.yml
+++ b/roles/base_firewall_repair/tasks/assert.yml
@@ -1,0 +1,35 @@
+---
+# roles/base_firewall_repair/tasks/assert.yml
+# Validate operator-selected repair options before making any host changes.
+
+- name: "Assert | Validate base_firewall_repair variables"
+  ansible.builtin.assert:
+    that:
+      - base_firewall_repair_safety_net_enabled is boolean
+      - base_firewall_repair_safety_net_service_name is string
+      - (base_firewall_repair_safety_net_service_name | trim | length) > 0
+      - base_firewall_repair_safety_net_on_active_sec is integer
+      - (base_firewall_repair_safety_net_on_active_sec | int) > 0
+      - base_firewall_repair_safety_net_on_unit_active_sec is integer
+      - (base_firewall_repair_safety_net_on_unit_active_sec | int) > 0
+      - base_firewall_repair_manage_ufw_service is boolean
+      - base_firewall_repair_pin_nft_backend is boolean
+      - base_firewall_repair_flush_legacy_tables is boolean
+      - base_firewall_repair_flush_nftables_ruleset is boolean
+      - base_firewall_repair_reset_ufw is boolean
+      - base_firewall_repair_stop_docker is boolean
+      - base_firewall_repair_start_docker_after is boolean
+      - base_firewall_repair_enable_ufw_after is boolean
+      - base_firewall_repair_safety_net_cleanup is boolean
+      - base_firewall_repair_legacy_tables is sequence
+      - base_firewall_repair_legacy_tables is not string
+      - >-
+        (
+          base_firewall_repair_legacy_tables
+          | difference(['filter', 'nat', 'mangle', 'raw'])
+          | length
+        ) == 0
+    fail_msg: >-
+      base_firewall_repair variables must use valid booleans, positive safety
+      timer values, and legacy table names from filter, nat, mangle, and raw
+    quiet: true

--- a/roles/base_firewall_repair/tasks/config.yml
+++ b/roles/base_firewall_repair/tasks/config.yml
@@ -1,0 +1,159 @@
+---
+# roles/base_firewall_repair/tasks/config.yml
+# Manual repair tasks for UFW service state and iptables/nft backend drift.
+
+- name: "Config | Gather service state before repair"
+  ansible.builtin.service_facts:
+  when: base_firewall_repair_start_docker_after | bool
+
+- name: "Config | Record whether Docker was running before repair"
+  ansible.builtin.set_fact:
+    base_firewall_repair_docker_was_running: >-
+      {{
+        (
+          (
+            'docker.service' in ansible_facts.services
+            and ansible_facts.services['docker.service'].state == 'running'
+          )
+          or (
+            'docker' in ansible_facts.services
+            and ansible_facts.services['docker'].state == 'running'
+          )
+        )
+      }}
+  when: base_firewall_repair_start_docker_after | bool
+
+- name: "Config | Stop Docker before firewall backend repair"
+  ansible.builtin.systemd:
+    name: docker
+    state: stopped
+  changed_when: false
+  failed_when: false
+  when: base_firewall_repair_stop_docker | bool
+
+- name: "Config | Unmask ufw.service"
+  ansible.builtin.systemd:
+    name: ufw
+    masked: false
+  when: base_firewall_repair_manage_ufw_service | bool
+
+- name: "Config | Ensure ufw.service is enabled"
+  ansible.builtin.systemd:
+    name: ufw
+    enabled: true
+  when: base_firewall_repair_manage_ufw_service | bool
+
+- name: "Config | Ensure iptables uses nft backend"
+  ansible.builtin.command:
+    argv:
+      - update-alternatives
+      - --query
+      - iptables
+  register: base_firewall_repair_iptables_query
+  changed_when: false
+  failed_when: false
+  when: base_firewall_repair_pin_nft_backend | bool
+
+- name: "Config | Pin iptables to nft backend"
+  ansible.builtin.command:
+    argv:
+      - update-alternatives
+      - --set
+      - iptables
+      - /usr/sbin/iptables-nft
+  changed_when: true
+  when:
+    - base_firewall_repair_pin_nft_backend | bool
+    - >-
+      base_firewall_repair_iptables_query.stdout is not defined
+      or
+      (base_firewall_repair_iptables_query.stdout is not search('Value: /usr/sbin/iptables-nft'))
+
+- name: "Config | Query ip6tables alternative"
+  ansible.builtin.command:
+    argv:
+      - update-alternatives
+      - --query
+      - ip6tables
+  register: base_firewall_repair_ip6tables_query
+  changed_when: false
+  failed_when: false
+  when: base_firewall_repair_pin_nft_backend | bool
+
+- name: "Config | Pin ip6tables to nft backend"
+  ansible.builtin.command:
+    argv:
+      - update-alternatives
+      - --set
+      - ip6tables
+      - /usr/sbin/ip6tables-nft
+  changed_when: true
+  when:
+    - base_firewall_repair_pin_nft_backend | bool
+    - >-
+      base_firewall_repair_ip6tables_query.stdout is not defined
+      or
+      (base_firewall_repair_ip6tables_query.stdout is not search('Value: /usr/sbin/ip6tables-nft'))
+
+- name: "Config | Check if iptables-legacy is available"
+  ansible.builtin.command:
+    argv:
+      - which
+      - iptables-legacy
+  register: base_firewall_repair_legacy_available
+  changed_when: false
+  failed_when: false
+  when: base_firewall_repair_flush_legacy_tables | bool
+
+- name: "Config | Flush iptables-legacy tables"
+  ansible.builtin.command:
+    argv: "{{ ['iptables-legacy'] + (['-t', item] if item != 'filter' else []) + ['-F'] }}"
+  changed_when: true
+  failed_when: false
+  loop: "{{ base_firewall_repair_legacy_tables }}"
+  when:
+    - base_firewall_repair_flush_legacy_tables | bool
+    - base_firewall_repair_legacy_available.rc == 0
+
+- name: "Config | Delete iptables-legacy chains"
+  ansible.builtin.command:
+    argv: "{{ ['iptables-legacy'] + (['-t', item] if item != 'filter' else []) + ['-X'] }}"
+  changed_when: true
+  failed_when: false
+  loop: "{{ base_firewall_repair_legacy_tables }}"
+  when:
+    - base_firewall_repair_flush_legacy_tables | bool
+    - base_firewall_repair_legacy_available.rc == 0
+
+- name: "Config | Flush nftables ruleset"
+  ansible.builtin.command:
+    argv:
+      - nft
+      - flush
+      - ruleset
+  changed_when: true
+  when: base_firewall_repair_flush_nftables_ruleset | bool
+
+- name: "Config | Reset UFW cached rule state"
+  ansible.builtin.command:
+    argv:
+      - ufw
+      - --force
+      - reset
+  changed_when: true
+  when: base_firewall_repair_reset_ufw | bool
+
+- name: "Config | Re-enable UFW after repair when requested"
+  community.general.ufw:
+    state: enabled
+  when: base_firewall_repair_enable_ufw_after | bool
+
+- name: "Config | Start Docker after firewall backend repair"
+  ansible.builtin.systemd:
+    name: docker
+    state: started
+  changed_when: false
+  failed_when: false
+  when:
+    - base_firewall_repair_start_docker_after | bool
+    - base_firewall_repair_docker_was_running | default(false)

--- a/roles/base_firewall_repair/tasks/main.yml
+++ b/roles/base_firewall_repair/tasks/main.yml
@@ -1,0 +1,31 @@
+---
+# roles/base_firewall_repair/tasks/main.yml
+# Entrypoint for manual firewall/backend repair operations.
+
+- name: Assert
+  ansible.builtin.import_tasks: assert.yml
+  tags: [assert, base_firewall_repair, base_firewall_repair_assert]
+
+- name: Safety
+  ansible.builtin.import_tasks: safety.yml
+  tags: [config, base_firewall_repair, base_firewall_repair_safety]
+  when: base_firewall_repair_safety_net_enabled | bool
+
+- name: Config
+  ansible.builtin.import_tasks: config.yml
+  tags: [config, base_firewall_repair, base_firewall_repair_config]
+
+- name: Validate
+  ansible.builtin.import_tasks: validate.yml
+  tags: [validate, base_firewall_repair, base_firewall_repair_validate]
+
+- name: "Cleanup | Stop and disable safety timer when requested"
+  ansible.builtin.systemd:
+    name: "{{ base_firewall_repair_safety_net_service_name }}.timer"
+    state: stopped
+    enabled: false
+  changed_when: false
+  failed_when: false
+  when:
+    - base_firewall_repair_safety_net_enabled | bool
+    - base_firewall_repair_safety_net_cleanup | bool

--- a/roles/base_firewall_repair/tasks/safety.yml
+++ b/roles/base_firewall_repair/tasks/safety.yml
@@ -1,0 +1,49 @@
+---
+# roles/base_firewall_repair/tasks/safety.yml
+# Installs a temporary timer that disables UFW during repair testing.
+
+- name: "Safety | Deploy UFW emergency-disable service unit"
+  ansible.builtin.copy:
+    dest: "/etc/systemd/system/{{ base_firewall_repair_safety_net_service_name }}.service"
+    owner: root
+    group: root
+    mode: "0644"
+    content: |
+      [Unit]
+      Description=UFW emergency disable safety net
+      Documentation=https://github.com/tatbyte/homelab-roles
+
+      [Service]
+      Type=oneshot
+      ExecStart=/usr/sbin/ufw disable
+      StandardOutput=journal
+      StandardError=journal
+
+- name: "Safety | Deploy UFW emergency-disable timer unit"
+  ansible.builtin.copy:
+    dest: "/etc/systemd/system/{{ base_firewall_repair_safety_net_service_name }}.timer"
+    owner: root
+    group: root
+    mode: "0644"
+    content: |
+      [Unit]
+      Description=UFW emergency disable timer
+      Documentation=https://github.com/tatbyte/homelab-roles
+
+      [Timer]
+      OnActiveSec={{ base_firewall_repair_safety_net_on_active_sec }}
+      OnUnitActiveSec={{ base_firewall_repair_safety_net_on_unit_active_sec }}
+      Persistent=false
+
+      [Install]
+      WantedBy=timers.target
+
+- name: "Safety | Reload systemd daemon"
+  ansible.builtin.systemd:
+    daemon_reload: true
+
+- name: "Safety | Start UFW emergency-disable timer"
+  ansible.builtin.systemd:
+    name: "{{ base_firewall_repair_safety_net_service_name }}.timer"
+    state: started
+    enabled: true

--- a/roles/base_firewall_repair/tasks/validate.yml
+++ b/roles/base_firewall_repair/tasks/validate.yml
@@ -1,0 +1,43 @@
+---
+# roles/base_firewall_repair/tasks/validate.yml
+# Report enough state for an operator to verify the repair path.
+
+- name: "Validate | Read UFW status"
+  ansible.builtin.command:
+    argv:
+      - ufw
+      - status
+      - verbose
+  register: base_firewall_repair_ufw_status
+  changed_when: false
+  failed_when: false
+
+- name: "Validate | Read iptables backend"
+  ansible.builtin.command:
+    argv:
+      - update-alternatives
+      - --query
+      - iptables
+  register: base_firewall_repair_iptables_backend
+  changed_when: false
+  failed_when: false
+
+- name: "Validate | Show repair status"
+  ansible.builtin.debug:
+    msg:
+      - "{{ base_firewall_repair_ufw_status.stdout_lines | default([]) }}"
+      - "{{ base_firewall_repair_iptables_backend.stdout_lines | default([]) }}"
+      - >-
+        Safety timer:
+        {{ base_firewall_repair_safety_net_service_name }}.timer
+        {{ 'started' if base_firewall_repair_safety_net_enabled else 'not installed' }}
+
+- name: "Validate | Remind operator about safety timer cleanup"
+  ansible.builtin.debug:
+    msg: >-
+      Safety timer is still enabled. Stop it when you are done verifying SSH:
+      systemctl stop {{ base_firewall_repair_safety_net_service_name }}.timer &&
+      systemctl disable {{ base_firewall_repair_safety_net_service_name }}.timer
+  when:
+    - base_firewall_repair_safety_net_enabled | bool
+    - not base_firewall_repair_safety_net_cleanup | bool

--- a/roles/base_upgrade/README.md
+++ b/roles/base_upgrade/README.md
@@ -22,6 +22,12 @@ Explains how the role applies explicit APT package upgrades on Debian-family hos
 | `base_upgrade_autoremove` | `false` | no | Whether the role should remove unused dependency packages after the requested upgrade |
 | `base_upgrade_allow_reboot` | `false` | no | Whether the role may reboot the host automatically when package maintenance requires it |
 | `base_upgrade_fail_if_reboot_required` | `false` | no | Whether the role should fail validation when the host still requires reboot after package maintenance |
+| `base_upgrade_lock_timeout` | `600` | no | Seconds to wait for the APT/dpkg lock before failing; set to `0` to skip waiting |
+| `base_upgrade_lock_check_delay` | `5` | no | Seconds to sleep between APT/dpkg lock checks |
+| `base_upgrade_reboot_timeout` | `900` | no | Seconds to wait for a rebooted host to become available before failing |
+| `base_upgrade_reboot_connect_timeout` | `10` | no | Seconds to use for each reboot SSH connection attempt |
+| `base_upgrade_reboot_post_reboot_delay` | `30` | no | Seconds to wait after the host first reconnects before running the reboot test command |
+| `base_upgrade_reboot_test_command` | `whoami` | no | Command Ansible runs after reconnecting to confirm the host is ready |
 
 ## Usage
 
@@ -46,6 +52,12 @@ base_upgrade_mode: safe
 base_upgrade_autoremove: false
 base_upgrade_allow_reboot: false
 base_upgrade_fail_if_reboot_required: false
+base_upgrade_lock_timeout: 600
+base_upgrade_lock_check_delay: 5
+base_upgrade_reboot_timeout: 900
+base_upgrade_reboot_connect_timeout: 10
+base_upgrade_reboot_post_reboot_delay: 30
+base_upgrade_reboot_test_command: whoami
 ```
 
 Use `base_updates` when you want to manage unattended-upgrades policy for future automatic maintenance.

--- a/roles/base_upgrade/defaults/main.yml
+++ b/roles/base_upgrade/defaults/main.yml
@@ -8,3 +8,9 @@ base_upgrade_mode: safe
 base_upgrade_autoremove: false
 base_upgrade_allow_reboot: false
 base_upgrade_fail_if_reboot_required: false
+base_upgrade_lock_timeout: 600
+base_upgrade_lock_check_delay: 5
+base_upgrade_reboot_timeout: 900
+base_upgrade_reboot_connect_timeout: 10
+base_upgrade_reboot_post_reboot_delay: 30
+base_upgrade_reboot_test_command: whoami

--- a/roles/base_upgrade/tasks/assert.yml
+++ b/roles/base_upgrade/tasks/assert.yml
@@ -13,9 +13,26 @@
       - base_upgrade_autoremove is boolean
       - base_upgrade_allow_reboot is boolean
       - base_upgrade_fail_if_reboot_required is boolean
+      - base_upgrade_lock_timeout is integer
+      - (base_upgrade_lock_timeout | int) >= 0
+      - base_upgrade_lock_check_delay is integer
+      - (base_upgrade_lock_check_delay | int) > 0
+      - base_upgrade_reboot_timeout is integer
+      - (base_upgrade_reboot_timeout | int) > 0
+      - base_upgrade_reboot_connect_timeout is integer
+      - (base_upgrade_reboot_connect_timeout | int) > 0
+      - base_upgrade_reboot_post_reboot_delay is integer
+      - (base_upgrade_reboot_post_reboot_delay | int) >= 0
+      - base_upgrade_reboot_test_command is string
+      - (base_upgrade_reboot_test_command | trim | length) > 0
     fail_msg: >-
       base_upgrade_cache_valid_time must be a non-negative integer,
       base_upgrade_mode must be safe or full, and
       base_upgrade_autoremove, base_upgrade_allow_reboot, and
-      base_upgrade_fail_if_reboot_required must be booleans
+      base_upgrade_fail_if_reboot_required must be booleans while
+      base_upgrade_lock_timeout must be a non-negative integer,
+      base_upgrade_lock_check_delay must be a positive integer,
+      reboot timeout/connect timeout must be positive integers,
+      reboot post delay must be a non-negative integer, and
+      reboot test command must be a non-empty string
     quiet: true

--- a/roles/base_upgrade/tasks/config.yml
+++ b/roles/base_upgrade/tasks/config.yml
@@ -3,15 +3,36 @@
 # Config phase tasks for the `base_upgrade` role.
 # Refreshes APT metadata, applies the requested upgrade mode, optionally removes unused packages, and handles reboot detection.
 
+- name: "Config | Wait for existing APT or dpkg lock holders"
+  ansible.builtin.command:
+    argv:
+      - timeout
+      - "{{ base_upgrade_lock_timeout | string }}"
+      - sh
+      - -c
+      - >-
+        while fuser
+        /var/lib/dpkg/lock-frontend
+        /var/lib/dpkg/lock
+        /var/cache/apt/archives/lock
+        /var/lib/apt/lists/lock
+        >/dev/null 2>&1; do
+          sleep {{ base_upgrade_lock_check_delay | int }};
+        done
+  changed_when: false
+  when: (base_upgrade_lock_timeout | int) > 0
+
 - name: "Config | Refresh APT package metadata"
   ansible.builtin.apt:
     update_cache: true
     cache_valid_time: "{{ base_upgrade_cache_valid_time }}"
+    lock_timeout: "{{ base_upgrade_lock_timeout }}"
 
 - name: "Config | Apply requested package upgrades"
   ansible.builtin.apt:
     upgrade: "{{ base_upgrade_mode }}"
     force_apt_get: true
+    lock_timeout: "{{ base_upgrade_lock_timeout }}"
   register: base_upgrade_upgrade_result
   environment:
     DEBIAN_FRONTEND: noninteractive
@@ -20,6 +41,7 @@
   ansible.builtin.apt:
     autoremove: true
     purge: false
+    lock_timeout: "{{ base_upgrade_lock_timeout }}"
   register: base_upgrade_autoremove_result
   environment:
     DEBIAN_FRONTEND: noninteractive
@@ -88,7 +110,11 @@
 
 - name: "Config | Reboot after upgrade when requested"
   ansible.builtin.reboot:
+    connect_timeout: "{{ base_upgrade_reboot_connect_timeout }}"
     msg: Reboot initiated by the base_upgrade role after package upgrades.
+    post_reboot_delay: "{{ base_upgrade_reboot_post_reboot_delay }}"
+    reboot_timeout: "{{ base_upgrade_reboot_timeout }}"
+    test_command: "{{ base_upgrade_reboot_test_command }}"
   when:
     - base_upgrade_allow_reboot
     - base_upgrade_reboot_required

--- a/roles/docker_traefik/README.md
+++ b/roles/docker_traefik/README.md
@@ -30,7 +30,7 @@ Explains how the role manages a Traefik reverse proxy through Docker Compose wit
 | `docker_traefik_service_user` | `srv_traefik` | no | Role-owned service user that owns Traefik data paths on the host |
 | `docker_traefik_access_group` | `access_traefik` | no | Role-owned feature access group used for Traefik host access |
 | `docker_traefik_access_group_members` | de-duplicated `bootstrap_user` / `user_account_name` list with `admin` fallback | no | Existing admin users that should receive Traefik host access when present |
-| `docker_traefik_image` | `traefik:v3.0` | no | Container image used for the managed Traefik service |
+| `docker_traefik_image` | `traefik:v3.6.13` | no | Container image used for the managed Traefik service |
 | `docker_traefik_network_name` | `traefik_proxy` | no | Stable Docker network name other Compose projects can join |
 | `docker_traefik_acme_email` | `admin@example.com` | yes | Email address used for Let's Encrypt ACME registration |
 | `docker_traefik_dns_challenge_provider` | `cloudflare` | yes | Traefik DNS challenge provider name |

--- a/roles/docker_traefik/defaults/main.yml
+++ b/roles/docker_traefik/defaults/main.yml
@@ -32,7 +32,7 @@ docker_traefik_data_dir: "{{ docker_traefik_project_dir }}/data"
 docker_traefik_compose_project_name: traefik
 docker_traefik_compose_service_name: traefik
 docker_traefik_container_name: traefik
-docker_traefik_image: traefik:v3.0
+docker_traefik_image: traefik:v3.6.13
 docker_traefik_docker_service_name: "{{ docker_engine_service_name | default('docker') }}"
 docker_traefik_service_user: srv_traefik
 docker_traefik_service_uid: 1150

--- a/roles/docker_traefik/tasks/config.yml
+++ b/roles/docker_traefik/tasks/config.yml
@@ -221,6 +221,7 @@
             docker_traefik_compose_file_path,
             'up',
             '--detach',
+            '--force-recreate',
           ]
       }}
   register: docker_traefik_compose_up

--- a/roles/docker_traefik/templates/docker_traefik_dashboard.yml.j2
+++ b/roles/docker_traefik/templates/docker_traefik_dashboard.yml.j2
@@ -25,6 +25,5 @@ http:
           - "{{ user }}"
 {% endfor %}
 {% else %}
-  routers: {}
-  middlewares: {}
+  {}
 {% endif %}


### PR DESCRIPTION
LGTM after the follow-up fixes.

Persisting `LOGLEVEL` in `ufw.conf` and reapplying runtime UFW logging keeps inactive hosts convergent without losing the validated live state. I also like that `base_firewall_repair` now snapshots Docker’s pre-repair state, so the helper only brings it back if it was already running before backend repair.
